### PR TITLE
plugins/{ptp,bridge}: teardown first

### DIFF
--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -238,6 +238,10 @@ func cmdDel(args *skel.CmdArgs) error {
 		return err
 	}
 
+	if err := ipam.ExecDel(n.IPAM.Type, args.StdinData); err != nil {
+		return err
+	}
+
 	var ipn *net.IPNet
 	err = ns.WithNetNSPath(args.Netns, false, func(hostNS *os.File) error {
 		var err error
@@ -256,7 +260,7 @@ func cmdDel(args *skel.CmdArgs) error {
 		}
 	}
 
-	return ipam.ExecDel(n.IPAM.Type, args.StdinData)
+	return nil
 }
 
 func main() {

--- a/plugins/main/ptp/ptp.go
+++ b/plugins/main/ptp/ptp.go
@@ -195,6 +195,10 @@ func cmdDel(args *skel.CmdArgs) error {
 		return fmt.Errorf("failed to load netconf: %v", err)
 	}
 
+	if err := ipam.ExecDel(conf.IPAM.Type, args.StdinData); err != nil {
+		return err
+	}
+
 	var ipn *net.IPNet
 	err := ns.WithNetNSPath(args.Netns, false, func(hostNS *os.File) error {
 		var err error
@@ -213,7 +217,7 @@ func cmdDel(args *skel.CmdArgs) error {
 		}
 	}
 
-	return ipam.ExecDel(conf.IPAM.Type, args.StdinData)
+	return nil
 }
 
 func main() {


### PR DESCRIPTION
This will allow the IPAM allocations to be cleared in case the
interfaces and iptables rules are non-existent.

Fixes #204 

/cc @iaguis @tomdee 