### PR TITLE
Fixed the check for network namespace path.

### DIFF
--- a/pkg/ns/ns.go
+++ b/pkg/ns/ns.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path"
 	"runtime"
-	"strings"
 	"sync"
 	"syscall"
 
@@ -101,19 +100,7 @@ func IsNSorErr(nspath string) error {
 	}
 
 	switch stat.Type {
-	case PROCFS_MAGIC:
-		// Kernel < 3.19
-
-		validPathContent := "ns/"
-		validName := strings.Contains(nspath, validPathContent)
-		if !validName {
-			return NSPathNotNSErr{msg: fmt.Sprintf("path %q doesn't contain %q", nspath, validPathContent)}
-		}
-
-		return nil
-	case NSFS_MAGIC:
-		// Kernel >= 3.19
-
+	case PROCFS_MAGIC, NSFS_MAGIC:
 		return nil
 	default:
 		return NSPathNotNSErr{msg: fmt.Sprintf("unknown FS magic on %q: %x", nspath, stat.Type)}


### PR DESCRIPTION
The expectation on older kernels (< 3.19) was to have the network
namespace always be a directory. This is not true if the network
namespace is bind mounted to a file, and will make the plugin fail
erroneously in such cases.

I have tried this with Mesos on a CentOS 7 cluster, running 3.10 kernel and it works fine. Moreover, have also tried it on Ubuntu 14.04 which has 3.13 kernel and works fine on that as well. 

This should fix #288 