### PR TITLE
ipam/host-local: Move allocator and config to backend

### DIFF
--- a/plugins/ipam/host-local/backend/allocator/allocator.go
+++ b/plugins/ipam/host-local/backend/allocator/allocator.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package allocator
 
 import (
 	"fmt"

--- a/plugins/ipam/host-local/backend/allocator/allocator_suite_test.go
+++ b/plugins/ipam/host-local/backend/allocator/allocator_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main_test
+package allocator_test
 
 import (
 	. "github.com/onsi/ginkgo"
@@ -21,7 +21,7 @@ import (
 	"testing"
 )
 
-func TestHostLocal(t *testing.T) {
+func TestAllocator(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "HostLocal Suite")
+	RunSpecs(t, "Allocator Suite")
 }

--- a/plugins/ipam/host-local/backend/allocator/allocator_test.go
+++ b/plugins/ipam/host-local/backend/allocator/allocator_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package allocator
 
 import (
 	"fmt"

--- a/plugins/ipam/host-local/backend/allocator/config.go
+++ b/plugins/ipam/host-local/backend/allocator/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package allocator
 
 import (
 	"encoding/json"

--- a/plugins/ipam/host-local/main.go
+++ b/plugins/ipam/host-local/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"github.com/containernetworking/cni/plugins/ipam/host-local/backend/allocator"
 	"github.com/containernetworking/cni/plugins/ipam/host-local/backend/disk"
 
 	"github.com/containernetworking/cni/pkg/skel"
@@ -27,7 +28,7 @@ func main() {
 }
 
 func cmdAdd(args *skel.CmdArgs) error {
-	ipamConf, err := LoadIPAMConfig(args.StdinData, args.Args)
+	ipamConf, err := allocator.LoadIPAMConfig(args.StdinData, args.Args)
 	if err != nil {
 		return err
 	}
@@ -38,7 +39,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 	defer store.Close()
 
-	allocator, err := NewIPAllocator(ipamConf, store)
+	allocator, err := allocator.NewIPAllocator(ipamConf, store)
 	if err != nil {
 		return err
 	}
@@ -55,7 +56,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 }
 
 func cmdDel(args *skel.CmdArgs) error {
-	ipamConf, err := LoadIPAMConfig(args.StdinData, args.Args)
+	ipamConf, err := allocator.LoadIPAMConfig(args.StdinData, args.Args)
 	if err != nil {
 		return err
 	}
@@ -66,10 +67,10 @@ func cmdDel(args *skel.CmdArgs) error {
 	}
 	defer store.Close()
 
-	allocator, err := NewIPAllocator(ipamConf, store)
+	ipAllocator, err := allocator.NewIPAllocator(ipamConf, store)
 	if err != nil {
 		return err
 	}
 
-	return allocator.Release(args.ContainerID)
+	return ipAllocator.Release(args.ContainerID)
 }

--- a/test
+++ b/test
@@ -11,7 +11,7 @@ set -e
 
 source ./build
 
-TESTABLE="libcni plugins/ipam/dhcp plugins/ipam/host-local plugins/main/loopback pkg/invoke pkg/ns pkg/skel pkg/types pkg/utils plugins/main/ipvlan plugins/main/macvlan plugins/main/bridge plugins/main/ptp plugins/test/noop pkg/utils/hwaddr pkg/ip pkg/version pkg/version/testhelpers plugins/meta/flannel"
+TESTABLE="libcni plugins/ipam/dhcp plugins/ipam/dhcp plugins/ipam/host-local/backend/allocator plugins/ipam/host-local/backend plugins/main/loopback pkg/invoke pkg/ns pkg/skel pkg/types pkg/utils plugins/main/ipvlan plugins/main/macvlan plugins/main/bridge plugins/main/ptp plugins/test/noop pkg/utils/hwaddr pkg/ip pkg/version pkg/version/testhelpers plugins/meta/flannel"
 FORMATTABLE="$TESTABLE pkg/testutils plugins/meta/flannel plugins/meta/tuning"
 
 # user has not provided PKG override


### PR DESCRIPTION
There's a lot of code that can be used by third parties in the IPAM host-local module (for example the configuration types).

Is it okay to split this up so it can be used by other packages?

Thanks!

Signed-off-by: André Martins aanm90@gmail.com
