### PR TITLE
bridge: leave TX queue length as kernel default, not 0

### DIFF
--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -101,6 +101,11 @@ func ensureBridge(brName string, mtu int) (*netlink.Bridge, error) {
 		LinkAttrs: netlink.LinkAttrs{
 			Name: brName,
 			MTU:  mtu,
+			// Let kernel use default txqueuelen; leaving it unset
+			// means 0, and a zero-length TX queue messes up FIFO
+			// traffic shapers which use TX queue length as the
+			// default packet limit
+			TxQLen: -1,
 		},
 	}
 


### PR DESCRIPTION
Not using NewLinkAttrs() or not initializing TxQLen leaves
the value as 0, which tells the kernel to set a zero-length
tx_queue_len.  That messes up FIFO traffic shapers (like pfifo)
that use the device TX queue length as the default packet
limit.  This leads to a default packet limit of 0, which drops
all packets.