### PR TITLE
macvlan: sysctl must be set in macvlan interface's namespace

### DIFF
--- a/plugins/main/macvlan/macvlan.go
+++ b/plugins/main/macvlan/macvlan.go
@@ -106,17 +106,18 @@ func createMacvlan(conf *NetConf, ifName string, netns *os.File) error {
 		return fmt.Errorf("failed to create macvlan: %v", err)
 	}
 
-	// TODO: duplicate following lines for ipv6 support, when it will be added in other places
-	ipv4SysctlValueName := fmt.Sprintf(IPv4InterfaceArpProxySysctlTemplate, tmpName)
-	if _, err := sysctl.Sysctl(ipv4SysctlValueName, "1"); err != nil {
-		// remove the newly added link and ignore errors, because we already are in a failed state
-		_ = netlink.LinkDel(mv)
-		return fmt.Errorf("failed to set proxy_arp on newly added interface %q: %v", tmpName, err)
-	}
-
 	return ns.WithNetNS(netns, false, func(_ *os.File) error {
+		// TODO: duplicate following lines for ipv6 support, when it will be added in other places
+		ipv4SysctlValueName := fmt.Sprintf(IPv4InterfaceArpProxySysctlTemplate, tmpName)
+		if _, err := sysctl.Sysctl(ipv4SysctlValueName, "1"); err != nil {
+			// remove the newly added link and ignore errors, because we already are in a failed state
+			_ = netlink.LinkDel(mv)
+			return fmt.Errorf("failed to set proxy_arp on newly added interface %q: %v", tmpName, err)
+		}
+
 		err := renameLink(tmpName, ifName)
 		if err != nil {
+			_ = netlink.LinkDel(mv)
 			return fmt.Errorf("failed to rename macvlan to %q: %v", ifName, err)
 		}
 		return nil


### PR DESCRIPTION
The macvlan is initially created in a separate network namespace
and the sysctl must be set in that namespace too.

Fixes #208.