### PR TITLE
Adding MAC address to the Result structure

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -69,6 +69,7 @@ type NetConf struct {
 
 // Result is what gets returned from the plugin (via stdout) to the caller
 type Result struct {
+	MAC string    `json:"mac,omitempty"`
 	IP4 *IPConfig `json:"ip4,omitempty"`
 	IP6 *IPConfig `json:"ip6,omitempty"`
 	DNS DNS       `json:"dns,omitempty"`


### PR DESCRIPTION
**Background Information:**

The json representation of the `Result` struct is the interface for both:
-  invoking application and the CNI network plugin
-  CNI network plugin and the CNI IPAM plugin.

Flow diagram: 
<pre>
<b>Invoking application</b>
        ^^^^^
        |||||
        |||||
json of {Result struct}
        |||||
        |||||
<b>CNI Network plugin</b>
        ^^^^^
        |||||
        |||||
json of {Result struct}
        |||||
        |||||
<b>CNI IPAM or other plugin</b>
</pre>

**Problem statement:**
Some of the CNI Network plugins (like bridge) are responsible for creating veth links and placing them in the appropriate name spaces, etc. 
- Currently there is no way for the CNI network plugin to communicate to the invoking application as to what MAC address has been assigned to the network interface of the container . 
- Also there is no way for either an IPAM plugin or some other plugin to inform the network plugin to specify what MAC address has to be assigned to the network interface inside the container. [This use case arises in our custom application/CNI plugins where we want to be able to override the random MAC address of the veth interface created for the container with our pre determined one.] 



**Proposed solution:**
The same `Result` structure is used by both IPAM and network plugins. Adding an additional field to communicate the MAC address information. It's left to the custom plugins to either implement their own MACAM (MAC Address Management) plugin or use IPAM plugin itself to communicate both the IP/MAC information. Using `string` instead of `net.HardwareAddr` for MAC field makes sense since the invoking apps could be using programming languages other than Go.

Comments are welcome!