### PR TITLE
Adds VERSION command

### DIFF
--- a/Documentation/tuning.md
+++ b/Documentation/tuning.md
@@ -22,9 +22,7 @@ Other sysctls can be modified as long as they belong to the network namespace (`
 
 A successful result would simply be:
 ```
-{
-  "cniVersion": "0.1.0"
-}
+{ }
 ```
 
 ## Network sysctls documentation

--- a/SPEC.md
+++ b/SPEC.md
@@ -62,9 +62,14 @@ The operations that the CNI plugin needs to support are:
     - **Extra arguments**, as defined above.
     - **Name of the interface inside the container**, as defined above.
 
+- Report version
+  - Parameters: NONE.
+  - Result:
+    - The version of the CNI spec implemented by the plugin: `{ "cniVersion": "0.2.0" }`
+
 The executable command-line API uses the type of network (see [Network Configuration](#network-configuration) below) as the name of the executable to invoke.
 It will then look for this executable in a list of predefined directories. Once found, it will invoke the executable using the following environment variables for argument passing:
-- `CNI_COMMAND`: indicates the desired operation; either `ADD` or `DEL`
+- `CNI_COMMAND`: indicates the desired operation; `ADD`, `DEL` or `VERSION`.
 - `CNI_CONTAINERID`: Container ID
 - `CNI_NETNS`: Path to network namespace file
 - `CNI_IFNAME`: Interface name to set up
@@ -80,7 +85,7 @@ Success is indicated by a return code of zero and the following JSON printed to 
 
 ```
 {
-  "cniVersion": "0.1.0",
+  "cniVersion": "0.2.0",
   "ip4": {
     "ip": <ipv4-and-subnet-in-CIDR>,
     "gateway": <ipv4-of-the-gateway>,  (optional)
@@ -109,7 +114,7 @@ Examples include generating an `/etc/resolv.conf` file to be injected into the c
 Errors are indicated by a non-zero return code and the following JSON being printed to stdout:
 ```
 {
-  "cniVersion": "0.1.0",
+  "cniVersion": "0.2.0",
   "code": <numeric-error-code>,
   "msg": <short-error-message>,
   "details": <long-error-message> (optional)
@@ -146,7 +151,7 @@ Plugins may define additional fields that they accept and may generate an error 
 
 ```json
 {
-  "cniVersion": "0.1.0",
+  "cniVersion": "0.2.0",
   "name": "dbnet",
   "type": "bridge",
   // type (plugin) specific
@@ -165,7 +170,7 @@ Plugins may define additional fields that they accept and may generate an error 
 
 ```json
 {
-  "cniVersion": "0.1.0",
+  "cniVersion": "0.2.0",
   "name": "pci",
   "type": "ovs",
   // type (plugin) specific
@@ -215,7 +220,7 @@ Success is indicated by a zero return code and the following JSON being printed 
 
 ```
 {
-  "cniVersion": "0.1.0",
+  "cniVersion": "0.2.0",
   "ip4": {
     "ip": <ipv4-and-subnet-in-CIDR>,
     "gateway": <ipv4-of-the-gateway>,  (optional)

--- a/SPEC.md
+++ b/SPEC.md
@@ -64,7 +64,6 @@ The operations that the CNI plugin needs to support are:
 
 The executable command-line API uses the type of network (see [Network Configuration](#network-configuration) below) as the name of the executable to invoke.
 It will then look for this executable in a list of predefined directories. Once found, it will invoke the executable using the following environment variables for argument passing:
-- `CNI_VERSION`:  [Semantic Version 2.0](http://semver.org) of CNI specification. This effectively versions the CNI_XXX environment variables.
 - `CNI_COMMAND`: indicates the desired operation; either `ADD` or `DEL`
 - `CNI_CONTAINERID`: Container ID
 - `CNI_NETNS`: Path to network namespace file

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,42 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// A PluginVersioner can encode information about its version
+type PluginVersioner interface {
+	Encode(io.Writer) error
+}
+
+// BasicVersioner is a PluginVersioner which reports a single cniVersion string
+type BasicVersioner struct {
+	CNIVersion string `json:"cniVersion"`
+}
+
+func (p *BasicVersioner) Encode(w io.Writer) error {
+	return json.NewEncoder(w).Encode(p)
+}
+
+// Current reports the version of the CNI spec implemented by this library
+func Current() string {
+	return "0.2.0"
+}
+
+// DefaultPluginVersioner reports the Current library spec version as the cniVersion
+var DefaultPluginVersioner = &BasicVersioner{CNIVersion: Current()}


### PR DESCRIPTION
At last CNI meeting, I volunteered to put together a first draft of spec versioning support, see https://github.com/containernetworking/cni/issues/266

This small PR is the first step -- add a VERSION command to all plugins transparently -- plugin authors only need to re-compile.

The `VERSION` is bumped to `0.2.0` because this new command was added.  There are no incompatibilities with `0.1.0`