### PR TITLE
added custom attributes for exchanging more information between ipam …

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -67,9 +67,10 @@ type NetConf struct {
 
 // Result is what gets returned from the plugin (via stdout) to the caller
 type Result struct {
-	IP4 *IPConfig `json:"ip4,omitempty"`
-	IP6 *IPConfig `json:"ip6,omitempty"`
-	DNS DNS       `json:"dns,omitempty"`
+	IP4 		*IPConfig `json:"ip4,omitempty"`
+	IP6 		*IPConfig `json:"ip6,omitempty"`
+	DNS 		DNS       `json:"dns,omitempty"`
+	CUSTOMATTR  	*CUSTOM    `json:"custom,omitempty"`
 }
 
 func (r *Result) Print() error {
@@ -87,6 +88,9 @@ func (r *Result) String() string {
 	if r.IP6 != nil {
 		str += fmt.Sprintf("IP6:%+v, ", *r.IP6)
 	}
+        if r.CUSTOMATTR != nil {
+		str += fmt.Sprintf("CUSTOMATTR:%+v, ", *r.CUSTOMATTR)
+        }
 	return fmt.Sprintf("%sDNS:%+v", str, r.DNS)
 }
 
@@ -103,6 +107,15 @@ type DNS struct {
 	Domain      string   `json:"domain,omitempty"`
 	Search      []string `json:"search,omitempty"`
 	Options     []string `json:"options,omitempty"`
+}
+
+type Attribute struct {
+	Name 	string
+	Value 	string
+}
+
+type CUSTOM struct {
+        CustomAttributes []Attribute
 }
 
 type Route struct {


### PR DESCRIPTION
…module and plugin
For some plugins more information must be exchanged between IPAM and plugin.
For OpenContrail the CNI OpenContrail IPAM module creates the virtual networks and assigns Ip addresses. 
The plugin itself creates the virtual port object in the database.
In order to assign the virtual port to the virtual network and the ip address to the port the plugin must know the UUID of the virtual network and virtual port the IPAM module created.
The CUSTOM attributes allow sending Name:Value information as part of the result struct from IPAM to plugin.
