### PR TITLE
Plugins validate cniVersion of NetConf

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Start out by creating a netconf file to describe a network:
 $ mkdir -p /etc/cni/net.d
 $ cat >/etc/cni/net.d/10-mynet.conf <<EOF
 {
+	"cniVersion": "0.2.0",
 	"name": "mynet",
 	"type": "bridge",
 	"bridge": "cni0",
@@ -85,6 +86,7 @@ $ cat >/etc/cni/net.d/10-mynet.conf <<EOF
 EOF
 $ cat >/etc/cni/net.d/99-loopback.conf <<EOF
 {
+	"cniVersion": "0.2.0",
 	"type": "loopback"
 }
 EOF

--- a/libcni/api_test.go
+++ b/libcni/api_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Invoking the plugin", func() {
 		Expect(debug.WriteDebug(debugFilePath)).To(Succeed())
 
 		cniBinPath = filepath.Dir(pathToPlugin)
-		pluginConfig = `{ "type": "noop", "some-key": "some-value" }`
+		pluginConfig = `{ "type": "noop", "some-key": "some-value", "cniVersion": "0.2.0" }`
 		cniConfig = libcni.CNIConfig{Path: []string{cniBinPath}}
 		netConfig = &libcni.NetworkConfig{
 			Network: &types.NetConf{

--- a/pkg/invoke/exec.go
+++ b/pkg/invoke/exec.go
@@ -16,6 +16,7 @@ package invoke
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/containernetworking/cni/pkg/types"
@@ -77,7 +78,8 @@ func (e *PluginExec) GetVersionInfo(pluginPath string) (version.PluginInfo, erro
 		IfName: "dummy",
 		Path:   "dummy",
 	}
-	stdoutBytes, err := e.RawExec.ExecPlugin(pluginPath, nil, args.AsEnv())
+	stdin := []byte(fmt.Sprintf(`{"cniVersion":%q}`, version.Current()))
+	stdoutBytes, err := e.RawExec.ExecPlugin(pluginPath, stdin, args.AsEnv())
 	if err != nil {
 		if err.Error() == "unknown CNI_COMMAND: VERSION" {
 			return version.PluginSupports("0.1.0"), nil

--- a/pkg/invoke/raw_exec_test.go
+++ b/pkg/invoke/raw_exec_test.go
@@ -58,7 +58,7 @@ var _ = Describe("RawExec", func() {
 			"CNI_PATH=/some/bin/path",
 			"CNI_IFNAME=some-eth0",
 		}
-		stdin = []byte(`{"some":"stdin-json"}`)
+		stdin = []byte(`{"some":"stdin-json", "cniVersion": "0.2.0"}`)
 		execer = &invoke.RawExec{}
 	})
 

--- a/pkg/skel/skel_test.go
+++ b/pkg/skel/skel_test.go
@@ -172,7 +172,7 @@ var _ = Describe("dispatching to the correct callback", func() {
 
 				It("immediately returns a useful error", func() {
 					err := dispatch.pluginMain(cmdAdd.Func, cmdDel.Func, versionInfo)
-					Expect(err.Code).To(Equal(uint(1))) // see https://github.com/containernetworking/cni/blob/master/SPEC.md#well-known-error-codes
+					Expect(err.Code).To(Equal(types.ErrIncompatibleCNIVersion)) // see https://github.com/containernetworking/cni/blob/master/SPEC.md#well-known-error-codes
 					Expect(err.Msg).To(Equal("incompatible CNI versions"))
 					Expect(err.Details).To(Equal(`config is "0.1.0", plugin supports ["4.3.2"]`))
 				})

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -112,6 +112,14 @@ type Route struct {
 	GW  net.IP
 }
 
+// Well known error codes
+// see https://github.com/containernetworking/cni/blob/master/SPEC.md#well-known-error-codes
+const (
+	ErrUnknown                uint = iota // 0
+	ErrIncompatibleCNIVersion             // 1
+	ErrUnsupportedField                   // 2
+)
+
 type Error struct {
 	Code    uint   `json:"code"`
 	Msg     string `json:"msg"`

--- a/pkg/version/conf.go
+++ b/pkg/version/conf.go
@@ -1,0 +1,37 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ConfigDecoder can decode the CNI version available in network config data
+type ConfigDecoder struct{}
+
+func (*ConfigDecoder) Decode(jsonBytes []byte) (string, error) {
+	var conf struct {
+		CNIVersion string `json:"cniVersion"`
+	}
+	err := json.Unmarshal(jsonBytes, &conf)
+	if err != nil {
+		return "", fmt.Errorf("decoding version from network config: %s", err)
+	}
+	if conf.CNIVersion == "" {
+		return "0.1.0", nil
+	}
+	return conf.CNIVersion, nil
+}

--- a/pkg/version/conf_test.go
+++ b/pkg/version/conf_test.go
@@ -1,0 +1,69 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version_test
+
+import (
+	"github.com/containernetworking/cni/pkg/version"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Decoding the version of network config", func() {
+	var (
+		decoder     *version.ConfigDecoder
+		configBytes []byte
+	)
+
+	BeforeEach(func() {
+		decoder = &version.ConfigDecoder{}
+		configBytes = []byte(`{ "cniVersion": "4.3.2" }`)
+	})
+
+	Context("when the version is explict", func() {
+		It("returns the version", func() {
+			version, err := decoder.Decode(configBytes)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(version).To(Equal("4.3.2"))
+		})
+	})
+
+	Context("when the version is not present in the config", func() {
+		BeforeEach(func() {
+			configBytes = []byte(`{ "not-a-version-field": "foo" }`)
+		})
+
+		It("assumes the config is version 0.1.0", func() {
+			version, err := decoder.Decode(configBytes)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(version).To(Equal("0.1.0"))
+		})
+	})
+
+	Context("when the config data is malformed", func() {
+		BeforeEach(func() {
+			configBytes = []byte(`{{{`)
+		})
+
+		It("returns a useful error", func() {
+			_, err := decoder.Decode(configBytes)
+			Expect(err).To(MatchError(HavePrefix(
+				"decoding version from network config: invalid character",
+			)))
+		})
+	})
+})

--- a/pkg/version/plugin.go
+++ b/pkg/version/plugin.go
@@ -59,7 +59,7 @@ func PluginSupports(supportedVersions ...string) PluginInfo {
 // PluginDecoder can decode the response returned by a plugin's VERSION command
 type PluginDecoder struct{}
 
-func (_ *PluginDecoder) Decode(jsonBytes []byte) (PluginInfo, error) {
+func (*PluginDecoder) Decode(jsonBytes []byte) (PluginInfo, error) {
 	var info pluginInfo
 	err := json.Unmarshal(jsonBytes, &info)
 	if err != nil {

--- a/pkg/version/plugin.go
+++ b/pkg/version/plugin.go
@@ -56,6 +56,7 @@ func PluginSupports(supportedVersions ...string) PluginInfo {
 	}
 }
 
+// PluginDecoder can decode the response returned by a plugin's VERSION command
 type PluginDecoder struct{}
 
 func (_ *PluginDecoder) Decode(jsonBytes []byte) (PluginInfo, error) {

--- a/pkg/version/reconcile.go
+++ b/pkg/version/reconcile.go
@@ -1,0 +1,47 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import "fmt"
+
+type ErrorIncompatible struct {
+	Config string
+	Plugin []string
+}
+
+func (e *ErrorIncompatible) Details() string {
+	return fmt.Sprintf("config is %q, plugin supports %q", e.Config, e.Plugin)
+}
+
+func (e *ErrorIncompatible) Error() string {
+	return fmt.Sprintf("incompatible CNI versions: %s", e.Details())
+}
+
+type Reconciler struct{}
+
+func (*Reconciler) Check(configVersion string, pluginInfo PluginInfo) *ErrorIncompatible {
+	pluginVersions := pluginInfo.SupportedVersions()
+
+	for _, pluginVersion := range pluginVersions {
+		if configVersion == pluginVersion {
+			return nil
+		}
+	}
+
+	return &ErrorIncompatible{
+		Config: configVersion,
+		Plugin: pluginVersions,
+	}
+}

--- a/pkg/version/reconcile_test.go
+++ b/pkg/version/reconcile_test.go
@@ -1,0 +1,51 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version_test
+
+import (
+	"github.com/containernetworking/cni/pkg/version"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Reconcile versions of net config with versions supported by plugins", func() {
+	var (
+		reconciler *version.Reconciler
+		pluginInfo version.PluginInfo
+	)
+
+	BeforeEach(func() {
+		reconciler = &version.Reconciler{}
+		pluginInfo = version.PluginSupports("1.2.3", "4.3.2")
+	})
+
+	It("succeeds if the config version is supported by the plugin", func() {
+		err := reconciler.Check("4.3.2", pluginInfo)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("when the config version is not supported by the plugin", func() {
+		It("returns a helpful error", func() {
+			err := reconciler.Check("0.1.0", pluginInfo)
+
+			Expect(err).To(Equal(&version.ErrorIncompatible{
+				Config: "0.1.0",
+				Plugin: []string{"1.2.3", "4.3.2"},
+			}))
+
+			Expect(err.Error()).To(Equal(`incompatible CNI versions: config is "0.1.0", plugin supports ["1.2.3" "4.3.2"]`))
+		})
+	})
+})

--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -135,7 +135,6 @@ var _ = Describe("bridge Operations", func() {
     "isDefaultGateway": true,
     "ipMasq": false,
     "ipam": {
-        "cniVersion": "0.2.0",
         "type": "host-local",
         "subnet": "%s"
     }

--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -51,8 +51,9 @@ var _ = Describe("bridge Operations", func() {
 
 		conf := &NetConf{
 			NetConf: types.NetConf{
-				Name: "testConfig",
-				Type: "bridge",
+				CNIVersion: "0.2.0",
+				Name:       "testConfig",
+				Type:       "bridge",
 			},
 			BrName: IFNAME,
 			IsGW:   false,
@@ -95,8 +96,9 @@ var _ = Describe("bridge Operations", func() {
 
 			conf := &NetConf{
 				NetConf: types.NetConf{
-					Name: "testConfig",
-					Type: "bridge",
+					CNIVersion: "0.2.0",
+					Name:       "testConfig",
+					Type:       "bridge",
 				},
 				BrName: IFNAME,
 				IsGW:   false,
@@ -126,12 +128,14 @@ var _ = Describe("bridge Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		conf := fmt.Sprintf(`{
+    "cniVersion": "0.2.0",
     "name": "mynet",
     "type": "bridge",
     "bridge": "%s",
     "isDefaultGateway": true,
     "ipMasq": false,
     "ipam": {
+        "cniVersion": "0.2.0",
         "type": "host-local",
         "subnet": "%s"
     }
@@ -253,15 +257,15 @@ var _ = Describe("bridge Operations", func() {
 	})
 
 	It("ensure bridge address", func() {
-
 		const IFNAME = "bridge0"
 		const EXPECTED_IP = "10.0.0.0/8"
 		const CHANGED_EXPECTED_IP = "10.1.2.3/16"
 
 		conf := &NetConf{
 			NetConf: types.NetConf{
-				Name: "testConfig",
-				Type: "bridge",
+				CNIVersion: "0.2.0",
+				Name:       "testConfig",
+				Type:       "bridge",
 			},
 			BrName: IFNAME,
 			IsGW:   true,
@@ -320,5 +324,4 @@ var _ = Describe("bridge Operations", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 	})
-
 })

--- a/plugins/main/ipvlan/ipvlan_test.go
+++ b/plugins/main/ipvlan/ipvlan_test.go
@@ -63,8 +63,9 @@ var _ = Describe("ipvlan Operations", func() {
 	It("creates an ipvlan link in a non-default namespace", func() {
 		conf := &NetConf{
 			NetConf: types.NetConf{
-				Name: "testConfig",
-				Type: "ipvlan",
+				CNIVersion: "0.2.0",
+				Name:       "testConfig",
+				Type:       "ipvlan",
 			},
 			Master: MASTER_NAME,
 			Mode:   "l2",
@@ -101,10 +102,12 @@ var _ = Describe("ipvlan Operations", func() {
 		const IFNAME = "ipvl0"
 
 		conf := fmt.Sprintf(`{
+    "cniVersion": "0.2.0",
     "name": "mynet",
     "type": "ipvlan",
     "master": "%s",
     "ipam": {
+        "cniVersion": "0.2.0",
         "type": "host-local",
         "subnet": "10.1.2.0/24"
     }

--- a/plugins/main/ipvlan/ipvlan_test.go
+++ b/plugins/main/ipvlan/ipvlan_test.go
@@ -107,7 +107,6 @@ var _ = Describe("ipvlan Operations", func() {
     "type": "ipvlan",
     "master": "%s",
     "ipam": {
-        "cniVersion": "0.2.0",
         "type": "host-local",
         "subnet": "10.1.2.0/24"
     }

--- a/plugins/main/loopback/loopback_test.go
+++ b/plugins/main/loopback/loopback_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Loopback", func() {
 			fmt.Sprintf("CNI_ARGS=%s", "none"),
 			fmt.Sprintf("CNI_PATH=%s", "/some/test/path"),
 		}
-		command.Stdin = strings.NewReader("this doesn't matter")
+		command.Stdin = strings.NewReader(`{ "cniVersion": "0.1.0" }`)
 	})
 
 	AfterEach(func() {

--- a/plugins/main/macvlan/macvlan_test.go
+++ b/plugins/main/macvlan/macvlan_test.go
@@ -64,8 +64,9 @@ var _ = Describe("macvlan Operations", func() {
 	It("creates an macvlan link in a non-default namespace", func() {
 		conf := &NetConf{
 			NetConf: types.NetConf{
-				Name: "testConfig",
-				Type: "macvlan",
+				CNIVersion: "0.2.0",
+				Name:       "testConfig",
+				Type:       "macvlan",
 			},
 			Master: MASTER_NAME,
 			Mode:   "bridge",
@@ -101,10 +102,12 @@ var _ = Describe("macvlan Operations", func() {
 		const IFNAME = "macvl0"
 
 		conf := fmt.Sprintf(`{
+    "cniVersion": "0.2.0",
     "name": "mynet",
     "type": "macvlan",
     "master": "%s",
     "ipam": {
+        "cniVersion": "0.2.0",
         "type": "host-local",
         "subnet": "10.1.2.0/24"
     }

--- a/plugins/main/macvlan/macvlan_test.go
+++ b/plugins/main/macvlan/macvlan_test.go
@@ -107,7 +107,6 @@ var _ = Describe("macvlan Operations", func() {
     "type": "macvlan",
     "master": "%s",
     "ipam": {
-        "cniVersion": "0.2.0",
         "type": "host-local",
         "subnet": "10.1.2.0/24"
     }

--- a/plugins/main/ptp/ptp_test.go
+++ b/plugins/main/ptp/ptp_test.go
@@ -43,11 +43,13 @@ var _ = Describe("ptp Operations", func() {
 		const IFNAME = "ptp0"
 
 		conf := `{
+    "cniVersion": "0.2.0",
     "name": "mynet",
     "type": "ptp",
     "ipMasq": true,
     "mtu": 5000,
     "ipam": {
+        "cniVersion": "0.2.0",
         "type": "host-local",
         "subnet": "10.1.2.0/24"
     }

--- a/plugins/main/ptp/ptp_test.go
+++ b/plugins/main/ptp/ptp_test.go
@@ -49,7 +49,6 @@ var _ = Describe("ptp Operations", func() {
     "ipMasq": true,
     "mtu": 5000,
     "ipam": {
-        "cniVersion": "0.2.0",
         "type": "host-local",
         "subnet": "10.1.2.0/24"
     }

--- a/plugins/test/noop/noop_test.go
+++ b/plugins/test/noop/noop_test.go
@@ -60,14 +60,14 @@ var _ = Describe("No-op plugin", func() {
 			"CNI_IFNAME=some-eth0",
 			"CNI_PATH=/some/bin/path",
 		}
-		cmd.Stdin = strings.NewReader(`{"some":"stdin-json"}`)
+		cmd.Stdin = strings.NewReader(`{"some":"stdin-json", "cniVersion": "0.2.0"}`)
 		expectedCmdArgs = skel.CmdArgs{
 			ContainerID: "some-container-id",
 			Netns:       "/some/netns/path",
 			IfName:      "some-eth0",
 			Args:        "DEBUG=" + debugFileName,
 			Path:        "/some/bin/path",
-			StdinData:   []byte(`{"some":"stdin-json"}`),
+			StdinData:   []byte(`{"some":"stdin-json", "cniVersion": "0.2.0"}`),
 		}
 	})
 


### PR DESCRIPTION
Another step in the [versioning effort](https://github.com/containernetworking/cni/issues/266).

# Updated

Building on #287, this PR puts version checks into the `skel` package, before the `cmdAdd` and `cmdDel` callbacks.

This way, the callbacks will only get called if stdin data (a.k.a. ["network configuration"](https://github.com/containernetworking/cni/blob/master/SPEC.md#network-configuration) a.k.a. `NetConf`) contains a `cniVersion` field that matches one of the `supportedVersions` that the plugin self-declared.

Importantly, legacy config that is missing the `cniVersion` field is assumed to be version 0.1.0 (thanks @dcbw), and will continue to work even with newer plugins build with this version of the library.