### PR TITLE
invoke: Enable plugin file names with extensions

### DIFF
--- a/pkg/invoke/find.go
+++ b/pkg/invoke/find.go
@@ -30,18 +30,14 @@ func FindInPath(plugin string, paths []string) (string, error) {
 		return "", fmt.Errorf("no paths provided")
 	}
 
-	var fullpath string
 	for _, path := range paths {
-		full := filepath.Join(path, plugin)
-		if fi, err := os.Stat(full); err == nil && fi.Mode().IsRegular() {
-			fullpath = full
-			break
+		for _, fe := range ExecutableFileExtensions {
+			fullpath := filepath.Join(path, plugin) + fe
+			if fi, err := os.Stat(fullpath); err == nil && fi.Mode().IsRegular() {
+				return fullpath, nil
+			}
 		}
 	}
 
-	if fullpath == "" {
-		return "", fmt.Errorf("failed to find plugin %q in path %s", plugin, paths)
-	}
-
-	return fullpath, nil
+	return "", fmt.Errorf("failed to find plugin %q in path %s", plugin, paths)
 }

--- a/pkg/invoke/os_unix.go
+++ b/pkg/invoke/os_unix.go
@@ -1,0 +1,20 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build darwin dragonfly freebsd linux netbsd opensbd solaris
+
+package invoke
+
+// Valid file extensions for plugin executables.
+var ExecutableFileExtensions = []string{""}

--- a/pkg/invoke/os_windows.go
+++ b/pkg/invoke/os_windows.go
@@ -1,0 +1,18 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package invoke
+
+// Valid file extensions for plugin executables.
+var ExecutableFileExtensions = []string{".exe", ""}


### PR DESCRIPTION
A CNI network configuration file contains the plugin's executable file name.
Some platforms like Windows require a file name extension for executables.
This causes unnecessary burden on admins as they now have to maintain two
versions of each type of netconfig file, which differ only by the ".exe"
extension. A much simpler design is for find package to also look for
well-known extensions. This is done only after checking without the extension,
so no behavioral difference is introduced. Tests are improved and new cases
are added to cover the new behavior.

Fixes #360