### PR TITLE
plugins/noop: return a helpful message for test authors

### DIFF
--- a/plugins/test/noop/debug/debug.go
+++ b/plugins/test/noop/debug/debug.go
@@ -22,6 +22,8 @@ import (
 	"github.com/containernetworking/cni/pkg/skel"
 )
 
+const EmptyReportResultMessage = "set debug.ReportResult and call debug.WriteDebug() before calling this plugin"
+
 // Debug is used to control and record the behavior of the noop plugin
 type Debug struct {
 	// Report* fields allow the test to control the behavior of the no-op plugin

--- a/plugins/test/noop/main.go
+++ b/plugins/test/noop/main.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/version"
-	"github.com/containernetworking/cni/plugins/test/noop/debug"
+	noop_debug "github.com/containernetworking/cni/plugins/test/noop/debug"
 )
 
 // parse extra args i.e. FOO=BAR;ABC=123
@@ -60,13 +60,17 @@ func debugBehavior(args *skel.CmdArgs, command string) error {
 		return nil
 	}
 
-	debug, err := debug.ReadDebug(debugFilePath)
+	debug, err := noop_debug.ReadDebug(debugFilePath)
 	if err != nil {
 		return err
 	}
 
 	debug.CmdArgs = *args
 	debug.Command = command
+
+	if debug.ReportResult == "" {
+		debug.ReportResult = fmt.Sprintf(` { "result": %q }`, noop_debug.EmptyReportResultMessage)
+	}
 
 	err = debug.WriteDebug(debugFilePath)
 	if err != nil {
@@ -101,7 +105,7 @@ func debugGetSupportedVersions() []string {
 		panic("test setup error: missing DEBUG in CNI_ARGS")
 	}
 
-	debug, err := debug.ReadDebug(debugFilePath)
+	debug, err := noop_debug.ReadDebug(debugFilePath)
 	if err != nil {
 		panic("test setup error: unable to read debug file: " + err.Error())
 	}

--- a/plugins/test/noop/noop_test.go
+++ b/plugins/test/noop/noop_test.go
@@ -96,6 +96,26 @@ var _ = Describe("No-op plugin", func() {
 		Expect(debug.CmdArgs).To(Equal(expectedCmdArgs))
 	})
 
+	Context("when the ReportResult debug field is empty", func() {
+		BeforeEach(func() {
+			debug.ReportResult = ""
+			Expect(debug.WriteDebug(debugFileName)).To(Succeed())
+		})
+
+		It("substitutes a helpful message for the test author", func() {
+			expectedResultString := fmt.Sprintf(` { "result": %q }`, noop_debug.EmptyReportResultMessage)
+
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(session).Should(gexec.Exit(0))
+			Expect(session.Out.Contents()).To(MatchJSON(expectedResultString))
+
+			debug, err := noop_debug.ReadDebug(debugFileName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(debug.ReportResult).To(MatchJSON(expectedResultString))
+		})
+	})
+
 	Context("when the ReportError debug field is set", func() {
 		BeforeEach(func() {
 			debug.ReportError = "banana"


### PR DESCRIPTION
This makes it a little bit easier to get started writing tests using the no-op plugin.

cc: @karampok
