### PR TITLE
ipam/host-local: Return correct IP version for allocation

### DIFF
--- a/plugins/ipam/host-local/main.go
+++ b/plugins/ipam/host-local/main.go
@@ -47,8 +47,11 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
-	r := &types.Result{
-		IP4: ipConf,
+	var r types.Result
+	if ipConf.IP.IP.To4() == nil {
+		r.IP6 = ipConf
+	} else {
+		r.IP4 = ipConf
 	}
 	return r.Print()
 }


### PR DESCRIPTION
The logic in the host-local IPAM plugin does support IPv6 allocation.
However, the result is given with types.IP4 regardless of IP address
type. This patch addresses this by checking for what IP version is
used before filling the result structure.

Fixes part of #31
