### PR TITLE
*: appc/cni -> containernetworking/cni

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,9 @@ contribution. See the [DCO](DCO) file for details.
 
 # Email and Chat
 
-The project uses the the cni-dev email list and #appc on Freenode for chat:
+The project uses the the cni-dev email list and IRC chat:
 - Email: [cni-dev](https://groups.google.com/forum/#!forum/cni-dev)
-- IRC: #[appc](irc://irc.freenode.org:6667/#appc) IRC channel on freenode.org
+- IRC: #[containernetworking](irc://irc.freenode.org:6667/#containernetworking) channel on freenode.org
 
 Please avoid emailing maintainers found in the MAINTAINERS file directly. They
 are very busy and read the mailing lists.

--- a/Documentation/dhcp.md
+++ b/Documentation/dhcp.md
@@ -3,7 +3,7 @@
 ## Overview
 
 With dhcp plugin the containers can get an IP allocated by a DHCP server already running on your network.
-This can be especially useful with plugin types such as [macvlan](https://github.com/appc/cni/blob/master/Documentation/macvlan.md).
+This can be especially useful with plugin types such as [macvlan](https://github.com/containernetworking/cni/blob/master/Documentation/macvlan.md).
 Because a DHCP lease must be periodically renewed for the duration of container lifetime, a separate daemon is required to be running.
 The same plugin binary can also be run in the daemon mode.
 

--- a/Documentation/host-local.md
+++ b/Documentation/host-local.md
@@ -32,7 +32,7 @@ It stores the state locally on the host filesystem, therefore ensuring uniquenes
 * `routes` (string, optional): list of routes to add to the container namespace. Each route is a dictionary with "dst" and optional "gw" fields. If "gw" is omitted, value of "gateway" will be used.
 
 ## Supported arguments
-The following [CNI_ARGS](https://github.com/appc/cni/blob/master/SPEC.md#parameters) are supported:
+The following [CNI_ARGS](https://github.com/containernetworking/cni/blob/master/SPEC.md#parameters) are supported:
 
 * `ip`: request a specific IP address from the subnet. If it's not available, the plugin will exit with an error
 

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
-	"ImportPath": "github.com/appc/cni",
+	"ImportPath": "github.com/containernetworking/cni",
 	"GoVersion": "go1.6",
 	"Packages": [
 		"./..."

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://travis-ci.org/appc/cni.svg?branch=master)](https://travis-ci.org/appc/cni)
-[![Coverage Status](https://coveralls.io/repos/github/appc/cni/badge.svg?branch=master)](https://coveralls.io/github/appc/cni?branch=master)
+[![Build Status](https://travis-ci.org/containernetworking/cni.svg?branch=master)](https://travis-ci.org/containernetworking/cni)
+[![Coverage Status](https://coveralls.io/repos/github/containernetworking/cni/badge.svg?branch=master)](https://coveralls.io/github/containernetworking/cni?branch=master)
 
 # CNI - the Container Network Interface
 
@@ -34,7 +34,7 @@ Hence we are proposing this specification, along with an initial set of plugins 
 
 ## Contributing to CNI
 
-We welcome contributions, including [bug reports](https://github.com/appc/cni/issues), and code and documentation improvements.
+We welcome contributions, including [bug reports](https://github.com/containernetworking/cni/issues), and code and documentation improvements.
 If you intend to contribute to code or documentation, please read [CONTRIBUTING.md](CONTRIBUTING.md). Also see the [contact section](#contact) in this README.
 
 ## How do I use CNI?
@@ -156,6 +156,6 @@ If these topics of are interest please contact the team via the mailing list or 
 
 ## Contact
 
-For any questions about CNI, please reach out on the mailing list or IRC:
+For any questions about CNI, please reach out on the mailing list:
 - Email: [cni-dev](https://groups.google.com/forum/#!forum/cni-dev)
-- IRC: #[appc](irc://irc.freenode.org:6667/#appc) IRC channel on freenode.org
+- IRC: #[containernetworking](irc://irc.freenode.org:6667/#containernetworking) channel on freenode.org

--- a/build
+++ b/build
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-ORG_PATH="github.com/appc"
+ORG_PATH="github.com/containernetworking"
 REPO_PATH="${ORG_PATH}/cni"
 
 if [ ! -h gopath/src/${REPO_PATH} ]; then

--- a/cnitool/cni.go
+++ b/cnitool/cni.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/appc/cni/libcni"
+	"github.com/containernetworking/cni/libcni"
 )
 
 const (

--- a/libcni/api.go
+++ b/libcni/api.go
@@ -17,8 +17,8 @@ package libcni
 import (
 	"strings"
 
-	"github.com/appc/cni/pkg/invoke"
-	"github.com/appc/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/types"
 )
 
 type RuntimeConf struct {

--- a/pkg/invoke/delegate.go
+++ b/pkg/invoke/delegate.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/appc/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types"
 )
 
 func DelegateAdd(delegatePlugin string, netconf []byte) (*types.Result, error) {

--- a/pkg/invoke/exec.go
+++ b/pkg/invoke/exec.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/appc/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types"
 )
 
 func pluginErr(err error, output []byte) error {

--- a/pkg/invoke/find_test.go
+++ b/pkg/invoke/find_test.go
@@ -19,7 +19,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/appc/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/invoke"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/pkg/ip/link.go
+++ b/pkg/ip/link.go
@@ -20,7 +20,7 @@ import (
 	"net"
 	"os"
 
-	"github.com/appc/cni/pkg/ns"
+	"github.com/containernetworking/cni/pkg/ns"
 	"github.com/vishvananda/netlink"
 )
 

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/appc/cni/pkg/invoke"
-	"github.com/appc/cni/pkg/ip"
-	"github.com/appc/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/ip"
+	"github.com/containernetworking/cni/pkg/types"
 
 	"github.com/vishvananda/netlink"
 )

--- a/pkg/ns/ns_test.go
+++ b/pkg/ns/ns_test.go
@@ -22,8 +22,8 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/appc/cni/pkg/ns"
-	"github.com/appc/cni/pkg/testhelpers"
+	"github.com/containernetworking/cni/pkg/ns"
+	"github.com/containernetworking/cni/pkg/testhelpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/pkg/skel/skel.go
+++ b/pkg/skel/skel.go
@@ -22,7 +22,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/appc/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types"
 )
 
 // CmdArgs captures all the arguments passed in to the plugin

--- a/pkg/testhelpers/testhelpers_test.go
+++ b/pkg/testhelpers/testhelpers_test.go
@@ -25,7 +25,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/appc/cni/pkg/testhelpers"
+	"github.com/containernetworking/cni/pkg/testhelpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/pkg/types/args_test.go
+++ b/pkg/types/args_test.go
@@ -17,7 +17,7 @@ package types_test
 import (
 	"reflect"
 
-	. "github.com/appc/cni/pkg/types"
+	. "github.com/containernetworking/cni/pkg/types"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"

--- a/plugins/ipam/dhcp/daemon.go
+++ b/plugins/ipam/dhcp/daemon.go
@@ -27,8 +27,8 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/appc/cni/pkg/skel"
-	"github.com/appc/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
 	"github.com/coreos/go-systemd/activation"
 )
 

--- a/plugins/ipam/dhcp/lease.go
+++ b/plugins/ipam/dhcp/lease.go
@@ -27,8 +27,8 @@ import (
 	"github.com/d2g/dhcp4client"
 	"github.com/vishvananda/netlink"
 
-	"github.com/appc/cni/pkg/ns"
-	"github.com/appc/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/ns"
+	"github.com/containernetworking/cni/pkg/types"
 )
 
 // RFC 2131 suggests using exponential backoff, starting with 4sec

--- a/plugins/ipam/dhcp/main.go
+++ b/plugins/ipam/dhcp/main.go
@@ -20,8 +20,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/appc/cni/pkg/skel"
-	"github.com/appc/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
 )
 
 const socketPath = "/run/cni/dhcp.sock"

--- a/plugins/ipam/dhcp/options.go
+++ b/plugins/ipam/dhcp/options.go
@@ -20,7 +20,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/appc/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types"
 	"github.com/d2g/dhcp4"
 )
 

--- a/plugins/ipam/dhcp/options_test.go
+++ b/plugins/ipam/dhcp/options_test.go
@@ -18,7 +18,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/appc/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types"
 	"github.com/d2g/dhcp4"
 )
 

--- a/plugins/ipam/host-local/allocator.go
+++ b/plugins/ipam/host-local/allocator.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/appc/cni/pkg/ip"
-	"github.com/appc/cni/pkg/types"
-	"github.com/appc/cni/plugins/ipam/host-local/backend"
+	"github.com/containernetworking/cni/pkg/ip"
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/plugins/ipam/host-local/backend"
 )
 
 type IPAllocator struct {

--- a/plugins/ipam/host-local/config.go
+++ b/plugins/ipam/host-local/config.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/appc/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types"
 )
 
 // IPAMConfig represents the IP related network configuration.

--- a/plugins/ipam/host-local/main.go
+++ b/plugins/ipam/host-local/main.go
@@ -15,10 +15,10 @@
 package main
 
 import (
-	"github.com/appc/cni/plugins/ipam/host-local/backend/disk"
+	"github.com/containernetworking/cni/plugins/ipam/host-local/backend/disk"
 
-	"github.com/appc/cni/pkg/skel"
-	"github.com/appc/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
 )
 
 func main() {

--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -23,12 +23,12 @@ import (
 	"runtime"
 	"syscall"
 
-	"github.com/appc/cni/pkg/ip"
-	"github.com/appc/cni/pkg/ipam"
-	"github.com/appc/cni/pkg/ns"
-	"github.com/appc/cni/pkg/skel"
-	"github.com/appc/cni/pkg/types"
-	"github.com/appc/cni/pkg/utils"
+	"github.com/containernetworking/cni/pkg/ip"
+	"github.com/containernetworking/cni/pkg/ipam"
+	"github.com/containernetworking/cni/pkg/ns"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/utils"
 	"github.com/vishvananda/netlink"
 )
 

--- a/plugins/main/ipvlan/ipvlan.go
+++ b/plugins/main/ipvlan/ipvlan.go
@@ -21,11 +21,11 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/appc/cni/pkg/ip"
-	"github.com/appc/cni/pkg/ipam"
-	"github.com/appc/cni/pkg/ns"
-	"github.com/appc/cni/pkg/skel"
-	"github.com/appc/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/ip"
+	"github.com/containernetworking/cni/pkg/ipam"
+	"github.com/containernetworking/cni/pkg/ns"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
 	"github.com/vishvananda/netlink"
 )
 

--- a/plugins/main/loopback/loopback.go
+++ b/plugins/main/loopback/loopback.go
@@ -17,9 +17,9 @@ package main
 import (
 	"os"
 
-	"github.com/appc/cni/pkg/ns"
-	"github.com/appc/cni/pkg/skel"
-	"github.com/appc/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/ns"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
 	"github.com/vishvananda/netlink"
 )
 

--- a/plugins/main/loopback/loopback_suite_test.go
+++ b/plugins/main/loopback/loopback_suite_test.go
@@ -32,7 +32,7 @@ func TestLoopback(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	var err error
-	pathToLoPlugin, err = gexec.Build("github.com/appc/cni/plugins/main/loopback")
+	pathToLoPlugin, err = gexec.Build("github.com/containernetworking/cni/plugins/main/loopback")
 	Expect(err).NotTo(HaveOccurred())
 })
 

--- a/plugins/main/loopback/loopback_test.go
+++ b/plugins/main/loopback/loopback_test.go
@@ -21,8 +21,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/appc/cni/pkg/ns"
-	"github.com/appc/cni/pkg/testhelpers"
+	"github.com/containernetworking/cni/pkg/ns"
+	"github.com/containernetworking/cni/pkg/testhelpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"

--- a/plugins/main/macvlan/macvlan.go
+++ b/plugins/main/macvlan/macvlan.go
@@ -21,12 +21,12 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/appc/cni/pkg/ip"
-	"github.com/appc/cni/pkg/ipam"
-	"github.com/appc/cni/pkg/ns"
-	"github.com/appc/cni/pkg/skel"
-	"github.com/appc/cni/pkg/types"
-	"github.com/appc/cni/pkg/utils/sysctl"
+	"github.com/containernetworking/cni/pkg/ip"
+	"github.com/containernetworking/cni/pkg/ipam"
+	"github.com/containernetworking/cni/pkg/ns"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/utils/sysctl"
 	"github.com/vishvananda/netlink"
 )
 

--- a/plugins/main/ptp/ptp.go
+++ b/plugins/main/ptp/ptp.go
@@ -24,12 +24,12 @@ import (
 
 	"github.com/vishvananda/netlink"
 
-	"github.com/appc/cni/pkg/ip"
-	"github.com/appc/cni/pkg/ipam"
-	"github.com/appc/cni/pkg/ns"
-	"github.com/appc/cni/pkg/skel"
-	"github.com/appc/cni/pkg/types"
-	"github.com/appc/cni/pkg/utils"
+	"github.com/containernetworking/cni/pkg/ip"
+	"github.com/containernetworking/cni/pkg/ipam"
+	"github.com/containernetworking/cni/pkg/ns"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/utils"
 )
 
 func init() {

--- a/plugins/meta/flannel/flannel.go
+++ b/plugins/meta/flannel/flannel.go
@@ -29,9 +29,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/appc/cni/pkg/invoke"
-	"github.com/appc/cni/pkg/skel"
-	"github.com/appc/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
 )
 
 const (

--- a/plugins/meta/tuning/tuning.go
+++ b/plugins/meta/tuning/tuning.go
@@ -25,9 +25,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/appc/cni/pkg/ns"
-	"github.com/appc/cni/pkg/skel"
-	"github.com/appc/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/ns"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
 )
 
 // TuningConf represents the network tuning configuration.


### PR DESCRIPTION
The project has been moved so internally we simply rename everything.
Consumers are recommended to update their vendored version of cni.