### PR TITLE
travis: cleanup and bump go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 
 matrix:
   include:
-    - go: 1.5.3
+    - go: 1.5.4
       env: GO15VENDOREXPERIMENT=1
     - go: 1.6.2
     - go: tip

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,20 @@ language: go
 sudo: required
 dist: trusty
 
-go:
-  - 1.5.3
-  - 1.6
-  - tip
 
 matrix:
-  allow_failures:
+  include:
+    - go: 1.5.3
+      env: GO15VENDOREXPERIMENT=1
+    - go: 1.6.2
+    - go: tip
+  allow_failures: 
     - go: tip
 
 env:
   global:
     - TOOLS_CMD=golang.org/x/tools/cmd
     - PATH=$GOROOT/bin:$PATH
-    - GO15VENDOREXPERIMENT=1
 
 install:
  - go get ${TOOLS_CMD}/cover


### PR DESCRIPTION
* cleanup structure
* explicitly use go-{1.5.4,1.6.2}