### PR TITLE
pkg/ip: Ensure that SetupVeth returns correct hostVeth

### DIFF
--- a/pkg/ip/link.go
+++ b/pkg/ip/link.go
@@ -117,7 +117,7 @@ func SetupVeth(contVethName string, mtu int, hostNS ns.NetNS) (hostVeth, contVet
 	}
 
 	err = hostNS.Do(func(_ ns.NetNS) error {
-		hostVeth, err := netlink.LinkByName(hostVethName)
+		hostVeth, err = netlink.LinkByName(hostVethName)
 		if err != nil {
 			return fmt.Errorf("failed to lookup %q in %q: %v", hostVethName, hostNS.Path(), err)
 		}


### PR DESCRIPTION
The veth is moved from the container NS to the host NS.
This is handled by the code that sets the link to UP but the wrong
hostVeth is returned to the calling code.