### PR TITLE
Add integration tests of libcni

### DIFF
--- a/build
+++ b/build
@@ -20,7 +20,7 @@ echo "Building reference CLI"
 go install "$@" ${REPO_PATH}/cnitool
 
 echo "Building plugins"
-PLUGINS="plugins/meta/* plugins/main/* plugins/ipam/*"
+PLUGINS="plugins/meta/* plugins/main/* plugins/ipam/* plugins/test/*"
 for d in $PLUGINS; do
 	if [ -d $d ]; then
 		plugin=$(basename $d)

--- a/libcni/api_test.go
+++ b/libcni/api_test.go
@@ -1,0 +1,158 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package libcni_test
+
+import (
+	"io/ioutil"
+	"net"
+	"path/filepath"
+
+	"github.com/containernetworking/cni/libcni"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types"
+	noop_debug "github.com/containernetworking/cni/plugins/test/noop/debug"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Invoking the plugin", func() {
+	var (
+		debugFilePath string
+		debug         *noop_debug.Debug
+		cniBinPath    string
+		pluginConfig  string
+		cniConfig     libcni.CNIConfig
+		netConfig     *libcni.NetworkConfig
+		runtimeConfig *libcni.RuntimeConf
+
+		expectedCmdArgs skel.CmdArgs
+	)
+
+	BeforeEach(func() {
+		debugFile, err := ioutil.TempFile("", "cni_debug")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(debugFile.Close()).To(Succeed())
+		debugFilePath = debugFile.Name()
+
+		debug = &noop_debug.Debug{
+			ReportResult: `{ "ip4": { "ip": "10.1.2.3/24" }, "dns": {} }`,
+		}
+		Expect(debug.WriteDebug(debugFilePath)).To(Succeed())
+
+		cniBinPath = filepath.Dir(pathToPlugin)
+		pluginConfig = `{ "type": "noop", "some-key": "some-value" }`
+		cniConfig = libcni.CNIConfig{Path: []string{cniBinPath}}
+		netConfig = &libcni.NetworkConfig{
+			Network: &types.NetConf{
+				Type: "noop",
+			},
+			Bytes: []byte(pluginConfig),
+		}
+		runtimeConfig = &libcni.RuntimeConf{
+			ContainerID: "some-container-id",
+			NetNS:       "/some/netns/path",
+			IfName:      "some-eth0",
+			Args:        [][2]string{[2]string{"DEBUG", debugFilePath}},
+		}
+
+		expectedCmdArgs = skel.CmdArgs{
+			ContainerID: "some-container-id",
+			Netns:       "/some/netns/path",
+			IfName:      "some-eth0",
+			Args:        "DEBUG=" + debugFilePath,
+			Path:        cniBinPath,
+			StdinData:   []byte(pluginConfig),
+		}
+	})
+
+	Describe("AddNetwork", func() {
+		It("executes the plugin with command ADD", func() {
+			result, err := cniConfig.AddNetwork(netConfig, runtimeConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result).To(Equal(&types.Result{
+				IP4: &types.IPConfig{
+					IP: net.IPNet{
+						IP:   net.ParseIP("10.1.2.3"),
+						Mask: net.IPv4Mask(255, 255, 255, 0),
+					},
+				},
+			}))
+
+			debug, err := noop_debug.ReadDebug(debugFilePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(debug.Command).To(Equal("ADD"))
+			Expect(debug.CmdArgs).To(Equal(expectedCmdArgs))
+		})
+
+		Context("when finding the plugin fails", func() {
+			BeforeEach(func() {
+				netConfig.Network.Type = "does-not-exist"
+			})
+
+			It("returns the error", func() {
+				_, err := cniConfig.AddNetwork(netConfig, runtimeConfig)
+				Expect(err).To(MatchError(ContainSubstring(`failed to find plugin "does-not-exist"`)))
+			})
+		})
+
+		Context("when the plugin errors", func() {
+			BeforeEach(func() {
+				debug.ReportError = "plugin error: banana"
+				Expect(debug.WriteDebug(debugFilePath)).To(Succeed())
+			})
+			It("unmarshals and returns the error", func() {
+				result, err := cniConfig.AddNetwork(netConfig, runtimeConfig)
+				Expect(result).To(BeNil())
+				Expect(err).To(MatchError("plugin error: banana"))
+			})
+		})
+	})
+
+	Describe("DelNetwork", func() {
+		It("executes the plugin with command DEL", func() {
+			err := cniConfig.DelNetwork(netConfig, runtimeConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			debug, err := noop_debug.ReadDebug(debugFilePath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(debug.Command).To(Equal("DEL"))
+			Expect(debug.CmdArgs).To(Equal(expectedCmdArgs))
+		})
+
+		Context("when finding the plugin fails", func() {
+			BeforeEach(func() {
+				netConfig.Network.Type = "does-not-exist"
+			})
+
+			It("returns the error", func() {
+				err := cniConfig.DelNetwork(netConfig, runtimeConfig)
+				Expect(err).To(MatchError(ContainSubstring(`failed to find plugin "does-not-exist"`)))
+			})
+		})
+
+		Context("when the plugin errors", func() {
+			BeforeEach(func() {
+				debug.ReportError = "plugin error: banana"
+				Expect(debug.WriteDebug(debugFilePath)).To(Succeed())
+			})
+			It("unmarshals and returns the error", func() {
+				err := cniConfig.DelNetwork(netConfig, runtimeConfig)
+				Expect(err).To(MatchError("plugin error: banana"))
+			})
+		})
+	})
+})

--- a/libcni/conf_test.go
+++ b/libcni/conf_test.go
@@ -1,0 +1,110 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package libcni_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/containernetworking/cni/libcni"
+	"github.com/containernetworking/cni/pkg/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Loading configuration from disk", func() {
+	var (
+		configDir    string
+		pluginConfig []byte
+	)
+
+	BeforeEach(func() {
+		var err error
+		configDir, err = ioutil.TempDir("", "plugin-conf")
+		Expect(err).NotTo(HaveOccurred())
+
+		pluginConfig = []byte(`{ "name": "some-plugin", "some-key": "some-value" }`)
+		Expect(ioutil.WriteFile(filepath.Join(configDir, "50-whatever.conf"), pluginConfig, 0600)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(configDir)).To(Succeed())
+	})
+
+	Describe("LoadConf", func() {
+		It("finds the network config file for the plugin of the given type", func() {
+			netConfig, err := libcni.LoadConf(configDir, "some-plugin")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(netConfig).To(Equal(&libcni.NetworkConfig{
+				Network: &types.NetConf{Name: "some-plugin"},
+				Bytes:   pluginConfig,
+			}))
+		})
+
+		Context("when the config directory does not exist", func() {
+			BeforeEach(func() {
+				Expect(os.RemoveAll(configDir)).To(Succeed())
+			})
+
+			It("returns a useful error", func() {
+				_, err := libcni.LoadConf(configDir, "some-plugin")
+				Expect(err).To(MatchError("no net configurations found"))
+			})
+		})
+
+		Context("when there is no config for the desired plugin", func() {
+			It("returns a useful error", func() {
+				_, err := libcni.LoadConf(configDir, "some-other-plugin")
+				Expect(err).To(MatchError(ContainSubstring(`no net configuration with name "some-other-plugin" in`)))
+			})
+		})
+
+		Context("when a config file is malformed", func() {
+			BeforeEach(func() {
+				Expect(ioutil.WriteFile(filepath.Join(configDir, "00-bad.conf"), []byte(`{`), 0600)).To(Succeed())
+			})
+
+			It("returns a useful error", func() {
+				_, err := libcni.LoadConf(configDir, "some-plugin")
+				Expect(err).To(MatchError(`error parsing configuration: unexpected end of JSON input`))
+			})
+		})
+
+		Context("when the config is in a nested subdir", func() {
+			BeforeEach(func() {
+				subdir := filepath.Join(configDir, "subdir1", "subdir2")
+				Expect(os.MkdirAll(subdir, 0700)).To(Succeed())
+
+				pluginConfig = []byte(`{ "name": "deep", "some-key": "some-value" }`)
+				Expect(ioutil.WriteFile(filepath.Join(subdir, "90-deep.conf"), pluginConfig, 0600)).To(Succeed())
+			})
+
+			It("will not find the config", func() {
+				_, err := libcni.LoadConf(configDir, "deep")
+				Expect(err).To(MatchError(HavePrefix("no net configuration with name")))
+			})
+		})
+	})
+
+	Describe("ConfFromFile", func() {
+		Context("when the file cannot be opened", func() {
+			It("returns a useful error", func() {
+				_, err := libcni.ConfFromFile("/tmp/nope/not-here")
+				Expect(err).To(MatchError(HavePrefix(`error reading /tmp/nope/not-here: open /tmp/nope/not-here`)))
+			})
+		})
+	})
+})

--- a/libcni/libcni_suite_test.go
+++ b/libcni/libcni_suite_test.go
@@ -1,0 +1,45 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package libcni_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+
+	"testing"
+)
+
+func TestLibcni(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Libcni Suite")
+}
+
+const packagePath = "github.com/containernetworking/cni/plugins/test/noop"
+
+var pathToPlugin string
+
+var _ = SynchronizedBeforeSuite(func() []byte {
+	var err error
+	pathToPlugin, err = gexec.Build(packagePath)
+	Expect(err).NotTo(HaveOccurred())
+	return []byte(pathToPlugin)
+}, func(crossNodeData []byte) {
+	pathToPlugin = string(crossNodeData)
+})
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	gexec.CleanupBuildArtifacts()
+})

