### PR TITLE
api/plugins: implement ordered plugin chaining

### DIFF
--- a/libcni/api.go
+++ b/libcni/api.go
@@ -34,7 +34,17 @@ type NetworkConfig struct {
 	Bytes   []byte
 }
 
+type NetworkConfigList struct {
+	Name       string
+	CNIVersion string
+	Plugins    []*NetworkConfig
+	Bytes      []byte
+}
+
 type CNI interface {
+	AddNetworkList(net *NetworkConfigList, rt *RuntimeConf) (*types.Result, error)
+	DelNetworkList(net *NetworkConfigList, rt *RuntimeConf) error
+
 	AddNetwork(net *NetworkConfig, rt *RuntimeConf) (*types.Result, error)
 	DelNetwork(net *NetworkConfig, rt *RuntimeConf) error
 }
@@ -45,6 +55,76 @@ type CNIConfig struct {
 
 // CNIConfig implements the CNI interface
 var _ CNI = &CNIConfig{}
+
+func buildOneConfig(list *NetworkConfigList, orig *NetworkConfig, prevResult *types.Result) (*NetworkConfig, error) {
+	var err error
+
+	// Ensure every config uses the same name and version
+	orig, err = InjectConf(orig, "name", list.Name)
+	if err != nil {
+		return nil, err
+	}
+	orig, err = InjectConf(orig, "cniVersion", list.CNIVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add previous plugin result
+	if prevResult != nil {
+		orig, err = InjectConf(orig, "prevResult", prevResult)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return orig, nil
+}
+
+// AddNetworkList executes a sequence of plugins with the ADD command
+func (c *CNIConfig) AddNetworkList(list *NetworkConfigList, rt *RuntimeConf) (*types.Result, error) {
+	var prevResult *types.Result
+	for _, net := range list.Plugins {
+		pluginPath, err := invoke.FindInPath(net.Network.Type, c.Path)
+		if err != nil {
+			return nil, err
+		}
+
+		newConf, err := buildOneConfig(list, net, prevResult)
+		if err != nil {
+			return nil, err
+		}
+
+		prevResult, err = invoke.ExecPluginWithResult(pluginPath, newConf.Bytes, c.args("ADD", rt))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return prevResult, nil
+}
+
+// DelNetworkList executes a sequence of plugins with the DEL command
+func (c *CNIConfig) DelNetworkList(list *NetworkConfigList, rt *RuntimeConf) error {
+	for i := len(list.Plugins) - 1; i >= 0; i-- {
+		net := list.Plugins[i]
+
+		pluginPath, err := invoke.FindInPath(net.Network.Type, c.Path)
+		if err != nil {
+			return err
+		}
+
+		newConf, err := buildOneConfig(list, net, nil)
+		if err != nil {
+			return err
+		}
+
+		if err := invoke.ExecPluginWithoutResult(pluginPath, newConf.Bytes, c.args("DEL", rt)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
 
 // AddNetwork executes the plugin with the ADD command
 func (c *CNIConfig) AddNetwork(net *NetworkConfig, rt *RuntimeConf) (*types.Result, error) {

--- a/libcni/api_test.go
+++ b/libcni/api_test.go
@@ -15,6 +15,8 @@
 package libcni_test
 
 import (
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"path/filepath"
@@ -28,150 +30,337 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Invoking the plugin", func() {
-	var (
-		debugFilePath string
-		debug         *noop_debug.Debug
-		cniBinPath    string
-		pluginConfig  string
-		cniConfig     libcni.CNIConfig
-		netConfig     *libcni.NetworkConfig
-		runtimeConfig *libcni.RuntimeConf
+type pluginInfo struct {
+	debugFilePath string
+	debug         *noop_debug.Debug
+	config        string
+}
 
-		expectedCmdArgs skel.CmdArgs
-	)
+func addNameToConfig(name, config string) ([]byte, error) {
+	obj := make(map[string]interface{})
+	err := json.Unmarshal([]byte(config), &obj)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal existing network bytes: %s", err)
+	}
+	obj["name"] = name
+	return json.Marshal(obj)
+}
 
-	BeforeEach(func() {
-		debugFile, err := ioutil.TempFile("", "cni_debug")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(debugFile.Close()).To(Succeed())
-		debugFilePath = debugFile.Name()
+func newPluginInfo(configKey, configValue, prevResult string, injectDebugFilePath bool, result string) pluginInfo {
+	debugFile, err := ioutil.TempFile("", "cni_debug")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(debugFile.Close()).To(Succeed())
+	debugFilePath := debugFile.Name()
 
-		debug = &noop_debug.Debug{
-			ReportResult: `{ "ip4": { "ip": "10.1.2.3/24" }, "dns": {} }`,
-		}
-		Expect(debug.WriteDebug(debugFilePath)).To(Succeed())
+	debug := &noop_debug.Debug{
+		ReportResult: result,
+	}
+	Expect(debug.WriteDebug(debugFilePath)).To(Succeed())
 
-		cniBinPath = filepath.Dir(pluginPaths["noop"])
-		pluginConfig = `{ "type": "noop", "some-key": "some-value", "cniVersion": "0.2.0" }`
-		cniConfig = libcni.CNIConfig{Path: []string{cniBinPath}}
-		netConfig = &libcni.NetworkConfig{
-			Network: &types.NetConf{
-				Type: "noop",
-			},
-			Bytes: []byte(pluginConfig),
-		}
-		runtimeConfig = &libcni.RuntimeConf{
-			ContainerID: "some-container-id",
-			NetNS:       "/some/netns/path",
-			IfName:      "some-eth0",
-			Args:        [][2]string{[2]string{"DEBUG", debugFilePath}},
-		}
+	config := fmt.Sprintf(`{"type": "noop", "%s": "%s", "cniVersion": "0.2.0"`, configKey, configValue)
+	if prevResult != "" {
+		config += fmt.Sprintf(`, "prevResult": %s`, prevResult)
+	}
+	if injectDebugFilePath {
+		config += fmt.Sprintf(`, "debugFile": "%s"`, debugFilePath)
+	}
+	config += "}"
 
-		expectedCmdArgs = skel.CmdArgs{
-			ContainerID: "some-container-id",
-			Netns:       "/some/netns/path",
-			IfName:      "some-eth0",
-			Args:        "DEBUG=" + debugFilePath,
-			Path:        cniBinPath,
-			StdinData:   []byte(pluginConfig),
-		}
-	})
+	return pluginInfo{
+		debugFilePath: debugFilePath,
+		debug:         debug,
+		config:        config,
+	}
+}
 
-	Describe("AddNetwork", func() {
-		It("executes the plugin with command ADD", func() {
-			result, err := cniConfig.AddNetwork(netConfig, runtimeConfig)
-			Expect(err).NotTo(HaveOccurred())
+var _ = Describe("Invoking plugins", func() {
+	Describe("Invoking a single plugin", func() {
+		var (
+			plugin        pluginInfo
+			cniBinPath    string
+			cniConfig     libcni.CNIConfig
+			netConfig     *libcni.NetworkConfig
+			runtimeConfig *libcni.RuntimeConf
 
-			Expect(result).To(Equal(&types.Result{
-				IP4: &types.IPConfig{
-					IP: net.IPNet{
-						IP:   net.ParseIP("10.1.2.3"),
-						Mask: net.IPv4Mask(255, 255, 255, 0),
-					},
+			expectedCmdArgs skel.CmdArgs
+		)
+
+		BeforeEach(func() {
+			pluginResult := `{ "ip4": { "ip": "10.1.2.3/24" }, "dns": {} }`
+			plugin = newPluginInfo("some-key", "some-value", "", false, pluginResult)
+
+			cniBinPath = filepath.Dir(pluginPaths["noop"])
+			cniConfig = libcni.CNIConfig{Path: []string{cniBinPath}}
+			netConfig = &libcni.NetworkConfig{
+				Network: &types.NetConf{
+					Type: "noop",
 				},
-			}))
+				Bytes: []byte(plugin.config),
+			}
+			runtimeConfig = &libcni.RuntimeConf{
+				ContainerID: "some-container-id",
+				NetNS:       "/some/netns/path",
+				IfName:      "some-eth0",
+				Args:        [][2]string{{"DEBUG", plugin.debugFilePath}},
+			}
 
-			debug, err := noop_debug.ReadDebug(debugFilePath)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(debug.Command).To(Equal("ADD"))
-			Expect(debug.CmdArgs).To(Equal(expectedCmdArgs))
+			expectedCmdArgs = skel.CmdArgs{
+				ContainerID: "some-container-id",
+				Netns:       "/some/netns/path",
+				IfName:      "some-eth0",
+				Args:        "DEBUG=" + plugin.debugFilePath,
+				Path:        cniBinPath,
+				StdinData:   []byte(plugin.config),
+			}
 		})
 
-		Context("when finding the plugin fails", func() {
-			BeforeEach(func() {
-				netConfig.Network.Type = "does-not-exist"
-			})
-
-			It("returns the error", func() {
-				_, err := cniConfig.AddNetwork(netConfig, runtimeConfig)
-				Expect(err).To(MatchError(ContainSubstring(`failed to find plugin "does-not-exist"`)))
-			})
-		})
-
-		Context("when the plugin errors", func() {
-			BeforeEach(func() {
-				debug.ReportError = "plugin error: banana"
-				Expect(debug.WriteDebug(debugFilePath)).To(Succeed())
-			})
-			It("unmarshals and returns the error", func() {
+		Describe("AddNetwork", func() {
+			It("executes the plugin with command ADD", func() {
 				result, err := cniConfig.AddNetwork(netConfig, runtimeConfig)
-				Expect(result).To(BeNil())
-				Expect(err).To(MatchError("plugin error: banana"))
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(result).To(Equal(&types.Result{
+					IP4: &types.IPConfig{
+						IP: net.IPNet{
+							IP:   net.ParseIP("10.1.2.3"),
+							Mask: net.IPv4Mask(255, 255, 255, 0),
+						},
+					},
+				}))
+
+				debug, err := noop_debug.ReadDebug(plugin.debugFilePath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(debug.Command).To(Equal("ADD"))
+				Expect(debug.CmdArgs).To(Equal(expectedCmdArgs))
+			})
+
+			Context("when finding the plugin fails", func() {
+				BeforeEach(func() {
+					netConfig.Network.Type = "does-not-exist"
+				})
+
+				It("returns the error", func() {
+					_, err := cniConfig.AddNetwork(netConfig, runtimeConfig)
+					Expect(err).To(MatchError(ContainSubstring(`failed to find plugin "does-not-exist"`)))
+				})
+			})
+
+			Context("when the plugin errors", func() {
+				BeforeEach(func() {
+					plugin.debug.ReportError = "plugin error: banana"
+					Expect(plugin.debug.WriteDebug(plugin.debugFilePath)).To(Succeed())
+				})
+				It("unmarshals and returns the error", func() {
+					result, err := cniConfig.AddNetwork(netConfig, runtimeConfig)
+					Expect(result).To(BeNil())
+					Expect(err).To(MatchError("plugin error: banana"))
+				})
+			})
+		})
+
+		Describe("DelNetwork", func() {
+			It("executes the plugin with command DEL", func() {
+				err := cniConfig.DelNetwork(netConfig, runtimeConfig)
+				Expect(err).NotTo(HaveOccurred())
+
+				debug, err := noop_debug.ReadDebug(plugin.debugFilePath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(debug.Command).To(Equal("DEL"))
+				Expect(debug.CmdArgs).To(Equal(expectedCmdArgs))
+			})
+
+			Context("when finding the plugin fails", func() {
+				BeforeEach(func() {
+					netConfig.Network.Type = "does-not-exist"
+				})
+
+				It("returns the error", func() {
+					err := cniConfig.DelNetwork(netConfig, runtimeConfig)
+					Expect(err).To(MatchError(ContainSubstring(`failed to find plugin "does-not-exist"`)))
+				})
+			})
+
+			Context("when the plugin errors", func() {
+				BeforeEach(func() {
+					plugin.debug.ReportError = "plugin error: banana"
+					Expect(plugin.debug.WriteDebug(plugin.debugFilePath)).To(Succeed())
+				})
+				It("unmarshals and returns the error", func() {
+					err := cniConfig.DelNetwork(netConfig, runtimeConfig)
+					Expect(err).To(MatchError("plugin error: banana"))
+				})
+			})
+		})
+
+		Describe("GetVersionInfo", func() {
+			It("executes the plugin with the command VERSION", func() {
+				versionInfo, err := cniConfig.GetVersionInfo("noop")
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(versionInfo).NotTo(BeNil())
+				Expect(versionInfo.SupportedVersions()).To(Equal([]string{
+					"0.-42.0", "0.1.0", "0.2.0",
+				}))
+			})
+
+			Context("when finding the plugin fails", func() {
+				It("returns the error", func() {
+					_, err := cniConfig.GetVersionInfo("does-not-exist")
+					Expect(err).To(MatchError(ContainSubstring(`failed to find plugin "does-not-exist"`)))
+				})
 			})
 		})
 	})
 
-	Describe("DelNetwork", func() {
-		It("executes the plugin with command DEL", func() {
-			err := cniConfig.DelNetwork(netConfig, runtimeConfig)
+	Describe("Invoking a plugin list", func() {
+		var (
+			plugins       []pluginInfo
+			cniBinPath    string
+			cniConfig     libcni.CNIConfig
+			netConfigList *libcni.NetworkConfigList
+			runtimeConfig *libcni.RuntimeConf
+
+			expectedCmdArgs skel.CmdArgs
+		)
+
+		BeforeEach(func() {
+			plugins = make([]pluginInfo, 3, 3)
+			plugins[0] = newPluginInfo("some-key", "some-value", "", true, `{"dns":{},"ip4":{"ip": "10.1.2.3/24"}}`)
+			plugins[1] = newPluginInfo("some-key", "some-other-value", `{"dns":{},"ip4":{"ip": "10.1.2.3/24"}}`, true, "PASSTHROUGH")
+			plugins[2] = newPluginInfo("some-key", "yet-another-value", `{"dns":{},"ip4":{"ip": "10.1.2.3/24"}}`, true, "INJECT-DNS")
+
+			configList := []byte(fmt.Sprintf(`{
+  "name": "some-list",
+  "cniVersion": "0.2.0",
+  "plugins": [
+    %s,
+    %s,
+    %s
+  ]
+}`, plugins[0].config, plugins[1].config, plugins[2].config))
+
+			var err error
+			netConfigList, err = libcni.ConfListFromBytes(configList)
 			Expect(err).NotTo(HaveOccurred())
 
-			debug, err := noop_debug.ReadDebug(debugFilePath)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(debug.Command).To(Equal("DEL"))
-			Expect(debug.CmdArgs).To(Equal(expectedCmdArgs))
+			cniBinPath = filepath.Dir(pluginPaths["noop"])
+			cniConfig = libcni.CNIConfig{Path: []string{cniBinPath}}
+			runtimeConfig = &libcni.RuntimeConf{
+				ContainerID: "some-container-id",
+				NetNS:       "/some/netns/path",
+				IfName:      "some-eth0",
+				Args:        [][2]string{{"FOO", "BAR"}},
+			}
+
+			expectedCmdArgs = skel.CmdArgs{
+				ContainerID: "some-container-id",
+				Netns:       "/some/netns/path",
+				IfName:      "some-eth0",
+				Args:        "FOO=BAR",
+				Path:        cniBinPath,
+			}
 		})
 
-		Context("when finding the plugin fails", func() {
-			BeforeEach(func() {
-				netConfig.Network.Type = "does-not-exist"
+		Describe("AddNetworkList", func() {
+			It("executes all plugins with command ADD and returns an intermediate result", func() {
+				result, err := cniConfig.AddNetworkList(netConfigList, runtimeConfig)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(result).To(Equal(&types.Result{
+					// IP4 added by first plugin
+					IP4: &types.IPConfig{
+						IP: net.IPNet{
+							IP:   net.ParseIP("10.1.2.3"),
+							Mask: net.IPv4Mask(255, 255, 255, 0),
+						},
+					},
+					// DNS injected by last plugin
+					DNS: types.DNS{
+						Nameservers: []string{"1.2.3.4"},
+					},
+				}))
+
+				for i := 0; i < len(plugins); i++ {
+					debug, err := noop_debug.ReadDebug(plugins[i].debugFilePath)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(debug.Command).To(Equal("ADD"))
+					newConfig, err := addNameToConfig("some-list", plugins[i].config)
+					Expect(err).NotTo(HaveOccurred())
+
+					// Must explicitly match JSON due to dict element ordering
+					debugJSON := debug.CmdArgs.StdinData
+					debug.CmdArgs.StdinData = nil
+					Expect(debugJSON).To(MatchJSON(newConfig))
+					Expect(debug.CmdArgs).To(Equal(expectedCmdArgs))
+				}
 			})
 
-			It("returns the error", func() {
-				err := cniConfig.DelNetwork(netConfig, runtimeConfig)
-				Expect(err).To(MatchError(ContainSubstring(`failed to find plugin "does-not-exist"`)))
+			Context("when finding the plugin fails", func() {
+				BeforeEach(func() {
+					netConfigList.Plugins[1].Network.Type = "does-not-exist"
+				})
+
+				It("returns the error", func() {
+					_, err := cniConfig.AddNetworkList(netConfigList, runtimeConfig)
+					Expect(err).To(MatchError(ContainSubstring(`failed to find plugin "does-not-exist"`)))
+				})
+			})
+
+			Context("when the second plugin errors", func() {
+				BeforeEach(func() {
+					plugins[1].debug.ReportError = "plugin error: banana"
+					Expect(plugins[1].debug.WriteDebug(plugins[1].debugFilePath)).To(Succeed())
+				})
+				It("unmarshals and returns the error", func() {
+					result, err := cniConfig.AddNetworkList(netConfigList, runtimeConfig)
+					Expect(result).To(BeNil())
+					Expect(err).To(MatchError("plugin error: banana"))
+				})
 			})
 		})
 
-		Context("when the plugin errors", func() {
-			BeforeEach(func() {
-				debug.ReportError = "plugin error: banana"
-				Expect(debug.WriteDebug(debugFilePath)).To(Succeed())
+		Describe("DelNetworkList", func() {
+			It("executes all the plugins in reverse order with command DEL", func() {
+				err := cniConfig.DelNetworkList(netConfigList, runtimeConfig)
+				Expect(err).NotTo(HaveOccurred())
+
+				for i := 0; i < len(plugins); i++ {
+					debug, err := noop_debug.ReadDebug(plugins[i].debugFilePath)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(debug.Command).To(Equal("DEL"))
+					newConfig, err := addNameToConfig("some-list", plugins[i].config)
+					Expect(err).NotTo(HaveOccurred())
+
+					// Must explicitly match JSON due to dict element ordering
+					debugJSON := debug.CmdArgs.StdinData
+					debug.CmdArgs.StdinData = nil
+					Expect(debugJSON).To(MatchJSON(newConfig))
+					Expect(debug.CmdArgs).To(Equal(expectedCmdArgs))
+				}
 			})
-			It("unmarshals and returns the error", func() {
-				err := cniConfig.DelNetwork(netConfig, runtimeConfig)
-				Expect(err).To(MatchError("plugin error: banana"))
+
+			Context("when finding the plugin fails", func() {
+				BeforeEach(func() {
+					netConfigList.Plugins[1].Network.Type = "does-not-exist"
+				})
+
+				It("returns the error", func() {
+					err := cniConfig.DelNetworkList(netConfigList, runtimeConfig)
+					Expect(err).To(MatchError(ContainSubstring(`failed to find plugin "does-not-exist"`)))
+				})
+			})
+
+			Context("when the plugin errors", func() {
+				BeforeEach(func() {
+					plugins[1].debug.ReportError = "plugin error: banana"
+					Expect(plugins[1].debug.WriteDebug(plugins[1].debugFilePath)).To(Succeed())
+				})
+				It("unmarshals and returns the error", func() {
+					err := cniConfig.DelNetworkList(netConfigList, runtimeConfig)
+					Expect(err).To(MatchError("plugin error: banana"))
+				})
 			})
 		})
-	})
 
-	Describe("GetVersionInfo", func() {
-		It("executes the plugin with the command VERSION", func() {
-			versionInfo, err := cniConfig.GetVersionInfo("noop")
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(versionInfo).NotTo(BeNil())
-			Expect(versionInfo.SupportedVersions()).To(Equal([]string{
-				"0.-42.0", "0.1.0", "0.2.0",
-			}))
-		})
-
-		Context("when finding the plugin fails", func() {
-			It("returns the error", func() {
-				_, err := cniConfig.GetVersionInfo("does-not-exist")
-				Expect(err).To(MatchError(ContainSubstring(`failed to find plugin "does-not-exist"`)))
-			})
-		})
 	})
 })

--- a/libcni/conf.go
+++ b/libcni/conf.go
@@ -39,7 +39,73 @@ func ConfFromFile(filename string) (*NetworkConfig, error) {
 	return ConfFromBytes(bytes)
 }
 
-func ConfFiles(dir string) ([]string, error) {
+func ConfListFromBytes(bytes []byte) (*NetworkConfigList, error) {
+	rawList := make(map[string]interface{})
+	if err := json.Unmarshal(bytes, &rawList); err != nil {
+		return nil, fmt.Errorf("error parsing configuration list: %s", err)
+	}
+
+	rawName, ok := rawList["name"]
+	if !ok {
+		return nil, fmt.Errorf("error parsing configuration list: no name")
+	}
+	name, ok := rawName.(string)
+	if !ok {
+		return nil, fmt.Errorf("error parsing configuration list: invalid name type %T", rawName)
+	}
+
+	var cniVersion string
+	rawVersion, ok := rawList["cniVersion"]
+	if ok {
+		cniVersion, ok = rawVersion.(string)
+		if !ok {
+			return nil, fmt.Errorf("error parsing configuration list: invalid cniVersion type %T", rawVersion)
+		}
+	}
+
+	list := &NetworkConfigList{
+		Name:       name,
+		CNIVersion: cniVersion,
+		Bytes:      bytes,
+	}
+
+	var plugins []interface{}
+	plug, ok := rawList["plugins"]
+	if !ok {
+		return nil, fmt.Errorf("error parsing configuration list: no 'plugins' key")
+	}
+	plugins, ok = plug.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("error parsing configuration list: invalid 'plugins' type %T", plug)
+	}
+	if len(plugins) == 0 {
+		return nil, fmt.Errorf("error parsing configuration list: no plugins in list")
+	}
+
+	for i, conf := range plugins {
+		newBytes, err := json.Marshal(conf)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to marshal plugin config %d: %v", i, err)
+		}
+		netConf, err := ConfFromBytes(newBytes)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse plugin config %d: %v", i, err)
+		}
+		list.Plugins = append(list.Plugins, netConf)
+	}
+
+	return list, nil
+}
+
+func ConfListFromFile(filename string) (*NetworkConfigList, error) {
+	bytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("error reading %s: %s", filename, err)
+	}
+	return ConfListFromBytes(bytes)
+}
+
+func ConfFiles(dir string, extensions []string) ([]string, error) {
 	// In part, adapted from rkt/networking/podenv.go#listFiles
 	files, err := ioutil.ReadDir(dir)
 	switch {
@@ -56,15 +122,17 @@ func ConfFiles(dir string) ([]string, error) {
 			continue
 		}
 		fileExt := filepath.Ext(f.Name())
-		if fileExt == ".conf" || fileExt == ".json" {
-			confFiles = append(confFiles, filepath.Join(dir, f.Name()))
+		for _, ext := range extensions {
+			if fileExt == ext {
+				confFiles = append(confFiles, filepath.Join(dir, f.Name()))
+			}
 		}
 	}
 	return confFiles, nil
 }
 
 func LoadConf(dir, name string) (*NetworkConfig, error) {
-	files, err := ConfFiles(dir)
+	files, err := ConfFiles(dir, []string{".conf", ".json"})
 	switch {
 	case err != nil:
 		return nil, err
@@ -83,6 +151,28 @@ func LoadConf(dir, name string) (*NetworkConfig, error) {
 		}
 	}
 	return nil, fmt.Errorf(`no net configuration with name "%s" in %s`, name, dir)
+}
+
+func LoadConfList(dir, name string) (*NetworkConfigList, error) {
+	files, err := ConfFiles(dir, []string{".conflist"})
+	switch {
+	case err != nil:
+		return nil, err
+	case len(files) == 0:
+		return nil, fmt.Errorf("no net configuration lists found")
+	}
+	sort.Strings(files)
+
+	for _, confFile := range files {
+		conf, err := ConfListFromFile(confFile)
+		if err != nil {
+			return nil, err
+		}
+		if conf.Name == name {
+			return conf, nil
+		}
+	}
+	return nil, fmt.Errorf(`no net configuration list with name "%s" in %s`, name, dir)
 }
 
 func InjectConf(original *NetworkConfig, key string, newValue interface{}) (*NetworkConfig, error) {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -59,12 +59,21 @@ func (n *IPNet) UnmarshalJSON(data []byte) error {
 type NetConf struct {
 	CNIVersion string `json:"cniVersion,omitempty"`
 
-	Name string `json:"name,omitempty"`
-	Type string `json:"type,omitempty"`
-	IPAM struct {
+	Name       string  `json:"name,omitempty"`
+	Type       string  `json:"type,omitempty"`
+	PrevResult *Result `json:"prevResult,omitempty"`
+	IPAM       struct {
 		Type string `json:"type,omitempty"`
 	} `json:"ipam,omitempty"`
 	DNS DNS `json:"dns"`
+}
+
+// NetConfList describes an ordered list of networks.
+type NetConfList struct {
+	CNIVersion string `json:"cniVersion,omitempty"`
+
+	Name    string     `json:"name,omitempty"`
+	Plugins []*NetConf `json:"plugins,omitempty"`
 }
 
 // Result is what gets returned from the plugin (via stdout) to the caller

--- a/plugins/test/noop/noop_test.go
+++ b/plugins/test/noop/noop_test.go
@@ -58,10 +58,11 @@ var _ = Describe("No-op plugin", func() {
 		cmd.Env = []string{
 			"CNI_COMMAND=ADD",
 			"CNI_CONTAINERID=some-container-id",
-			"CNI_ARGS=" + args,
 			"CNI_NETNS=/some/netns/path",
 			"CNI_IFNAME=some-eth0",
 			"CNI_PATH=/some/bin/path",
+			// Keep this last
+			"CNI_ARGS=" + args,
 		}
 		cmd.Stdin = strings.NewReader(`{"some":"stdin-json", "cniVersion": "0.2.0"}`)
 		expectedCmdArgs = skel.CmdArgs{
@@ -83,6 +84,36 @@ var _ = Describe("No-op plugin", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(session).Should(gexec.Exit(0))
 		Expect(session.Out.Contents()).To(MatchJSON(reportResult))
+	})
+
+	It("panics when no debug file is given", func() {
+		// Remove the DEBUG option from CNI_ARGS and regular args
+		cmd.Env[len(cmd.Env)-1] = "CNI_ARGS=FOO=BAR"
+		expectedCmdArgs.Args = "FOO=BAR"
+
+		session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(session).Should(gexec.Exit(2))
+	})
+
+	It("allows passing debug file in config JSON", func() {
+		// Remove the DEBUG option from CNI_ARGS and regular args
+		newArgs := "FOO=BAR"
+		cmd.Env[len(cmd.Env)-1] = "CNI_ARGS=" + newArgs
+		newStdin := fmt.Sprintf(`{"some":"stdin-json", "cniVersion": "0.2.0", "debugFile": "%s"}`, debugFileName)
+		cmd.Stdin = strings.NewReader(newStdin)
+		expectedCmdArgs.Args = newArgs
+		expectedCmdArgs.StdinData = []byte(newStdin)
+
+		session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(session).Should(gexec.Exit(0))
+		Expect(session.Out.Contents()).To(MatchJSON(reportResult))
+
+		debug, err := noop_debug.ReadDebug(debugFileName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(debug.Command).To(Equal("ADD"))
+		Expect(debug.CmdArgs).To(Equal(expectedCmdArgs))
 	})
 
 	It("records all the args provided by skel.PluginMain", func() {


### PR DESCRIPTION
Implements @squeed "ordered" suggestion in https://gist.github.com/squeed/c69206c51f7d38d1cbb5211a3fde5d06.

Shows how both IPAM and regular plugins need to be modified to support prevResult and missing IPAM structures (since IPAM could also be in a standalone config block).

One missing piece is versioning of course, which needs to be bumped for this. I don't think we yet need to do everything #145 does since this doesn't change structures in a backwards compatible way.

@containernetworking/cni-maintainers @rosenhouse @squeed @freehan @asridharan @rajatchopra @caseydavenport