### PR TITLE
plugins: don't require CNI_NETNS for DEL command

### DIFF
--- a/pkg/skel/skel.go
+++ b/pkg/skel/skel.go
@@ -36,28 +36,72 @@ type CmdArgs struct {
 	StdinData   []byte
 }
 
+type reqForCmdEntry map[string]bool
+
 // PluginMain is the "main" for a plugin. It accepts
 // two callback functions for add and del commands.
 func PluginMain(cmdAdd, cmdDel func(_ *CmdArgs) error) {
 	var cmd, contID, netns, ifName, args, path string
 
 	vars := []struct {
-		name string
-		val  *string
-		req  bool
+		name      string
+		val       *string
+		reqForCmd reqForCmdEntry
 	}{
-		{"CNI_COMMAND", &cmd, true},
-		{"CNI_CONTAINERID", &contID, false},
-		{"CNI_NETNS", &netns, true},
-		{"CNI_IFNAME", &ifName, true},
-		{"CNI_ARGS", &args, false},
-		{"CNI_PATH", &path, true},
+		{
+			"CNI_COMMAND",
+			&cmd,
+			reqForCmdEntry{
+				"ADD": true,
+				"DEL": true,
+			},
+		},
+		{
+			"CNI_CONTAINERID",
+			&contID,
+			reqForCmdEntry{
+				"ADD": false,
+				"DEL": false,
+			},
+		},
+		{
+			"CNI_NETNS",
+			&netns,
+			reqForCmdEntry{
+				"ADD": true,
+				"DEL": true,
+			},
+		},
+		{
+			"CNI_IFNAME",
+			&ifName,
+			reqForCmdEntry{
+				"ADD": true,
+				"DEL": true,
+			},
+		},
+		{
+			"CNI_ARGS",
+			&args,
+			reqForCmdEntry{
+				"ADD": false,
+				"DEL": false,
+			},
+		},
+		{
+			"CNI_PATH",
+			&path,
+			reqForCmdEntry{
+				"ADD": true,
+				"DEL": true,
+			},
+		},
 	}
 
 	argsMissing := false
 	for _, v := range vars {
 		*v.val = os.Getenv(v.name)
-		if v.req && *v.val == "" {
+		if v.reqForCmd[cmd] && *v.val == "" {
 			log.Printf("%v env variable missing", v.name)
 			argsMissing = true
 		}

--- a/pkg/skel/skel.go
+++ b/pkg/skel/skel.go
@@ -69,7 +69,7 @@ func PluginMain(cmdAdd, cmdDel func(_ *CmdArgs) error) {
 			&netns,
 			reqForCmdEntry{
 				"ADD": true,
-				"DEL": true,
+				"DEL": false,
 			},
 		},
 		{

--- a/pkg/skel/skel_test.go
+++ b/pkg/skel/skel_test.go
@@ -71,5 +71,14 @@ var _ = Describe("Skel", func() {
 		// 	Expect(err).NotTo(HaveOccurred())
 		// 	PluginMain(fErr, nil)
 		// })
+
+		It("should not fail with DEL and no NETNS and noop callback", func() {
+			err := os.Setenv("CNI_COMMAND", "DEL")
+			Expect(err).NotTo(HaveOccurred())
+			err = os.Unsetenv("CNI_NETNS")
+			Expect(err).NotTo(HaveOccurred())
+			PluginMain(nil, fNoop)
+		})
+
 	})
 })

--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -289,6 +289,10 @@ func cmdDel(args *skel.CmdArgs) error {
 		return err
 	}
 
+	if args.Netns == "" {
+		return nil
+	}
+
 	var ipn *net.IPNet
 	err = ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
 		var err error

--- a/plugins/main/ipvlan/ipvlan.go
+++ b/plugins/main/ipvlan/ipvlan.go
@@ -152,6 +152,10 @@ func cmdDel(args *skel.CmdArgs) error {
 		return err
 	}
 
+	if args.Netns == "" {
+		return nil
+	}
+
 	return ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
 		return ip.DelLinkByName(args.IfName)
 	})

--- a/plugins/main/macvlan/macvlan.go
+++ b/plugins/main/macvlan/macvlan.go
@@ -170,6 +170,10 @@ func cmdDel(args *skel.CmdArgs) error {
 		return err
 	}
 
+	if args.Netns == "" {
+		return nil
+	}
+
 	return ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
 		return ip.DelLinkByName(args.IfName)
 	})

--- a/plugins/main/ptp/ptp.go
+++ b/plugins/main/ptp/ptp.go
@@ -199,6 +199,10 @@ func cmdDel(args *skel.CmdArgs) error {
 		return err
 	}
 
+	if args.Netns == "" {
+		return nil
+	}
+
 	var ipn *net.IPNet
 	err := ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
 		var err error


### PR DESCRIPTION
This will allow to free up the IPAM allocations when the caller doesn't
have access to the network namespace anymore, e.g. due to a reboot.

Fixes #220.