### PR TITLE
travis: roll forward the versions of Go that we test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: required
 dist: trusty
 
 go:
-  - 1.5.4
-  - 1.6.2
+  - 1.6.x
+  - 1.7.x
   - tip
 
 env:
@@ -23,12 +23,6 @@ matrix:
   allow_failures:
     - go: tip
   exclude:
-    - go: 1.5.4
-      env: arm
-    - go: 1.5.4
-      env: arm64
-    - go: 1.5.4
-      env: ppc64le
     - go: tip
       env: arm
     - go: tip


### PR DESCRIPTION
- Start testing against Go 1.7.x
- No longer test against Go 1.5.x

According to the Go language [Release Policy](https://golang.org/doc/devel/release.html#policy):

> Each major Go release obsoletes and ends support for the previous one. 
> ...
> As a special case, we issue minor revisions for critical security problems in both the current release and the previous release. 

Therefore, Go 1.5.x hasn't been supported for security fixes since last August.