--- a/pkg/testutils/bad_reader.go
+++ b/pkg/testutils/bad_reader.go
@@ -16,6 +16,7 @@ package testutils
 
 import "errors"
 
+// BadReader is an io.Reader which always errors
 type BadReader struct {
 	Error error
 }

--- a/plugins/test/noop/debug/debug.go
+++ b/plugins/test/noop/debug/debug.go
@@ -1,0 +1,62 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// debug supports tests that use the noop plugin
+package debug
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	"github.com/containernetworking/cni/pkg/skel"
+)
+
+// Debug is used to control and record the behavior of the noop plugin
+type Debug struct {
+	ReportResult string
+	ReportError  string
+	Command      string
+	CmdArgs      skel.CmdArgs
+}
+
+// ReadDebug will return a debug file recorded by the noop plugin
+func ReadDebug(debugFilePath string) (*Debug, error) {
+	debugBytes, err := ioutil.ReadFile(debugFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var debug Debug
+	err = json.Unmarshal(debugBytes, &debug)
+	if err != nil {
+		return nil, err
+	}
+
+	return &debug, nil
+}
+
+// WriteDebug will create a debug file to control the noop plugin
+func (debug *Debug) WriteDebug(debugFilePath string) error {
+	debugBytes, err := json.Marshal(debug)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(debugFilePath, debugBytes, 0600)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/plugins/test/noop/main.go
+++ b/plugins/test/noop/main.go
@@ -1,0 +1,73 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Noop plugin is a CNI plugin designed for use as a test-double.
+
+When calling, set the CNI_ARGS env var equal to the path of a file containing
+the JSON encoding of a Debug.
+*/
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/plugins/test/noop/debug"
+)
+
+func debugBehavior(args *skel.CmdArgs, command string) error {
+	if !strings.HasPrefix(args.Args, "DEBUG=") {
+		fmt.Printf(`{}`)
+		os.Stderr.WriteString("CNI_ARGS empty, no debug behavior\n")
+		return nil
+	}
+	debugFilePath := strings.TrimPrefix(args.Args, "DEBUG=")
+	debug, err := debug.ReadDebug(debugFilePath)
+	if err != nil {
+		return err
+	}
+
+	debug.CmdArgs = *args
+	debug.Command = command
+
+	err = debug.WriteDebug(debugFilePath)
+	if err != nil {
+		return err
+	}
+
+	if debug.ReportError != "" {
+		return errors.New(debug.ReportError)
+	} else {
+		os.Stdout.WriteString(debug.ReportResult)
+	}
+
+	return nil
+}
+
+func cmdAdd(args *skel.CmdArgs) error {
+	return debugBehavior(args, "ADD")
+}
+
+func cmdDel(args *skel.CmdArgs) error {
+	return debugBehavior(args, "DEL")
+}
+
+func main() {
+	skel.PluginMain(cmdAdd, cmdDel)
+}

--- a/plugins/test/noop/noop_suite_test.go
+++ b/plugins/test/noop/noop_suite_test.go
@@ -1,0 +1,45 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+
+	"testing"
+)
+
+func TestNoop(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "No-op plugin Suite")
+}
+
+const packagePath = "github.com/containernetworking/cni/plugins/test/noop"
+
+var pathToPlugin string
+
+var _ = SynchronizedBeforeSuite(func() []byte {
+	var err error
+	pathToPlugin, err = gexec.Build(packagePath)
+	Expect(err).NotTo(HaveOccurred())
+	return []byte(pathToPlugin)
+}, func(crossNodeData []byte) {
+	pathToPlugin = string(crossNodeData)
+})
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	gexec.CleanupBuildArtifacts()
+})

