### PR TITLE
plugins/main/ptp: support for creating tap devices

### DIFF
--- a/libcni/api.go
+++ b/libcni/api.go
@@ -15,6 +15,7 @@
 package libcni
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/containernetworking/cni/pkg/invoke"
@@ -22,10 +23,11 @@ import (
 )
 
 type RuntimeConf struct {
-	ContainerID string
-	NetNS       string
-	IfName      string
-	Args        [][2]string
+	ContainerID   string
+	UsesTapDevice bool
+	NetNS         string
+	IfName        string
+	Args          [][2]string
 }
 
 type NetworkConfig struct {
@@ -63,11 +65,12 @@ func (c *CNIConfig) DelNetwork(net *NetworkConfig, rt *RuntimeConf) error {
 // =====
 func (c *CNIConfig) args(action string, rt *RuntimeConf) *invoke.Args {
 	return &invoke.Args{
-		Command:     action,
-		ContainerID: rt.ContainerID,
-		NetNS:       rt.NetNS,
-		PluginArgs:  rt.Args,
-		IfName:      rt.IfName,
-		Path:        strings.Join(c.Path, ":"),
+		Command:       action,
+		ContainerID:   rt.ContainerID,
+		NetNS:         rt.NetNS,
+		PluginArgs:    rt.Args,
+		IfName:        rt.IfName,
+		Path:          strings.Join(c.Path, ":"),
+		UsesTapDevice: strconv.FormatBool(rt.UsesTapDevice),
 	}
 }

--- a/pkg/invoke/args.go
+++ b/pkg/invoke/args.go
@@ -45,6 +45,7 @@ type Args struct {
 	PluginArgsStr string
 	IfName        string
 	Path          string
+	UsesTapDevice string
 }
 
 func (args *Args) AsEnv() []string {
@@ -60,7 +61,8 @@ func (args *Args) AsEnv() []string {
 		"CNI_NETNS="+args.NetNS,
 		"CNI_ARGS="+pluginArgsStr,
 		"CNI_IFNAME="+args.IfName,
-		"CNI_PATH="+args.Path)
+		"CNI_PATH="+args.Path,
+		"CNI_USE_TAP="+args.UsesTapDevice)
 	return env
 }
 

--- a/pkg/ip/link.go
+++ b/pkg/ip/link.go
@@ -164,7 +164,6 @@ func RandomTapName() (string, error) {
 		return "", fmt.Errorf("failed to generate random veth name: %v", err)
 	}
 
-	// NetworkManager (recent versions) will ignore veth devices that start with "veth"
 	return fmt.Sprintf("tap%x", entropy), nil
 }
 

