### PR TITLE
3rd party plugins belong in their own repos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,3 +109,17 @@ The first line is the subject and should be no longer than 70 characters, the
 second line is always blank, and other lines should be wrapped at 80 characters.
 This allows the message to be easier to read on GitHub as well as in various
 git tools.
+
+## 3rd party plugins
+So you've built a CNI plugin.  Where should it live?
+
+Short answer: We'd be happy to link to it from our [list of 3rd party plugins](README.md#3rd-party-plugins).
+But we'd rather you kept the code in your own repo.
+
+Long answer: An advantage of the CNI model is that independent plugins can be
+built, distributed and used without any code changes to this repository.  While
+some widely used plugins (and a few less-popular legacy ones) live in this repo,
+we're reluctant to add more.
+
+If you have a good reason why the CNI maintainers should take custody of your
+plugin, please open an issue or PR.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To avoid duplication, we think it is prudent to define a common interface betwee
 - [Cloud Foundry - a platform for cloud applications](https://github.com/cloudfoundry-incubator/netman-release)
 - [Mesos - a distributed systems kernel](https://github.com/apache/mesos/blob/master/docs/cni.md)
 
-### 3rd Party Network plugins
+### 3rd party plugins
 - [Project Calico - a layer 3 virtual network](https://github.com/projectcalico/calico-cni)
 - [Weave - a multi-host Docker network](https://github.com/weaveworks/weave)
 - [Contiv Networking - policy networking for various use cases](https://github.com/contiv/netplugin)


### PR DESCRIPTION
Motivated by https://github.com/containernetworking/cni/issues/300#issuecomment-251032278 and https://github.com/containernetworking/cni/pull/259#issuecomment-234377787

@containernetworking/cni-maintainers : thoughts?