### PR TITLE
flannel: set forceAddress option of delegated bridge plugin to true by default

### DIFF
--- a/Documentation/flannel.md
+++ b/Documentation/flannel.md
@@ -29,6 +29,7 @@ the flannel plugin will generate another network configuration file:
 	"mtu": 1472,
 	"ipMasq": false,
 	"isGateway": true,
+	"forceAddress": true,
 	"ipam": {
 		"type": "host-local",
 		"subnet": "10.1.17.0/24"

--- a/plugins/meta/flannel/flannel.go
+++ b/plugins/meta/flannel/flannel.go
@@ -220,6 +220,9 @@ func cmdAdd(args *skel.CmdArgs) error {
 		if !hasKey(n.Delegate, "isGateway") {
 			n.Delegate["isGateway"] = true
 		}
+		if !hasKey(n.Delegate, "forceAddress") {
+			n.Delegate["forceAddress"] = true
+		}
 	}
 
 	n.Delegate["ipam"] = map[string]interface{}{


### PR DESCRIPTION
Yes, we can manually set `forceAddress` to true in flannel cni network config. But I think it's better to make this option be true by default because lots of people may not aware of this option.