### PR TITLE
pkg/types: Makes IPAM concrete type

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -63,10 +63,12 @@ type NetConf struct {
 	Name         string          `json:"name,omitempty"`
 	Type         string          `json:"type,omitempty"`
 	Capabilities map[string]bool `json:"capabilities,omitempty"`
-	IPAM         struct {
-		Type string `json:"type,omitempty"`
-	} `json:"ipam,omitempty"`
-	DNS DNS `json:"dns"`
+	IPAM         IPAM            `json:"ipam,omitempty"`
+	DNS          DNS             `json:"dns"`
+}
+
+type IPAM struct {
+	Type string `json:"type,omitempty"`
 }
 
 // NetConfList describes an ordered list of networks.


### PR DESCRIPTION
IPAM is now a concrete type. Was considering testing all of the types.go package, thoughts?

closes #95
