### PR TITLE
pkg/ns README: expand on danger in ns switching in long-lived programs

### DIFF
--- a/pkg/ns/README.md
+++ b/pkg/ns/README.md
@@ -9,7 +9,7 @@ Go provides the `runtime.LockOSThread()` function to ensure a specific goroutine
 For example, you cannot rely on the `ns.Set()` namespace being the current namespace after the `Set()` call unless you do two things.  First, the goroutine calling `Set()` must have previously called `LockOSThread()`.  Second, you must ensure `runtime.UnlockOSThread()` is not called somewhere in-between.  You also cannot rely on the initial network namespace remaining the current network namespace if any other code in your program switches namespaces, unless you have already called `LockOSThread()` in that goroutine.  Note that `LockOSThread()` prevents the Go scheduler from optimally scheduling goroutines for best performance, so `LockOSThread()` should only be used in small, isolated goroutines that release the lock quickly.
 
 ### Do() The Recommended Thing
-The `ns.Do()` method provides control over network namespaces for you by implementing these strategies. All code dependent on a particular network namespace (including the root namespace) should be wrapped in the `ns.Do()` method to ensure the correct namespace is selected for the duration of your code.  For example:
+The `ns.Do()` method provides **partial** control over network namespaces for you by implementing these strategies. All code dependent on a particular network namespace (including the root namespace) should be wrapped in the `ns.Do()` method to ensure the correct namespace is selected for the duration of your code.  For example:
 
 ```go
 targetNs, err := ns.NewNS()
@@ -28,7 +28,12 @@ err = targetNs.Do(func(hostNs ns.NetNS) error {
 
 Note this requirement to wrap every network call is very onerous - any libraries you call might call out to network services such as DNS, and all such calls need to be protected after you call `ns.Do()`. The CNI plugins all exit very soon after calling `ns.Do()` which helps to minimize the problem.
 
+Also:  If the runtime spawns a new OS thread, it will inherit the network namespace of the parent thread, which may have been temporarily switched, and thus the new OS thread will be permanently "stuck in the wrong namespace".
+
+In short, **there is no safe way to change network namespaces from within a long-lived, multithreaded Go process**.  If your daemon process needs to be namespace aware, consider spawning a separate process (like a CNI plugin) for each namespace.
+
 ### Further Reading
  - https://github.com/golang/go/wiki/LockOSThread
  - http://morsmachine.dk/go-scheduler
  - https://github.com/containernetworking/cni/issues/262
+ - https://golang.org/pkg/runtime/


### PR DESCRIPTION
cc: @bboreham I realized there was another key point missing in the readme: that long-lived Go processes cannot switch namespaces safely, because even new goroutines may share threads with old goroutines.

Follow up to #330 and #262 
