### PR TITLE
noop plugin: support multiple CNI_ARGS

### DIFF
--- a/plugins/test/noop/noop_test.go
+++ b/plugins/test/noop/noop_test.go
@@ -15,6 +15,7 @@
 package main_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -52,10 +53,12 @@ var _ = Describe("No-op plugin", func() {
 		Expect(debug.WriteDebug(debugFileName)).To(Succeed())
 
 		cmd = exec.Command(pathToPlugin)
+
+		args := fmt.Sprintf("DEBUG=%s;FOO=BAR", debugFileName)
 		cmd.Env = []string{
 			"CNI_COMMAND=ADD",
 			"CNI_CONTAINERID=some-container-id",
-			"CNI_ARGS=DEBUG=" + debugFileName,
+			"CNI_ARGS=" + args,
 			"CNI_NETNS=/some/netns/path",
 			"CNI_IFNAME=some-eth0",
 			"CNI_PATH=/some/bin/path",
@@ -65,7 +68,7 @@ var _ = Describe("No-op plugin", func() {
 			ContainerID: "some-container-id",
 			Netns:       "/some/netns/path",
 			IfName:      "some-eth0",
-			Args:        "DEBUG=" + debugFileName,
+			Args:        args,
 			Path:        "/some/bin/path",
 			StdinData:   []byte(`{"some":"stdin-json", "cniVersion": "0.2.0"}`),
 		}


### PR DESCRIPTION
The `noop` CNI plugin can be useful when testing other CNI plugins (i.e. delegating to noop plugin).
The only problem I encountered was when **CNI_ARGS** had more than one key/value pair, the noop plugin fails to load the debug file. Basically it is expecting only a single CNI_ARG pair.

This PR is just an update to noop plugin to parse the **CNI_ARGS** pairs, to allow more than just
the `DEBUG` arg.

```sh
CNI_ARGS="DEBUG=/path/to/file;FOO=BAR;ABC=123"
```

Cheers

cc: @rosenhouse 