--- a/plugins/test/noop/noop_test.go
+++ b/plugins/test/noop/noop_test.go
@@ -1,0 +1,135 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main_test
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/containernetworking/cni/pkg/skel"
+	noop_debug "github.com/containernetworking/cni/plugins/test/noop/debug"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("No-op plugin", func() {
+	var (
+		cmd           *exec.Cmd
+		debugFileName string
+		debug         *noop_debug.Debug
+	)
+
+	BeforeEach(func() {
+		debug = &noop_debug.Debug{
+			ReportResult: `{ "ip4": { "ip": "10.1.2.3/24" }, "dns": {} }`,
+		}
+
+		debugFile, err := ioutil.TempFile("", "cni_debug")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(debugFile.Close()).To(Succeed())
+		debugFileName = debugFile.Name()
+
+		Expect(debug.WriteDebug(debugFileName)).To(Succeed())
+
+		cmd = exec.Command(pathToPlugin)
+		cmd.Env = []string{
+			"CNI_COMMAND=ADD",
+			"CNI_CONTAINERID=some-container-id",
+			"CNI_ARGS=DEBUG=" + debugFile.Name(),
+			"CNI_NETNS=/some/netns/path",
+			"CNI_IFNAME=some-eth0",
+			"CNI_PATH=/some/bin/path",
+		}
+		cmd.Stdin = strings.NewReader(`{"some":"stdin-json"}`)
+	})
+
+	AfterEach(func() {
+		os.Remove(debugFileName)
+	})
+
+	It("responds to ADD using the ReportResult debug field", func() {
+		session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(session).Should(gexec.Exit(0))
+		Expect(session.Out.Contents()).To(MatchJSON(`{
+				 "ip4": { "ip": "10.1.2.3/24" },
+				 "dns": {}
+      }`))
+	})
+
+	It("records all the args provided by skel.PluginMain", func() {
+		session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(session).Should(gexec.Exit(0))
+
+		debug, err := noop_debug.ReadDebug(debugFileName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(debug.Command).To(Equal("ADD"))
+		Expect(debug.CmdArgs).To(Equal(skel.CmdArgs{
+			ContainerID: "some-container-id",
+			Netns:       "/some/netns/path",
+			IfName:      "some-eth0",
+			Args:        "DEBUG=" + debugFileName,
+			Path:        "/some/bin/path",
+			StdinData:   []byte(`{"some":"stdin-json"}`),
+		}))
+	})
+
+	Context("when the ReportError debug field is set", func() {
+		BeforeEach(func() {
+			debug.ReportError = "banana"
+			Expect(debug.WriteDebug(debugFileName)).To(Succeed())
+		})
+
+		It("returns an error to skel.PluginMain, causing the process to exit code 1", func() {
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(session).Should(gexec.Exit(1))
+			Expect(session.Out.Contents()).To(MatchJSON(`{ "code": 100, "msg": "banana" }`))
+		})
+	})
+
+	Context("when the CNI_COMMAND is DEL", func() {
+		BeforeEach(func() {
+			cmd.Env[0] = "CNI_COMMAND=DEL"
+			debug.ReportResult = `{ "some": "delete-data" }`
+			Expect(debug.WriteDebug(debugFileName)).To(Succeed())
+		})
+
+		It("still does all the debug behavior", func() {
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(session).Should(gexec.Exit(0))
+			Expect(session.Out.Contents()).To(MatchJSON(`{
+				"some": "delete-data"
+      }`))
+			debug, err := noop_debug.ReadDebug(debugFileName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(debug.Command).To(Equal("DEL"))
+			Expect(debug.CmdArgs).To(Equal(skel.CmdArgs{
+				ContainerID: "some-container-id",
+				Netns:       "/some/netns/path",
+				IfName:      "some-eth0",
+				Args:        "DEBUG=" + debugFileName,
+				Path:        "/some/bin/path",
+				StdinData:   []byte(`{"some":"stdin-json"}`),
+			}))
+		})
+
+	})
+})

--- a/test
+++ b/test
@@ -11,7 +11,7 @@ set -e
 
 source ./build
 
-TESTABLE="plugins/ipam/dhcp plugins/ipam/host-local plugins/main/loopback pkg/invoke pkg/ns pkg/skel pkg/types pkg/utils plugins/main/ipvlan plugins/main/macvlan plugins/main/bridge plugins/main/ptp plugins/test/noop"
+TESTABLE="libcni plugins/ipam/dhcp plugins/ipam/host-local plugins/main/loopback pkg/invoke pkg/ns pkg/skel pkg/types pkg/utils plugins/main/ipvlan plugins/main/macvlan plugins/main/bridge plugins/main/ptp plugins/test/noop"
 FORMATTABLE="$TESTABLE libcni pkg/ip pkg/ipam pkg/testutils plugins/meta/flannel plugins/meta/tuning"
 
 # user has not provided PKG override

--- a/test
+++ b/test
@@ -11,8 +11,8 @@ set -e
 
 source ./build
 
-TESTABLE="plugins/ipam/dhcp plugins/ipam/host-local plugins/main/loopback pkg/invoke pkg/ns pkg/skel pkg/types pkg/utils plugins/main/ipvlan plugins/main/macvlan plugins/main/bridge plugins/main/ptp"
-FORMATTABLE="$TESTABLE libcni pkg/ip pkg/ipam pkg/testutils plugins/ipam/host-local plugins/main/bridge plugins/meta/flannel plugins/meta/tuning"
+TESTABLE="plugins/ipam/dhcp plugins/ipam/host-local plugins/main/loopback pkg/invoke pkg/ns pkg/skel pkg/types pkg/utils plugins/main/ipvlan plugins/main/macvlan plugins/main/bridge plugins/main/ptp plugins/test/noop"
+FORMATTABLE="$TESTABLE libcni pkg/ip pkg/ipam pkg/testutils plugins/meta/flannel plugins/meta/tuning"
 
 # user has not provided PKG override
 if [ -z "$PKG" ]; then


### PR DESCRIPTION
The `libcni` package provides the public API used by container runtimes, including loading configuration files from disk and executing plugins.

It is currently untested.  This PR adds integration tests, primarily to catch any regressions that might arise as we add new functionality (e.g. #267).

The tests of the plugin execution use a new "no-op" plugin.  The no-op plugin does not touch namespaces or the network stack.  Instead it records its inputs and can be configured to respond with arbitrary data or to error.  The tests use it to verify behavior of the plugin execution code.

