### PR TITLE
Reconfigure bridge IP address

### DIFF
--- a/Documentation/bridge.md
+++ b/Documentation/bridge.md
@@ -18,6 +18,7 @@ If the bridge is missing, the plugin will create one on first use and, if gatewa
 	"type": "bridge",
 	"bridge": "mynet0",
 	"isDefaultGateway": true,
+	"forceAddress": false,
 	"ipMasq": true,
 	"hairpinMode": true,
 	"ipam": {
@@ -34,6 +35,7 @@ If the bridge is missing, the plugin will create one on first use and, if gatewa
 * `bridge` (string, optional): name of the bridge to use/create. Defaults to "cni0".
 * `isGateway` (boolean, optional): assign an IP address to the bridge. Defaults to false.
 * `isDefaultGateway` (boolean, optional): Sets isGateway to true and makes the assigned IP the default route. Defaults to false.
+* `forceAddress` (boolean, optional): Indicates if a new IP address should be set if the previous value has been changed. Defaults to false.
 * `ipMasq` (boolean, optional): set up IP Masquerade on the host for traffic originating from this network and destined outside of it. Defaults to false.
 * `mtu` (integer, optional): explicitly set MTU to the specified value. Defaults to the value chosen by the kernel.
 * `hairpinMode` (boolean, optional): set hairpin mode for interfaces on the bridge. Defaults to false.

--- a/libcni/conf.go
+++ b/libcni/conf.go
@@ -83,3 +83,28 @@ func LoadConf(dir, name string) (*NetworkConfig, error) {
 	}
 	return nil, fmt.Errorf(`no net configuration with name "%s" in %s`, name, dir)
 }
+
+func InjectConf(original *NetworkConfig, key string, newValue interface{}) (*NetworkConfig, error) {
+	config := make(map[string]interface{})
+	err := json.Unmarshal(original.Bytes, &config)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal existing network bytes: %s", err)
+	}
+
+	if key == "" {
+		return nil, fmt.Errorf("key value can not be empty")
+	}
+
+	if newValue == nil {
+		return nil, fmt.Errorf("newValue must be specified")
+	}
+
+	config[key] = newValue
+
+	newBytes, err := json.Marshal(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return ConfFromBytes(newBytes)
+}

--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -236,4 +236,74 @@ var _ = Describe("bridge Operations", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 	})
+
+	It("ensure bridge address", func() {
+
+		const IFNAME = "bridge0"
+		const EXPECTED_IP = "10.0.0.0/8"
+		const CHANGED_EXPECTED_IP = "10.1.2.3/16"
+
+		conf := &NetConf{
+			NetConf: types.NetConf{
+				Name: "testConfig",
+				Type: "bridge",
+			},
+			BrName: IFNAME,
+			IsGW:   true,
+			IPMasq: false,
+			MTU:    5000,
+		}
+
+		gwnFirst := &net.IPNet{
+			IP:   net.IPv4(10, 0, 0, 0),
+			Mask: net.CIDRMask(8, 32),
+		}
+
+		gwnSecond := &net.IPNet{
+			IP:   net.IPv4(10, 1, 2, 3),
+			Mask: net.CIDRMask(16, 32),
+		}
+
+		err := originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			bridge, err := setupBridge(conf)
+			Expect(err).NotTo(HaveOccurred())
+			// Check if ForceAddress has default value
+			Expect(conf.ForceAddress).To(Equal(false))
+
+			err = ensureBridgeAddr(bridge, gwnFirst, conf.ForceAddress)
+			Expect(err).NotTo(HaveOccurred())
+
+			//Check if IP address is set correctly
+			addrs, err := netlink.AddrList(bridge, syscall.AF_INET)
+			Expect(len(addrs)).To(Equal(1))
+			addr := addrs[0].IPNet.String()
+			Expect(addr).To(Equal(EXPECTED_IP))
+
+			//The bridge IP address has been changed. Error expected when ForceAddress is set to false.
+			err = ensureBridgeAddr(bridge, gwnSecond, false)
+			Expect(err).To(HaveOccurred())
+
+			//The IP address should stay the same.
+			addrs, err = netlink.AddrList(bridge, syscall.AF_INET)
+			Expect(len(addrs)).To(Equal(1))
+			addr = addrs[0].IPNet.String()
+			Expect(addr).To(Equal(EXPECTED_IP))
+
+			//Reconfigure IP when ForceAddress is set to true and IP address has been changed.
+			err = ensureBridgeAddr(bridge, gwnSecond, true)
+			Expect(err).NotTo(HaveOccurred())
+
+			//Retrieve the IP address after reconfiguration
+			addrs, err = netlink.AddrList(bridge, syscall.AF_INET)
+			Expect(len(addrs)).To(Equal(1))
+			addr = addrs[0].IPNet.String()
+			Expect(addr).To(Equal(CHANGED_EXPECTED_IP))
+
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 })


### PR DESCRIPTION
Instead of throwing error it is better reconfigure the bridge IP address.
Currently the CNI plugin is used in kubernetes and after hyperkube restart cni0 bridge retains its old value. This PR fix the issue. 