### PR TITLE
plugins/main/host-local: don't always assign gw

### DIFF
--- a/plugins/ipam/host-local/allocator.go
+++ b/plugins/ipam/host-local/allocator.go
@@ -74,9 +74,6 @@ func (a *IPAllocator) Get(id string) (*types.IPConfig, error) {
 	defer a.store.Unlock()
 
 	gw := a.conf.Gateway
-	if gw == nil {
-		gw = ip.NextIP(a.conf.Subnet.IP)
-	}
 
 	var requestedIP net.IP
 	if a.conf.Args != nil {

--- a/plugins/ipam/host-local/allocator_test.go
+++ b/plugins/ipam/host-local/allocator_test.go
@@ -50,7 +50,7 @@ var _ = Describe("host-local ip allocator", func() {
 				{
 					subnet:       "10.0.0.0/29",
 					ipmap:        map[string]string{},
-					expectResult: "10.0.0.2",
+					expectResult: "10.0.0.1",
 					lastIP:       "",
 				},
 				{
@@ -58,7 +58,7 @@ var _ = Describe("host-local ip allocator", func() {
 					ipmap: map[string]string{
 						"10.0.0.2": "id",
 					},
-					expectResult: "10.0.0.3",
+					expectResult: "10.0.0.1",
 					lastIP:       "",
 				},
 				// next ip of last reserved ip
@@ -83,16 +83,16 @@ var _ = Describe("host-local ip allocator", func() {
 					ipmap: map[string]string{
 						"10.0.0.7": "id",
 					},
-					expectResult: "10.0.0.2",
+					expectResult: "10.0.0.1",
 					lastIP:       "10.0.0.6",
 				},
 				// lastIP is out of range
 				{
 					subnet: "10.0.0.0/29",
 					ipmap: map[string]string{
-						"10.0.0.2": "id",
+						"10.0.0.1": "id",
 					},
-					expectResult: "10.0.0.3",
+					expectResult: "10.0.0.2",
 					lastIP:       "10.0.0.128",
 				},
 			}
@@ -111,6 +111,7 @@ var _ = Describe("host-local ip allocator", func() {
 				{
 					subnet: "10.0.0.0/30",
 					ipmap: map[string]string{
+						"10.0.0.1": "id",
 						"10.0.0.2": "id",
 						"10.0.0.3": "id",
 					},
@@ -118,6 +119,7 @@ var _ = Describe("host-local ip allocator", func() {
 				{
 					subnet: "10.0.0.0/29",
 					ipmap: map[string]string{
+						"10.0.0.1": "id",
 						"10.0.0.2": "id",
 						"10.0.0.3": "id",
 						"10.0.0.4": "id",


### PR DESCRIPTION
The automatic assignment of the GW should not be enforced by the
host-local plugin. This commit stops the allocator from setting the gw in the
IPAM result if it hasn't been passed.

/cc @freehan
