### PR TITLE
libcni, pkg\invoke: Use OS-specific list separator when parsing CNI_PATH

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -88,7 +88,7 @@ It will then look for this executable in a list of predefined directories. Once 
 - `CNI_NETNS`: Path to network namespace file
 - `CNI_IFNAME`: Interface name to set up; plugin must honor this interface name or return an error
 - `CNI_ARGS`: Extra arguments passed in by the user at invocation time. Alphanumeric key-value pairs separated by semicolons; for example, "FOO=BAR;ABC=123"
-- `CNI_PATH`: Colon-separated list of paths to search for CNI plugin executables
+- `CNI_PATH`: List of paths to search for CNI plugin executables. Paths are separated by an OS-specific list separator; for example ':' on Linux and ';' on Windows
 
 Network configuration in JSON format is streamed to the plugin through stdin. This means it is not tied to a particular file on disk and can contain information which changes between invocations.
 

--- a/cnitool/cni.go
+++ b/cnitool/cni.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/containernetworking/cni/libcni"
 )
@@ -51,7 +50,7 @@ func main() {
 	netns := os.Args[3]
 
 	cninet := &libcni.CNIConfig{
-		Path: strings.Split(os.Getenv(EnvCNIPath), ":"),
+		Path: filepath.SplitList(os.Getenv(EnvCNIPath)),
 	}
 
 	rt := &libcni.RuntimeConf{

--- a/libcni/api.go
+++ b/libcni/api.go
@@ -15,6 +15,7 @@
 package libcni
 
 import (
+	"os"
 	"strings"
 
 	"github.com/containernetworking/cni/pkg/invoke"
@@ -165,6 +166,6 @@ func (c *CNIConfig) args(action string, rt *RuntimeConf) *invoke.Args {
 		NetNS:       rt.NetNS,
 		PluginArgs:  rt.Args,
 		IfName:      rt.IfName,
-		Path:        strings.Join(c.Path, ":"),
+		Path:        strings.Join(c.Path, string(os.PathListSeparator)),
 	}
 }

--- a/pkg/invoke/delegate.go
+++ b/pkg/invoke/delegate.go
@@ -17,7 +17,7 @@ package invoke
 import (
 	"fmt"
 	"os"
-	"strings"
+	"path/filepath"
 
 	"github.com/containernetworking/cni/pkg/types"
 )
@@ -27,7 +27,7 @@ func DelegateAdd(delegatePlugin string, netconf []byte) (types.Result, error) {
 		return nil, fmt.Errorf("CNI_COMMAND is not ADD")
 	}
 
-	paths := strings.Split(os.Getenv("CNI_PATH"), ":")
+	paths := filepath.SplitList(os.Getenv("CNI_PATH"))
 
 	pluginPath, err := FindInPath(delegatePlugin, paths)
 	if err != nil {
@@ -42,7 +42,7 @@ func DelegateDel(delegatePlugin string, netconf []byte) error {
 		return fmt.Errorf("CNI_COMMAND is not DEL")
 	}
 
-	paths := strings.Split(os.Getenv("CNI_PATH"), ":")
+	paths := filepath.SplitList(os.Getenv("CNI_PATH"))
 
 	pluginPath, err := FindInPath(delegatePlugin, paths)
 	if err != nil {


### PR DESCRIPTION
Hardcoding the list separator character as ":" causes CNI to fail when parsing
CNI_PATH on other operating systems. For example, Windows uses ";" as list
separator because ":" can legally appear in paths such as "C:\path\to\file".

Fixes #358 