### PR TITLE
v0.2.X cherry-pick masquerading rules cleanup

### DIFF
--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -238,14 +238,25 @@ func cmdDel(args *skel.CmdArgs) error {
 		return err
 	}
 
-	err = ipam.ExecDel(n.IPAM.Type, args.StdinData)
+	var ipn *net.IPNet
+	err = ns.WithNetNSPath(args.Netns, false, func(hostNS *os.File) error {
+		var err error
+		ipn, err = ip.DelLinkByNameAddr(args.IfName, netlink.FAMILY_V4)
+		return err
+	})
 	if err != nil {
 		return err
 	}
 
-	return ns.WithNetNSPath(args.Netns, false, func(hostNS *os.File) error {
-		return ip.DelLinkByName(args.IfName)
-	})
+	if n.IPMasq {
+		chain := utils.FormatChainName(n.Name, args.ContainerID)
+		comment := utils.FormatComment(n.Name, args.ContainerID)
+		if err = ip.TeardownIPMasq(ipn, chain, comment); err != nil {
+			return err
+		}
+	}
+
+	return ipam.ExecDel(n.IPAM.Type, args.StdinData)
 }
 
 func main() {


### PR DESCRIPTION
In the Add command we set up masquerading rules that didn't have a
corresponding clean-up code in Del.

Add the clean-up code.

Blocked by
- [x] #205 