### PR TITLE
Refactor skel with dependency injection

### DIFF
--- a/pkg/skel/skel.go
+++ b/pkg/skel/skel.go
@@ -1,4 +1,4 @@
-// Copyright 2014 CNI authors
+// Copyright 2014-2016 CNI authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/skel/skel.go
+++ b/pkg/skel/skel.go
@@ -40,6 +40,7 @@ type CmdArgs struct {
 type dispatcher struct {
 	Getenv func(string) string
 	Stdin  io.Reader
+	Stderr io.Writer
 }
 
 type reqForCmdEntry map[string]bool
@@ -106,8 +107,7 @@ func (t *dispatcher) getCmdArgsFromEnv() (string, *CmdArgs, error) {
 	for _, v := range vars {
 		*v.val = t.Getenv(v.name)
 		if v.reqForCmd[cmd] && *v.val == "" {
-			log.Printf("%v env variable missing", v.name)
-			// TODO: test this logging ^^^  and log to stderr instead of stdout
+			fmt.Fprintf(t.Stderr, "%v env variable missing\n", v.name)
 			argsMissing = true
 		}
 	}
@@ -172,6 +172,7 @@ func PluginMain(cmdAdd, cmdDel func(_ *CmdArgs) error) {
 	caller := dispatcher{
 		Getenv: os.Getenv,
 		Stdin:  os.Stdin,
+		Stderr: os.Stderr,
 	}
 
 	err := caller.pluginMain(cmdAdd, cmdDel)

--- a/pkg/skel/skel.go
+++ b/pkg/skel/skel.go
@@ -106,9 +106,11 @@ func (t *dispatcher) getCmdArgsFromEnv() (string, *CmdArgs, error) {
 	argsMissing := false
 	for _, v := range vars {
 		*v.val = t.Getenv(v.name)
-		if v.reqForCmd[cmd] && *v.val == "" {
-			fmt.Fprintf(t.Stderr, "%v env variable missing\n", v.name)
-			argsMissing = true
+		if *v.val == "" {
+			if v.reqForCmd[cmd] || v.name == "CNI_COMMAND" {
+				fmt.Fprintf(t.Stderr, "%v env variable missing\n", v.name)
+				argsMissing = true
+			}
 		}
 	}
 

--- a/pkg/skel/skel_test.go
+++ b/pkg/skel/skel_test.go
@@ -115,7 +115,7 @@ var _ = Describe("dispatching to the correct callback", func() {
 		})
 
 		DescribeTable("required / optional env vars", envVarChecker,
-			// TODO: Entry("command", "CNI_COMMAND", true),
+			Entry("command", "CNI_COMMAND", true),
 			Entry("container id", "CNI_CONTAINER_ID", false),
 			Entry("net ns", "CNI_NETNS", true),
 			Entry("if name", "CNI_IFNAME", true),
@@ -162,7 +162,7 @@ var _ = Describe("dispatching to the correct callback", func() {
 		})
 
 		DescribeTable("required / optional env vars", envVarChecker,
-			// TODO: Entry("command", "CNI_COMMAND", true),
+			Entry("command", "CNI_COMMAND", true),
 			Entry("container id", "CNI_CONTAINER_ID", false),
 			Entry("net ns", "CNI_NETNS", false),
 			Entry("if name", "CNI_IFNAME", true),

--- a/pkg/testutils/bad_reader.go
+++ b/pkg/testutils/bad_reader.go
@@ -1,4 +1,4 @@
-// Copyright 2014 CNI authors
+// Copyright 2016 CNI authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/testutils/bad_reader.go
+++ b/pkg/testutils/bad_reader.go
@@ -1,0 +1,32 @@
+// Copyright 2014 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutils
+
+import "errors"
+
+type BadReader struct {
+	Error error
+}
+
+func (r *BadReader) Read(buffer []byte) (int, error) {
+	if r.Error != nil {
+		return 0, r.Error
+	}
+	return 0, errors.New("banana")
+}
+
+func (r *BadReader) Close() error {
+	return nil
+}


### PR DESCRIPTION
A refactor that provides better unit test coverage and modularity for the `skel.PluginMain` behavior.

Should make it easier to add features in the future, e.g. #267 

And coverage on `pkg/skel` jumped from 50% to 80% !

Cheers.