### PR TITLE
pkg/types: Add UnmarshallableString type

### DIFF
--- a/pkg/types/args.go
+++ b/pkg/types/args.go
@@ -41,6 +41,16 @@ func (b *UnmarshallableBool) UnmarshalText(data []byte) error {
 	return nil
 }
 
+// UnmarshallableString typedef for builtin string
+type UnmarshallableString string
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+// Returns the string
+func (s *UnmarshallableString) UnmarshalText(data []byte) error {
+	*s = UnmarshallableString(data)
+	return nil
+}
+
 // CommonArgs contains the IgnoreUnknown argument
 // and must be embedded by all Arg structs
 type CommonArgs struct {


### PR DESCRIPTION
Allow strings to be unmarshalled for CNI_ARGS

CNI_ARGS uses types.LoadArgs to populate a struct.
The fields in the struct must meet the TextUnmarshaler interface.

This code adds a UnmarshallableString type to assist with this.