--- a/pkg/skel/skel.go
+++ b/pkg/skel/skel.go
@@ -30,12 +30,13 @@ import (
 // CmdArgs captures all the arguments passed in to the plugin
 // via both env vars and stdin
 type CmdArgs struct {
-	ContainerID string
-	Netns       string
-	IfName      string
-	Args        string
-	Path        string
-	StdinData   []byte
+	ContainerID   string
+	Netns         string
+	IfName        string
+	Args          string
+	Path          string
+	UsesTapDevice string
+	StdinData     []byte
 }
 
 type dispatcher struct {
@@ -49,7 +50,7 @@ type dispatcher struct {
 type reqForCmdEntry map[string]bool
 
 func (t *dispatcher) getCmdArgsFromEnv() (string, *CmdArgs, error) {
-	var cmd, contID, netns, ifName, args, path string
+	var cmd, contID, netns, ifName, args, path, usesTapDevice string
 
 	vars := []struct {
 		name      string
@@ -104,6 +105,14 @@ func (t *dispatcher) getCmdArgsFromEnv() (string, *CmdArgs, error) {
 				"DEL": true,
 			},
 		},
+		{
+			"CNI_VIRT",
+			&usesTapDevice,
+			reqForCmdEntry{
+				"ADD": false,
+				"DEL": false,
+			},
+		},
 	}
 
 	argsMissing := false
@@ -127,12 +136,13 @@ func (t *dispatcher) getCmdArgsFromEnv() (string, *CmdArgs, error) {
 	}
 
 	cmdArgs := &CmdArgs{
-		ContainerID: contID,
-		Netns:       netns,
-		IfName:      ifName,
-		Args:        args,
-		Path:        path,
-		StdinData:   stdinData,
+		ContainerID:   contID,
+		Netns:         netns,
+		IfName:        ifName,
+		Args:          args,
+		Path:          path,
+		UsesTapDevice: usesTapDevice,
+		StdinData:     stdinData,
 	}
 	return cmd, cmdArgs, nil
 }

--- a/pkg/skel/skel.go
+++ b/pkg/skel/skel.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/version"
@@ -35,7 +36,7 @@ type CmdArgs struct {
 	IfName        string
 	Args          string
 	Path          string
-	UsesTapDevice string
+	UsesTapDevice bool
 	StdinData     []byte
 }
 
@@ -106,7 +107,7 @@ func (t *dispatcher) getCmdArgsFromEnv() (string, *CmdArgs, error) {
 			},
 		},
 		{
-			"CNI_VIRT",
+			"CNI_USE_TAP",
 			&usesTapDevice,
 			reqForCmdEntry{
 				"ADD": false,
@@ -135,13 +136,23 @@ func (t *dispatcher) getCmdArgsFromEnv() (string, *CmdArgs, error) {
 		return "", nil, fmt.Errorf("error reading from stdin: %v", err)
 	}
 
+	var useTap bool
+	if usesTapDevice == "" {
+		useTap = false
+	} else {
+		useTap, err = strconv.ParseBool(usesTapDevice)
+		if err != nil {
+			return "", nil, fmt.Errorf("CNI_USE_TAP should only contain 'true' or 'false'")
+		}
+	}
+
 	cmdArgs := &CmdArgs{
 		ContainerID:   contID,
 		Netns:         netns,
 		IfName:        ifName,
 		Args:          args,
 		Path:          path,
-		UsesTapDevice: usesTapDevice,
+		UsesTapDevice: useTap,
 		StdinData:     stdinData,
 	}
 	return cmd, cmdArgs, nil

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -94,6 +94,7 @@ func (r *Result) String() string {
 type IPConfig struct {
 	IP      net.IPNet
 	Gateway net.IP
+	Iface   string
 	Routes  []Route
 }
 
@@ -132,6 +133,7 @@ type ipConfig struct {
 	IP      IPNet   `json:"ip"`
 	Gateway net.IP  `json:"gateway,omitempty"`
 	Routes  []Route `json:"routes,omitempty"`
+	Iface   string  `json:"iface,omitempty"`
 }
 
 type route struct {
@@ -144,6 +146,7 @@ func (c *IPConfig) MarshalJSON() ([]byte, error) {
 		IP:      IPNet(c.IP),
 		Gateway: c.Gateway,
 		Routes:  c.Routes,
+		Iface:   c.Iface,
 	}
 
 	return json.Marshal(ipc)
@@ -158,6 +161,7 @@ func (c *IPConfig) UnmarshalJSON(data []byte) error {
 	c.IP = net.IPNet(ipc.IP)
 	c.Gateway = ipc.Gateway
 	c.Routes = ipc.Routes
+	c.Iface = ipc.Iface
 	return nil
 }
 

--- a/plugins/main/ptp/ptp.go
+++ b/plugins/main/ptp/ptp.go
@@ -160,6 +160,54 @@ func setupHostVeth(vethName string, ipConf *types.IPConfig) error {
 	return nil
 }
 
+// setupTapDevice creates persistent tap device
+// and returns a newly created netlink.Link structure
+func setupTapDevice(podID string, mtu int, pr *types.Result) error {
+	// network device names are limited to 16 characters
+	// the suffix %d will be replaced by the kernel with a suitable number
+	ifName := fmt.Sprintf("rkt-%s-tap%d", podID[0:4], 0)
+	la := netlink.NewLinkAttrs()
+	la.Name = ifName
+	la.MTU = mtu
+	mode := netlink.TUNTAP_MODE_TAP
+	flags := netlink.TUNTAP_NO_PI | netlink.TUNTAP_VNET_HDR
+	tunDesc := &netlink.Tuntap{la, mode, flags}
+	if err := netlink.LinkAdd(tunDesc); err != nil {
+		return fmt.Errorf("%v", err)
+	}
+
+	link, err := netlink.LinkByName(tunDesc.Name)
+	if err != nil {
+		return fmt.Errorf("cannot find link %v %v", tunDesc.Name, err)
+	}
+
+	if err := netlink.LinkSetUp(link); err != nil {
+		return fmt.Errorf("cannot set link up %q", ifName)
+	}
+
+	ipn := &net.IPNet{
+		IP:   pr.IP4.Gateway,
+		Mask: net.CIDRMask(32, 32),
+	}
+	addr := &netlink.Addr{IPNet: ipn, Label: ""}
+	if err = netlink.AddrAdd(link, addr); err != nil {
+		return fmt.Errorf("failed to add IP addr (%#v) to tap: %v", ipn, err)
+	}
+
+	ipn = &net.IPNet{
+		IP:   pr.IP4.IP.IP,
+		Mask: net.CIDRMask(32, 32),
+	}
+	// dst happens to be the same as IP/net of host veth
+	if err = ip.AddHostRoute(ipn, nil, link); err != nil && !os.IsExist(err) {
+		return fmt.Errorf("failed to add route on host: %v", err)
+	}
+
+	pr.IP4.Iface = link.Attrs().Name
+
+	return nil
+}
+
 func cmdAdd(args *skel.CmdArgs) error {
 	conf := NetConf{}
 	if err := json.Unmarshal(args.StdinData, &conf); err != nil {
@@ -179,13 +227,23 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return errors.New("IPAM plugin returned missing IPv4 config")
 	}
 
-	hostVethName, err := setupContainerVeth(args.Netns, args.IfName, conf.MTU, result)
-	if err != nil {
-		return err
-	}
+	if args.UsesTapDevice == "" {
+		// veth pair
+		// regular network configuration for containers
+		hostVethName, err := setupContainerVeth(args.Netns, args.IfName, conf.MTU, result)
+		if err != nil {
+			return err
+		}
 
-	if err = setupHostVeth(hostVethName, result.IP4); err != nil {
-		return err
+		if err = setupHostVeth(hostVethName, result.IP4); err != nil {
+			return err
+		}
+	} else {
+		// tap device
+		// for vm based containers
+		if err := setupTapDevice(args.ContainerID, conf.MTU, result); err != nil {
+			return err
+		}
 	}
 
 	if conf.IPMasq {

--- a/plugins/main/ptp/ptp.go
+++ b/plugins/main/ptp/ptp.go
@@ -183,7 +183,7 @@ func setupTapDevice(mtu int, pr *types.Result) error {
 		IP:   pr.IP4.IP.IP,
 		Mask: net.CIDRMask(32, 32),
 	}
-	// dst happens to be the same as IP/net of host veth
+
 	if err = ip.AddHostRoute(ipn, nil, link); err != nil && !os.IsExist(err) {
 		return fmt.Errorf("failed to add route on host: %v", err)
 	}
@@ -253,24 +253,32 @@ func cmdDel(args *skel.CmdArgs) error {
 		return err
 	}
 
-	if args.Netns == "" {
-		return nil
-	}
-
 	var ipn *net.IPNet
-	err := ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
+	if !args.UsesTapDevice {
+		if args.Netns == "" {
+			return nil
+		}
+
+		err := ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
+			var err error
+			ipn, err = ip.DelLinkByNameAddr(args.IfName, netlink.FAMILY_V4)
+			return err
+		})
+		if err != nil {
+			return err
+		}
+	} else {
 		var err error
 		ipn, err = ip.DelLinkByNameAddr(args.IfName, netlink.FAMILY_V4)
-		return err
-	})
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
 	}
 
 	if conf.IPMasq {
 		chain := utils.FormatChainName(conf.Name, args.ContainerID)
 		comment := utils.FormatComment(conf.Name, args.ContainerID)
-		if err = ip.TeardownIPMasq(ipn, chain, comment); err != nil {
+		if err := ip.TeardownIPMasq(ipn, chain, comment); err != nil {
 			return err
 		}
 	}

--- a/plugins/main/ptp/ptp_test.go
+++ b/plugins/main/ptp/ptp_test.go
@@ -110,4 +110,81 @@ var _ = Describe("ptp Operations", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 	})
+
+	It("configures and deconfigures a ptp link with ADD/DEL using TAP device", func() {
+		// Used only to fill CNI_IFNAME, not actually used in this test
+		const IFNAME = "tap"
+
+		const TAP_PREFIX = "tap"
+
+		conf := `{
+    "name": "mynet",
+    "type": "ptp",
+    "ipMasq": false,
+    "mtu": 5000,
+    "ipam": {
+        "type": "host-local",
+        "subnet": "10.1.2.0/24"
+    }
+}`
+
+		targetNs, err := ns.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+		defer targetNs.Close()
+
+		args := &skel.CmdArgs{
+			ContainerID:   "dummy",
+			Netns:         targetNs.Path(),
+			IfName:        IFNAME,
+			StdinData:     []byte(conf),
+			UsesTapDevice: true,
+		}
+
+		// Execute the plugin with the ADD command, creating the TAP device in the original namespace
+		err = originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			_, err := testutils.CmdAddWithResult(targetNs.Path(), IFNAME, func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Get the second link (lo being first one)
+			link, err := netlink.LinkByIndex(2)
+			// Tap devices are created with a tap prefix and a random id
+			Expect(link.Attrs().Name[:3]).To(Equal(TAP_PREFIX))
+			Expect(err).NotTo(HaveOccurred())
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Call the plugins with the DEL command, deleting the TAP device
+		err = originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			link, err := netlink.LinkByIndex(2)
+			Expect(err).NotTo(HaveOccurred())
+			args.IfName = link.Attrs().Name
+			Expect(args.IfName[:3]).To(Equal(TAP_PREFIX))
+
+			err = testutils.CmdDelWithResult(targetNs.Path(), args.IfName, func() error {
+				return cmdDel(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Make sure TAP ptp link has been deleted
+		err = originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			// There should be no more interfaces/devices other than lo
+			link, err := netlink.LinkByIndex(2)
+			Expect(err).To(HaveOccurred())
+			Expect(link).To(BeNil())
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
 })


### PR DESCRIPTION
It's prototype code to move forward with discussion at https://github.com/containernetworking/cni/issues/251 

If non-empty CNI_VIRT is passed in env variable then instead of creating veth pair there's created tap interface and passed via iface field. Most of code changes here is related to updating netlink version, also in vendor clone I have to add additional codepath for specifying custom flags for tap creation.

Related PR: https://github.com/vishvananda/netlink/pull/154
