### PR TITLE
test: run golint  

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
  - go get ${TOOLS_CMD}/cover
  - go get github.com/modocache/gover
  - go get github.com/mattn/goveralls
+ - go get github.com/golang/lint/golint
 
 script:
  - >

--- a/cnitool/cni.go
+++ b/cnitool/cni.go
@@ -23,12 +23,15 @@ import (
 )
 
 const (
+	// EnvCNIPath represents paths to search for CNI plugin executables
 	EnvCNIPath = "CNI_PATH"
-	EnvNetDir  = "NETCONFPATH"
-
+	// EnvNetDir represents path of netconf file
+	EnvNetDir = "NETCONFPATH"
+	// DefaultNetDir is the default location in which the scripts will look for net configurations
 	DefaultNetDir = "/etc/cni/net.d"
-
+	// CmdAdd adds a container to a network
 	CmdAdd = "add"
+	// CmdDel deletes a container from a network
 	CmdDel = "del"
 )
 

--- a/libcni/api.go
+++ b/libcni/api.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containernetworking/cni/pkg/version"
 )
 
+// RuntimeConf contains runtime configuration for network add/del operations.
 type RuntimeConf struct {
 	ContainerID string
 	NetNS       string
@@ -30,11 +31,13 @@ type RuntimeConf struct {
 	Args        [][2]string
 }
 
+// NetworkConfig contains a plug-in network configuration.
 type NetworkConfig struct {
 	Network *types.NetConf
 	Bytes   []byte
 }
 
+// NetworkConfigList contains a list of plug-in network configurations.
 type NetworkConfigList struct {
 	Name       string
 	CNIVersion string
@@ -42,6 +45,7 @@ type NetworkConfigList struct {
 	Bytes      []byte
 }
 
+// CNI defines the operations that a CNI plugin needs to support.
 type CNI interface {
 	AddNetworkList(net *NetworkConfigList, rt *RuntimeConf) (types.Result, error)
 	DelNetworkList(net *NetworkConfigList, rt *RuntimeConf) error
@@ -50,11 +54,12 @@ type CNI interface {
 	DelNetwork(net *NetworkConfig, rt *RuntimeConf) error
 }
 
+// CNIConfig contains a list of pathes where to look for plug-in network configurations.
 type CNIConfig struct {
 	Path []string
 }
 
-// CNIConfig implements the CNI interface
+// CNIConfig implements the CNI interface.
 var _ CNI = &CNIConfig{}
 
 func buildOneConfig(list *NetworkConfigList, orig *NetworkConfig, prevResult types.Result) (*NetworkConfig, error) {
@@ -81,7 +86,7 @@ func buildOneConfig(list *NetworkConfigList, orig *NetworkConfig, prevResult typ
 	return orig, nil
 }
 
-// AddNetworkList executes a sequence of plugins with the ADD command
+// AddNetworkList executes a sequence of plugins with the ADD command.
 func (c *CNIConfig) AddNetworkList(list *NetworkConfigList, rt *RuntimeConf) (types.Result, error) {
 	var prevResult types.Result
 	for _, net := range list.Plugins {
@@ -104,7 +109,7 @@ func (c *CNIConfig) AddNetworkList(list *NetworkConfigList, rt *RuntimeConf) (ty
 	return prevResult, nil
 }
 
-// DelNetworkList executes a sequence of plugins with the DEL command
+// DelNetworkList executes a sequence of plugins with the DEL command.
 func (c *CNIConfig) DelNetworkList(list *NetworkConfigList, rt *RuntimeConf) error {
 	for i := len(list.Plugins) - 1; i >= 0; i-- {
 		net := list.Plugins[i]
@@ -127,7 +132,7 @@ func (c *CNIConfig) DelNetworkList(list *NetworkConfigList, rt *RuntimeConf) err
 	return nil
 }
 
-// AddNetwork executes the plugin with the ADD command
+// AddNetwork executes the plugin with the ADD command.
 func (c *CNIConfig) AddNetwork(net *NetworkConfig, rt *RuntimeConf) (types.Result, error) {
 	pluginPath, err := invoke.FindInPath(net.Network.Type, c.Path)
 	if err != nil {
@@ -137,7 +142,7 @@ func (c *CNIConfig) AddNetwork(net *NetworkConfig, rt *RuntimeConf) (types.Resul
 	return invoke.ExecPluginWithResult(pluginPath, net.Bytes, c.args("ADD", rt))
 }
 
-// DelNetwork executes the plugin with the DEL command
+// DelNetwork executes the plugin with the DEL command.
 func (c *CNIConfig) DelNetwork(net *NetworkConfig, rt *RuntimeConf) error {
 	pluginPath, err := invoke.FindInPath(net.Network.Type, c.Path)
 	if err != nil {

--- a/libcni/api.go
+++ b/libcni/api.go
@@ -54,7 +54,7 @@ type CNI interface {
 	DelNetwork(net *NetworkConfig, rt *RuntimeConf) error
 }
 
-// CNIConfig contains a list of pathes where to look for plug-in network configurations.
+// CNIConfig contains a list of paths where to look for plug-in network configurations.
 type CNIConfig struct {
 	Path []string
 }

--- a/libcni/backwards_compatibility_test.go
+++ b/libcni/backwards_compatibility_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/containernetworking/cni/libcni"
-	"github.com/containernetworking/cni/pkg/version/legacy_examples"
+	legacy_examples "github.com/containernetworking/cni/pkg/version/legacyexamples"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -60,7 +60,7 @@ var _ = Describe("Backwards compatibility", func() {
 			Fail("must be run as root")
 		}
 
-		example := legacy_examples.V010_Runtime
+		example := legacy_examples.V010Runtime
 
 		binPath, err := example.Build()
 		Expect(err).NotTo(HaveOccurred())

--- a/libcni/conf.go
+++ b/libcni/conf.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 )
 
+// ConfFromBytes loads a network config list from an array of bytes.
 func ConfFromBytes(bytes []byte) (*NetworkConfig, error) {
 	conf := &NetworkConfig{Bytes: bytes}
 	if err := json.Unmarshal(bytes, &conf.Network); err != nil {
@@ -31,6 +32,7 @@ func ConfFromBytes(bytes []byte) (*NetworkConfig, error) {
 	return conf, nil
 }
 
+// ConfFromFile loads a network config list from a file.
 func ConfFromFile(filename string) (*NetworkConfig, error) {
 	bytes, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -39,6 +41,7 @@ func ConfFromFile(filename string) (*NetworkConfig, error) {
 	return ConfFromBytes(bytes)
 }
 
+// ConfListFromBytes loads a network config list from an array of bytes.
 func ConfListFromBytes(bytes []byte) (*NetworkConfigList, error) {
 	rawList := make(map[string]interface{})
 	if err := json.Unmarshal(bytes, &rawList); err != nil {
@@ -97,6 +100,7 @@ func ConfListFromBytes(bytes []byte) (*NetworkConfigList, error) {
 	return list, nil
 }
 
+// ConfListFromFile loads a network config list from a file.
 func ConfListFromFile(filename string) (*NetworkConfigList, error) {
 	bytes, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -105,6 +109,7 @@ func ConfListFromFile(filename string) (*NetworkConfigList, error) {
 	return ConfListFromBytes(bytes)
 }
 
+// ConfFiles walks a path and returns any existing network configuration files.
 func ConfFiles(dir string, extensions []string) ([]string, error) {
 	// In part, adapted from rkt/networking/podenv.go#listFiles
 	files, err := ioutil.ReadDir(dir)
@@ -131,6 +136,7 @@ func ConfFiles(dir string, extensions []string) ([]string, error) {
 	return confFiles, nil
 }
 
+// LoadConf loads a network configuration from a specified path, with a name.
 func LoadConf(dir, name string) (*NetworkConfig, error) {
 	files, err := ConfFiles(dir, []string{".conf", ".json"})
 	switch {
@@ -153,6 +159,7 @@ func LoadConf(dir, name string) (*NetworkConfig, error) {
 	return nil, fmt.Errorf(`no net configuration with name "%s" in %s`, name, dir)
 }
 
+// LoadConfList loads a network configuration list from a specified path, with a name.
 func LoadConfList(dir, name string) (*NetworkConfigList, error) {
 	files, err := ConfFiles(dir, []string{".conflist"})
 	switch {
@@ -175,6 +182,7 @@ func LoadConfList(dir, name string) (*NetworkConfigList, error) {
 	return nil, fmt.Errorf(`no net configuration list with name "%s" in %s`, name, dir)
 }
 
+// InjectConf returns a clone of the passed NetworkConfig with an updated value.
 func InjectConf(original *NetworkConfig, key string, newValue interface{}) (*NetworkConfig, error) {
 	config := make(map[string]interface{})
 	err := json.Unmarshal(original.Bytes, &config)

--- a/pkg/invoke/args.go
+++ b/pkg/invoke/args.go
@@ -19,6 +19,9 @@ import (
 	"strings"
 )
 
+// CNIArgs represents the arguments to be passed to the plugin via the process environment.
+// Sometimes these must be assembled from configuration.
+// Sometimes (when calling a plugin recursively) they must be inherited from the calling process.
 type CNIArgs interface {
 	// For use with os/exec; i.e., return nil to inherit the
 	// environment from this process
@@ -29,14 +32,18 @@ type inherited struct{}
 
 var inheritArgsFromEnv inherited
 
-func (_ *inherited) AsEnv() []string {
+func (i *inherited) AsEnv() []string {
+	// It stands in for "just use the calling process's environment"
 	return nil
 }
 
+// ArgsFromEnv returns CNIArgs by inheriting environment variables.
 func ArgsFromEnv() CNIArgs {
+	// So far no environment variables inherited
 	return &inheritArgsFromEnv
 }
 
+// Args defines the contents of CNIArgs.
 type Args struct {
 	Command       string
 	ContainerID   string
@@ -50,6 +57,7 @@ type Args struct {
 // Args implements the CNIArgs interface
 var _ CNIArgs = &Args{}
 
+// AsEnv returns args serialised as an array of environment variables.
 func (args *Args) AsEnv() []string {
 	env := os.Environ()
 	pluginArgsStr := args.PluginArgsStr

--- a/pkg/invoke/args.go
+++ b/pkg/invoke/args.go
@@ -33,13 +33,11 @@ type inherited struct{}
 var inheritArgsFromEnv inherited
 
 func (i *inherited) AsEnv() []string {
-	// It stands in for "just use the calling process's environment"
 	return nil
 }
 
 // ArgsFromEnv returns CNIArgs by inheriting environment variables.
 func ArgsFromEnv() CNIArgs {
-	// So far no environment variables inherited
 	return &inheritArgsFromEnv
 }
 

--- a/pkg/invoke/delegate.go
+++ b/pkg/invoke/delegate.go
@@ -22,6 +22,7 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 )
 
+// DelegateAdd delegates the execution of ADD command to a named plug-in.
 func DelegateAdd(delegatePlugin string, netconf []byte) (types.Result, error) {
 	if os.Getenv("CNI_COMMAND") != "ADD" {
 		return nil, fmt.Errorf("CNI_COMMAND is not ADD")
@@ -37,6 +38,7 @@ func DelegateAdd(delegatePlugin string, netconf []byte) (types.Result, error) {
 	return ExecPluginWithResult(pluginPath, netconf, ArgsFromEnv())
 }
 
+// DelegateDel delegates the execution of DEL command to a named plug-in.
 func DelegateDel(delegatePlugin string, netconf []byte) error {
 	if os.Getenv("CNI_COMMAND") != "DEL" {
 		return fmt.Errorf("CNI_COMMAND is not DEL")

--- a/pkg/invoke/exec.go
+++ b/pkg/invoke/exec.go
@@ -22,14 +22,17 @@ import (
 	"github.com/containernetworking/cni/pkg/version"
 )
 
+// ExecPluginWithResult invokes network plugin and returns the result and error, if any.
 func ExecPluginWithResult(pluginPath string, netconf []byte, args CNIArgs) (types.Result, error) {
 	return defaultPluginExec.WithResult(pluginPath, netconf, args)
 }
 
+// ExecPluginWithoutResult invokes network plugin and returns an error, if any.
 func ExecPluginWithoutResult(pluginPath string, netconf []byte, args CNIArgs) error {
 	return defaultPluginExec.WithoutResult(pluginPath, netconf, args)
 }
 
+// GetVersionInfo returns network plugin version.
 func GetVersionInfo(pluginPath string) (version.PluginInfo, error) {
 	return defaultPluginExec.GetVersionInfo(pluginPath)
 }
@@ -39,6 +42,7 @@ var defaultPluginExec = &PluginExec{
 	VersionDecoder: &version.PluginDecoder{},
 }
 
+// PluginExec is a placeholder for a raw executable plugin.
 type PluginExec struct {
 	RawExec interface {
 		ExecPlugin(pluginPath string, stdinData []byte, environ []string) ([]byte, error)
@@ -48,6 +52,7 @@ type PluginExec struct {
 	}
 }
 
+// WithResult invokes network plugin and returns the result and error, if any.
 func (e *PluginExec) WithResult(pluginPath string, netconf []byte, args CNIArgs) (types.Result, error) {
 	stdoutBytes, err := e.RawExec.ExecPlugin(pluginPath, netconf, args.AsEnv())
 	if err != nil {
@@ -64,6 +69,7 @@ func (e *PluginExec) WithResult(pluginPath string, netconf []byte, args CNIArgs)
 	return version.NewResult(confVersion, stdoutBytes)
 }
 
+// WithoutResult invokes network plugin and returns an error, if any.
 func (e *PluginExec) WithoutResult(pluginPath string, netconf []byte, args CNIArgs) error {
 	_, err := e.RawExec.ExecPlugin(pluginPath, netconf, args.AsEnv())
 	return err

--- a/pkg/invoke/fakes/cni_args.go
+++ b/pkg/invoke/fakes/cni_args.go
@@ -14,6 +14,7 @@
 
 package fakes
 
+// CNIArgs represents fake CNIArgs.
 type CNIArgs struct {
 	AsEnvCall struct {
 		Returns struct {
@@ -22,6 +23,7 @@ type CNIArgs struct {
 	}
 }
 
+// AsEnv returns the fake CNIArgs as an array of stringified environment variables.
 func (a *CNIArgs) AsEnv() []string {
 	return a.AsEnvCall.Returns.Env
 }

--- a/pkg/invoke/fakes/raw_exec.go
+++ b/pkg/invoke/fakes/raw_exec.go
@@ -14,6 +14,7 @@
 
 package fakes
 
+// RawExec represents fake RawExec.
 type RawExec struct {
 	ExecPluginCall struct {
 		Received struct {
@@ -28,6 +29,7 @@ type RawExec struct {
 	}
 }
 
+// ExecPlugin returns the fake result of fake RawExec execution.
 func (e *RawExec) ExecPlugin(pluginPath string, stdinData []byte, environ []string) ([]byte, error) {
 	e.ExecPluginCall.Received.PluginPath = pluginPath
 	e.ExecPluginCall.Received.StdinData = stdinData

--- a/pkg/invoke/fakes/version_decoder.go
+++ b/pkg/invoke/fakes/version_decoder.go
@@ -16,6 +16,7 @@ package fakes
 
 import "github.com/containernetworking/cni/pkg/version"
 
+// VersionDecoder represents a fake VersionDecoder.
 type VersionDecoder struct {
 	DecodeCall struct {
 		Received struct {
@@ -28,6 +29,7 @@ type VersionDecoder struct {
 	}
 }
 
+// Decode returns the fake result of the fake VersionDecoder decode execution.
 func (e *VersionDecoder) Decode(jsonData []byte) (version.PluginInfo, error) {
 	e.DecodeCall.Received.JSONBytes = jsonData
 	return e.DecodeCall.Returns.PluginInfo, e.DecodeCall.Returns.Error

--- a/pkg/invoke/raw_exec.go
+++ b/pkg/invoke/raw_exec.go
@@ -24,10 +24,12 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 )
 
+// RawExec implements the PluginExec.RawExec interface.
 type RawExec struct {
 	Stderr io.Writer
 }
 
+// ExecPlugin runs the executable plugin.
 func (e *RawExec) ExecPlugin(pluginPath string, stdinData []byte, environ []string) ([]byte, error) {
 	stdout := &bytes.Buffer{}
 

--- a/pkg/ip/ipforward.go
+++ b/pkg/ip/ipforward.go
@@ -18,10 +18,12 @@ import (
 	"io/ioutil"
 )
 
+// EnableIP4Forward enables IPv4 forwarding
 func EnableIP4Forward() error {
 	return echo1("/proc/sys/net/ipv4/ip_forward")
 }
 
+// EnableIP6Forward enables IPv6 forwarding
 func EnableIP6Forward() error {
 	return echo1("/proc/sys/net/ipv6/conf/all/forwarding")
 }

--- a/pkg/ip/link.go
+++ b/pkg/ip/link.go
@@ -90,6 +90,7 @@ func RandomVethName() (string, error) {
 	return fmt.Sprintf("veth%x", entropy), nil
 }
 
+// RenameLink renames a network link.
 func RenameLink(curName, newName string) error {
 	link, err := netlink.LinkByName(curName)
 	if err == nil {
@@ -172,6 +173,7 @@ func DelLinkByNameAddr(ifName string, family int) (*net.IPNet, error) {
 	return addrs[0].IPNet, nil
 }
 
+// SetHWAddrByIP sets MAC address for an interface link based on net family.
 func SetHWAddrByIP(ifName string, ip4 net.IP, ip6 net.IP) error {
 	iface, err := netlink.LinkByName(ifName)
 	if err != nil {

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -27,16 +27,17 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+// ExecAdd delegates the ADD command execution to a named plugin.
 func ExecAdd(plugin string, netconf []byte) (types.Result, error) {
 	return invoke.DelegateAdd(plugin, netconf)
 }
 
+// ExecDel delegates the DEL command execution to a named plugin.
 func ExecDel(plugin string, netconf []byte) error {
 	return invoke.DelegateDel(plugin, netconf)
 }
 
-// ConfigureIface takes the result of IPAM plugin and
-// applies to the ifName interface
+// ConfigureIface applies the plugin ADD execution result to a named network interface.
 func ConfigureIface(ifName string, res *current.Result) error {
 	if len(res.Interfaces) == 0 {
 		return fmt.Errorf("no interfaces to configure")

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -28,7 +28,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const LINK_NAME = "eth0"
+const LinkName = "eth0"
 
 func ipNetEqual(a, b *net.IPNet) bool {
 	aPrefix, aBits := a.Mask.Size()
@@ -57,11 +57,11 @@ var _ = Describe("IPAM Operations", func() {
 			// Add master
 			err = netlink.LinkAdd(&netlink.Dummy{
 				LinkAttrs: netlink.LinkAttrs{
-					Name: LINK_NAME,
+					Name: LinkName,
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			_, err = netlink.LinkByName(LINK_NAME)
+			_, err = netlink.LinkByName(LinkName)
 			Expect(err).NotTo(HaveOccurred())
 			return nil
 		})
@@ -135,12 +135,12 @@ var _ = Describe("IPAM Operations", func() {
 		err := originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
-			err := ConfigureIface(LINK_NAME, result)
+			err := ConfigureIface(LinkName, result)
 			Expect(err).NotTo(HaveOccurred())
 
-			link, err := netlink.LinkByName(LINK_NAME)
+			link, err := netlink.LinkByName(LinkName)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(link.Attrs().Name).To(Equal(LINK_NAME))
+			Expect(link.Attrs().Name).To(Equal(LinkName))
 
 			v4addrs, err := netlink.AddrList(link, syscall.AF_INET)
 			Expect(err).NotTo(HaveOccurred())
@@ -192,12 +192,12 @@ var _ = Describe("IPAM Operations", func() {
 		err := originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
-			err := ConfigureIface(LINK_NAME, result)
+			err := ConfigureIface(LinkName, result)
 			Expect(err).NotTo(HaveOccurred())
 
-			link, err := netlink.LinkByName(LINK_NAME)
+			link, err := netlink.LinkByName(LinkName)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(link.Attrs().Name).To(Equal(LINK_NAME))
+			Expect(link.Attrs().Name).To(Equal(LinkName))
 
 			// Ensure the v4 route, v6 route, and subnet route
 			routes, err := netlink.RouteList(link, 0)
@@ -228,7 +228,7 @@ var _ = Describe("IPAM Operations", func() {
 	It("returns an error when the interface index doesn't match the link name", func() {
 		result.IPs[0].Interface = 1
 		err := originalNS.Do(func(ns.NetNS) error {
-			return ConfigureIface(LINK_NAME, result)
+			return ConfigureIface(LinkName, result)
 		})
 		Expect(err).To(HaveOccurred())
 	})
@@ -236,7 +236,7 @@ var _ = Describe("IPAM Operations", func() {
 	It("returns an error when the interface index is too big", func() {
 		result.IPs[0].Interface = 2
 		err := originalNS.Do(func(ns.NetNS) error {
-			return ConfigureIface(LINK_NAME, result)
+			return ConfigureIface(LinkName, result)
 		})
 		Expect(err).To(HaveOccurred())
 	})
@@ -244,7 +244,7 @@ var _ = Describe("IPAM Operations", func() {
 	It("returns an error when there are no interfaces to configure", func() {
 		result.Interfaces = []*current.Interface{}
 		err := originalNS.Do(func(ns.NetNS) error {
-			return ConfigureIface(LINK_NAME, result)
+			return ConfigureIface(LinkName, result)
 		})
 		Expect(err).To(HaveOccurred())
 	})

--- a/pkg/ns/ns.go
+++ b/pkg/ns/ns.go
@@ -79,7 +79,7 @@ func GetCurrentNS() (NetNS, error) {
 }
 
 const (
-	// The following are inherited by
+	// The following are inherited from
 	// https://github.com/torvalds/linux/blob/master/include/uapi/linux/magic.h
 	// hence won't follow golint rules for constants.
 	NSFS_MAGIC   = 0x6e736673

--- a/pkg/ns/ns.go
+++ b/pkg/ns/ns.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// NetNS describes network namespace behavior.
 type NetNS interface {
 	// Executes the passed closure in this object's network namespace,
 	// attempting to restore the original namespace before returning.
@@ -72,30 +73,35 @@ func getCurrentThreadNetNSPath() string {
 	return fmt.Sprintf("/proc/%d/task/%d/ns/net", os.Getpid(), unix.Gettid())
 }
 
-// Returns an object representing the current OS thread's network namespace
+// GetCurrentNS returns an object representing the current OS thread's network namespace
 func GetCurrentNS() (NetNS, error) {
 	return GetNS(getCurrentThreadNetNSPath())
 }
 
 const (
+	// The following are inherited by
 	// https://github.com/torvalds/linux/blob/master/include/uapi/linux/magic.h
+	// hence won't follow golint rules for constants.
 	NSFS_MAGIC   = 0x6e736673
 	PROCFS_MAGIC = 0x9fa0
 )
 
-type NSPathNotExistErr struct{ msg string }
+// PathNotExistErr represents a namespace path doesn't exist error.
+type PathNotExistErr struct{ msg string }
 
-func (e NSPathNotExistErr) Error() string { return e.msg }
+func (e PathNotExistErr) Error() string { return e.msg }
 
-type NSPathNotNSErr struct{ msg string }
+// PathNotNSErr represents a namespace path isn't a namespace error.
+type PathNotNSErr struct{ msg string }
 
-func (e NSPathNotNSErr) Error() string { return e.msg }
+func (e PathNotNSErr) Error() string { return e.msg }
 
+// IsNSorErr validates namespace path and return an error if it's invalid.
 func IsNSorErr(nspath string) error {
 	stat := syscall.Statfs_t{}
 	if err := syscall.Statfs(nspath, &stat); err != nil {
 		if os.IsNotExist(err) {
-			err = NSPathNotExistErr{msg: fmt.Sprintf("failed to Statfs %q: %v", nspath, err)}
+			err = PathNotExistErr{msg: fmt.Sprintf("failed to Statfs %q: %v", nspath, err)}
 		} else {
 			err = fmt.Errorf("failed to Statfs %q: %v", nspath, err)
 		}
@@ -106,11 +112,11 @@ func IsNSorErr(nspath string) error {
 	case PROCFS_MAGIC, NSFS_MAGIC:
 		return nil
 	default:
-		return NSPathNotNSErr{msg: fmt.Sprintf("unknown FS magic on %q: %x", nspath, stat.Type)}
+		return PathNotNSErr{msg: fmt.Sprintf("unknown FS magic on %q: %x", nspath, stat.Type)}
 	}
 }
 
-// Returns an object representing the namespace referred to by @path
+// GetNS returns an object representing the namespace referred to by nspath.
 func GetNS(nspath string) (NetNS, error) {
 	err := IsNSorErr(nspath)
 	if err != nil {
@@ -125,8 +131,8 @@ func GetNS(nspath string) (NetNS, error) {
 	return &netNS{file: fd}, nil
 }
 
-// Creates a new persistent network namespace and returns an object
-// representing that namespace, without switching to it
+// NewNS creates a new persistent network namespace and returns an object
+// representing that namespace, without switching to it.
 func NewNS() (NetNS, error) {
 	const nsRunDir = "/var/run/netns"
 

--- a/pkg/ns/ns.go
+++ b/pkg/ns/ns.go
@@ -86,22 +86,22 @@ const (
 	PROCFS_MAGIC = 0x9fa0
 )
 
-// PathNotExistErr represents a namespace path doesn't exist error.
-type PathNotExistErr struct{ msg string }
+// NSPathNotExistErr represents a namespace path doesn't exist error.
+type NSPathNotExistErr struct{ msg string }
 
-func (e PathNotExistErr) Error() string { return e.msg }
+func (e NSPathNotExistErr) Error() string { return e.msg }
 
-// PathNotNSErr represents a namespace path isn't a namespace error.
-type PathNotNSErr struct{ msg string }
+// NSPathNotNSErr represents a namespace path isn't a namespace error.
+type NSPathNotNSErr struct{ msg string }
 
-func (e PathNotNSErr) Error() string { return e.msg }
+func (e NSPathNotNSErr) Error() string { return e.msg }
 
 // IsNSorErr validates namespace path and return an error if it's invalid.
 func IsNSorErr(nspath string) error {
 	stat := syscall.Statfs_t{}
 	if err := syscall.Statfs(nspath, &stat); err != nil {
 		if os.IsNotExist(err) {
-			err = PathNotExistErr{msg: fmt.Sprintf("failed to Statfs %q: %v", nspath, err)}
+			err = NSPathNotExistErr{msg: fmt.Sprintf("failed to Statfs %q: %v", nspath, err)}
 		} else {
 			err = fmt.Errorf("failed to Statfs %q: %v", nspath, err)
 		}
@@ -112,7 +112,7 @@ func IsNSorErr(nspath string) error {
 	case PROCFS_MAGIC, NSFS_MAGIC:
 		return nil
 	default:
-		return PathNotNSErr{msg: fmt.Sprintf("unknown FS magic on %q: %x", nspath, stat.Type)}
+		return NSPathNotNSErr{msg: fmt.Sprintf("unknown FS magic on %q: %x", nspath, stat.Type)}
 	}
 }
 

--- a/pkg/ns/ns_test.go
+++ b/pkg/ns/ns_test.go
@@ -181,8 +181,8 @@ var _ = Describe("Linux namespace operations", func() {
 
 				_, err = ns.GetNS(nspath)
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(BeAssignableToTypeOf(ns.PathNotNSErr{}))
-				Expect(err).NotTo(BeAssignableToTypeOf(ns.PathNotExistErr{}))
+				Expect(err).To(BeAssignableToTypeOf(ns.NSPathNotNSErr{}))
+				Expect(err).NotTo(BeAssignableToTypeOf(ns.NSPathNotExistErr{}))
 			})
 		})
 
@@ -231,15 +231,15 @@ var _ = Describe("Linux namespace operations", func() {
 
 			err = ns.IsNSorErr(nspath)
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(BeAssignableToTypeOf(ns.PathNotNSErr{}))
-			Expect(err).NotTo(BeAssignableToTypeOf(ns.PathNotExistErr{}))
+			Expect(err).To(BeAssignableToTypeOf(ns.NSPathNotNSErr{}))
+			Expect(err).NotTo(BeAssignableToTypeOf(ns.NSPathNotExistErr{}))
 		})
 
 		It("should error on non-existing paths", func() {
 			err := ns.IsNSorErr("/tmp/IDoNotExist")
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(BeAssignableToTypeOf(ns.PathNotExistErr{}))
-			Expect(err).NotTo(BeAssignableToTypeOf(ns.PathNotNSErr{}))
+			Expect(err).To(BeAssignableToTypeOf(ns.NSPathNotExistErr{}))
+			Expect(err).NotTo(BeAssignableToTypeOf(ns.NSPathNotNSErr{}))
 		})
 	})
 })

--- a/pkg/ns/ns_test.go
+++ b/pkg/ns/ns_test.go
@@ -181,8 +181,8 @@ var _ = Describe("Linux namespace operations", func() {
 
 				_, err = ns.GetNS(nspath)
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(BeAssignableToTypeOf(ns.NSPathNotNSErr{}))
-				Expect(err).NotTo(BeAssignableToTypeOf(ns.NSPathNotExistErr{}))
+				Expect(err).To(BeAssignableToTypeOf(ns.PathNotNSErr{}))
+				Expect(err).NotTo(BeAssignableToTypeOf(ns.PathNotExistErr{}))
 			})
 		})
 
@@ -231,15 +231,15 @@ var _ = Describe("Linux namespace operations", func() {
 
 			err = ns.IsNSorErr(nspath)
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(BeAssignableToTypeOf(ns.NSPathNotNSErr{}))
-			Expect(err).NotTo(BeAssignableToTypeOf(ns.NSPathNotExistErr{}))
+			Expect(err).To(BeAssignableToTypeOf(ns.PathNotNSErr{}))
+			Expect(err).NotTo(BeAssignableToTypeOf(ns.PathNotExistErr{}))
 		})
 
 		It("should error on non-existing paths", func() {
 			err := ns.IsNSorErr("/tmp/IDoNotExist")
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(BeAssignableToTypeOf(ns.NSPathNotExistErr{}))
-			Expect(err).NotTo(BeAssignableToTypeOf(ns.NSPathNotNSErr{}))
+			Expect(err).To(BeAssignableToTypeOf(ns.PathNotExistErr{}))
+			Expect(err).NotTo(BeAssignableToTypeOf(ns.PathNotNSErr{}))
 		})
 	})
 })

--- a/pkg/testutils/bad_reader.go
+++ b/pkg/testutils/bad_reader.go
@@ -16,11 +16,12 @@ package testutils
 
 import "errors"
 
-// BadReader is an io.Reader which always errors
+// BadReader is an io.Reader which always errors.
 type BadReader struct {
 	Error error
 }
 
+// Read always errors.
 func (r *BadReader) Read(buffer []byte) (int, error) {
 	if r.Error != nil {
 		return 0, r.Error
@@ -28,6 +29,7 @@ func (r *BadReader) Read(buffer []byte) (int, error) {
 	return 0, errors.New("banana")
 }
 
+// Close is a no-op.
 func (r *BadReader) Close() error {
 	return nil
 }

--- a/pkg/testutils/cmd.go
+++ b/pkg/testutils/cmd.go
@@ -29,6 +29,7 @@ func envCleanup() {
 	os.Unsetenv("CNI_IFNAME")
 }
 
+// CmdAddWithResult runs ADD and returns the result.
 func CmdAddWithResult(cniNetns, cniIfname string, conf []byte, f func() error) (types.Result, []byte, error) {
 	os.Setenv("CNI_COMMAND", "ADD")
 	os.Setenv("CNI_PATH", os.Getenv("PATH"))
@@ -72,6 +73,7 @@ func CmdAddWithResult(cniNetns, cniIfname string, conf []byte, f func() error) (
 	return result, out, nil
 }
 
+// CmdDelWithResult runs DEL and returns the result.
 func CmdDelWithResult(cniNetns, cniIfname string, f func() error) error {
 	os.Setenv("CNI_COMMAND", "DEL")
 	os.Setenv("CNI_PATH", os.Getenv("PATH"))

--- a/pkg/types/020/types.go
+++ b/pkg/types/020/types.go
@@ -25,10 +25,12 @@ import (
 
 const implementedSpecVersion string = "0.2.0"
 
+// SupportedVersions contains all the supported versions.
 var SupportedVersions = []string{"", "0.1.0", implementedSpecVersion}
 
 // Compatibility types for CNI version 0.1.0 and 0.2.0
 
+// NewResult loads a new result from a JSON byte array.
 func NewResult(data []byte) (types.Result, error) {
 	result := &Result{}
 	if err := json.Unmarshal(data, result); err != nil {
@@ -37,6 +39,7 @@ func NewResult(data []byte) (types.Result, error) {
 	return result, nil
 }
 
+// GetResult converts and returns the result.
 func GetResult(r types.Result) (*Result, error) {
 	// We expect version 0.1.0/0.2.0 results
 	result020, err := r.GetAsVersion(implementedSpecVersion)
@@ -50,17 +53,19 @@ func GetResult(r types.Result) (*Result, error) {
 	return result, nil
 }
 
-// Result is what gets returned from the plugin (via stdout) to the caller
+// Result is what gets returned from the plugin (via stdout) to the caller.
 type Result struct {
 	IP4 *IPConfig `json:"ip4,omitempty"`
 	IP6 *IPConfig `json:"ip6,omitempty"`
 	DNS types.DNS `json:"dns,omitempty"`
 }
 
+// Version returns the currently implemented version.
 func (r *Result) Version() string {
 	return implementedSpecVersion
 }
 
+// GetAsVersion makes sure the result has a supported version.
 func (r *Result) GetAsVersion(version string) (types.Result, error) {
 	for _, supportedVersion := range SupportedVersions {
 		if version == supportedVersion {
@@ -70,6 +75,7 @@ func (r *Result) GetAsVersion(version string) (types.Result, error) {
 	return nil, fmt.Errorf("cannot convert version %q to %s", SupportedVersions, version)
 }
 
+// Print prints the result to stdout.
 func (r *Result) Print() error {
 	data, err := json.MarshalIndent(r, "", "    ")
 	if err != nil {
@@ -110,6 +116,7 @@ type ipConfig struct {
 	Routes  []types.Route `json:"routes,omitempty"`
 }
 
+// MarshalJSON marshals an IPConfig to a JSON byte array.
 func (c *IPConfig) MarshalJSON() ([]byte, error) {
 	ipc := ipConfig{
 		IP:      types.IPNet(c.IP),
@@ -120,6 +127,7 @@ func (c *IPConfig) MarshalJSON() ([]byte, error) {
 	return json.Marshal(ipc)
 }
 
+// UnmarshalJSON unmarshals an IPConfig from a JSON byte array.
 func (c *IPConfig) UnmarshalJSON(data []byte) error {
 	ipc := ipConfig{}
 	if err := json.Unmarshal(data, &ipc); err != nil {

--- a/pkg/types/args.go
+++ b/pkg/types/args.go
@@ -57,13 +57,13 @@ type CommonArgs struct {
 	IgnoreUnknown UnmarshallableBool `json:"ignoreunknown,omitempty"`
 }
 
-// GetKeyField is a helper function to receive Values
-// Values that represent a pointer to a struct
+// GetKeyField is a helper function to receive values that represent a pointer
+// to a struct.
 func GetKeyField(keyString string, v reflect.Value) reflect.Value {
 	return v.Elem().FieldByName(keyString)
 }
 
-// LoadArgs parses args from a string in the form "K=V;K2=V2;..."
+// LoadArgs parses args from a string in the form "K=V;K2=V2;...".
 func LoadArgs(args string, container interface{}) error {
 	if args == "" {
 		return nil

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -21,11 +21,11 @@ import (
 	"os"
 )
 
-// like net.IPNet but adds JSON marshalling and unmarshalling
+// IPNet is like net.IPNet but adds JSON marshalling and unmarshalling.
 type IPNet net.IPNet
 
 // ParseCIDR takes a string like "10.2.3.1/24" and
-// return IPNet with "10.2.3.1" and /24 mask
+// returns IPNet with "10.2.3.1" and /24 mask.
 func ParseCIDR(s string) (*net.IPNet, error) {
 	ip, ipn, err := net.ParseCIDR(s)
 	if err != nil {
@@ -36,10 +36,12 @@ func ParseCIDR(s string) (*net.IPNet, error) {
 	return ipn, nil
 }
 
+// MarshalJSON returns the JSON encoding for IPNet.
 func (n IPNet) MarshalJSON() ([]byte, error) {
 	return json.Marshal((*net.IPNet)(&n).String())
 }
 
+// UnmarshalJSON unmarshals a JSON-encoded IPNet.
 func (n *IPNet) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
@@ -75,6 +77,7 @@ type NetConfList struct {
 	Plugins []*NetConf `json:"plugins,omitempty"`
 }
 
+// ResultFactoryFunc represents a Result factory function.
 type ResultFactoryFunc func([]byte) (Result, error)
 
 // Result is an interface that provides the result of plugin execution
@@ -94,6 +97,7 @@ type Result interface {
 	String() string
 }
 
+// PrintResult prints the result in JSON format.
 func PrintResult(result Result, version string) error {
 	newResult, err := result.GetAsVersion(version)
 	if err != nil {
@@ -110,11 +114,13 @@ type DNS struct {
 	Options     []string `json:"options,omitempty"`
 }
 
+// Route represents a routing table entry
 type Route struct {
 	Dst net.IPNet
 	GW  net.IP
 }
 
+// String prints a route.
 func (r *Route) String() string {
 	return fmt.Sprintf("%+v", *r)
 }
@@ -127,16 +133,19 @@ const (
 	ErrUnsupportedField                   // 2
 )
 
+// Error encapsulates a structured error message.
 type Error struct {
 	Code    uint   `json:"code"`
 	Msg     string `json:"msg"`
 	Details string `json:"details,omitempty"`
 }
 
+// Error prints the error message.
 func (e *Error) Error() string {
 	return e.Msg
 }
 
+// Print pretty prints the error message.
 func (e *Error) Print() error {
 	return prettyPrint(e)
 }
@@ -150,6 +159,7 @@ type route struct {
 	GW  net.IP `json:"gw,omitempty"`
 }
 
+// UnmarshalJSON unmarshals a JSON-encoded Route.
 func (r *Route) UnmarshalJSON(data []byte) error {
 	rt := route{}
 	if err := json.Unmarshal(data, &rt); err != nil {
@@ -161,6 +171,7 @@ func (r *Route) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON returns the JSON encoding for Route.
 func (r *Route) MarshalJSON() ([]byte, error) {
 	rt := route{
 		Dst: IPNet(r.Dst),

--- a/pkg/utils/hwaddr/hwaddr.go
+++ b/pkg/utils/hwaddr/hwaddr.go
@@ -31,10 +31,10 @@ var (
 	PrivateMACPrefix = []byte{0x0a, 0x58}
 )
 
-// SupportIP4OnlyErr represents an only IPv4 is supported error.
-type SupportIP4OnlyErr struct{ msg string }
+// SupportIp4OnlyErr represents an only IPv4 is supported error.
+type SupportIp4OnlyErr struct{ msg string }
 
-func (e SupportIP4OnlyErr) Error() string { return e.msg }
+func (e SupportIp4OnlyErr) Error() string { return e.msg }
 
 // MacParseErr represents a parse MAC address error.
 type MacParseErr struct{ msg string }
@@ -51,7 +51,7 @@ func GenerateHardwareAddr4(ip net.IP, prefix []byte) (net.HardwareAddr, error) {
 	switch {
 
 	case ip.To4() == nil:
-		return nil, SupportIP4OnlyErr{msg: "GenerateHardwareAddr4 only supports valid IPv4 address as input"}
+		return nil, SupportIp4OnlyErr{msg: "GenerateHardwareAddr4 only supports valid IPv4 address as input"}
 
 	case len(prefix) != len(PrivateMACPrefix):
 		return nil, InvalidPrefixLengthErr{msg: fmt.Sprintf(

--- a/pkg/utils/hwaddr/hwaddr.go
+++ b/pkg/utils/hwaddr/hwaddr.go
@@ -20,23 +20,28 @@ import (
 )
 
 const (
-	ipRelevantByteLen      = 4
+	ipRelevantByteLen = 4
+
+	// PrivateMACPrefixString represents a private mac prefix that is safe to use.
 	PrivateMACPrefixString = "0a:58"
 )
 
 var (
-	// private mac prefix safe to use
+	// PrivateMACPrefix represents a private mac prefix that is safe to use.
 	PrivateMACPrefix = []byte{0x0a, 0x58}
 )
 
-type SupportIp4OnlyErr struct{ msg string }
+// SupportIP4OnlyErr represents an only IPv4 is supported error.
+type SupportIP4OnlyErr struct{ msg string }
 
-func (e SupportIp4OnlyErr) Error() string { return e.msg }
+func (e SupportIP4OnlyErr) Error() string { return e.msg }
 
+// MacParseErr represents a parse MAC address error.
 type MacParseErr struct{ msg string }
 
 func (e MacParseErr) Error() string { return e.msg }
 
+// InvalidPrefixLengthErr represents an invalid prefix length error.
 type InvalidPrefixLengthErr struct{ msg string }
 
 func (e InvalidPrefixLengthErr) Error() string { return e.msg }
@@ -46,7 +51,7 @@ func GenerateHardwareAddr4(ip net.IP, prefix []byte) (net.HardwareAddr, error) {
 	switch {
 
 	case ip.To4() == nil:
-		return nil, SupportIp4OnlyErr{msg: "GenerateHardwareAddr4 only supports valid IPv4 address as input"}
+		return nil, SupportIP4OnlyErr{msg: "GenerateHardwareAddr4 only supports valid IPv4 address as input"}
 
 	case len(prefix) != len(PrivateMACPrefix):
 		return nil, InvalidPrefixLengthErr{msg: fmt.Sprintf(

--- a/pkg/utils/hwaddr/hwaddr_test.go
+++ b/pkg/utils/hwaddr/hwaddr_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Hwaddr", func() {
 			}
 			for _, tc := range testCases {
 				_, err := hwaddr.GenerateHardwareAddr4(tc, hwaddr.PrivateMACPrefix)
-				Expect(err).To(BeAssignableToTypeOf(hwaddr.SupportIP4OnlyErr{}))
+				Expect(err).To(BeAssignableToTypeOf(hwaddr.SupportIp4OnlyErr{}))
 			}
 		})
 

--- a/pkg/utils/hwaddr/hwaddr_test.go
+++ b/pkg/utils/hwaddr/hwaddr_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Hwaddr", func() {
 			}
 			for _, tc := range testCases {
 				_, err := hwaddr.GenerateHardwareAddr4(tc, hwaddr.PrivateMACPrefix)
-				Expect(err).To(BeAssignableToTypeOf(hwaddr.SupportIp4OnlyErr{}))
+				Expect(err).To(BeAssignableToTypeOf(hwaddr.SupportIP4OnlyErr{}))
 			}
 		})
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -25,17 +25,17 @@ const (
 	prefixLength   = len(chainPrefix)
 )
 
-// Generates a chain name to be used with iptables.
-// Ensures that the generated chain name is exactly
-// maxChainLength chars in length
+// FormatChainName generates a chain name to be used with iptables.
+// It ensures that the generated chain name is exactly maxChainLength chars in
+// length.
 func FormatChainName(name string, id string) string {
 	chainBytes := sha512.Sum512([]byte(name + id))
 	chain := fmt.Sprintf("%s%x", chainPrefix, chainBytes)
 	return chain[:maxChainLength]
 }
 
-// FormatComment returns a comment used for easier
-// rule identification within iptables.
+// FormatComment returns a comment used for easier rule identification within
+// iptables.
 func FormatComment(name string, id string) string {
 	return fmt.Sprintf("name: %q id: %q", name, id)
 }

--- a/pkg/version/conf.go
+++ b/pkg/version/conf.go
@@ -19,9 +19,10 @@ import (
 	"fmt"
 )
 
-// ConfigDecoder can decode the CNI version available in network config data
+// ConfigDecoder can decode the CNI version available in network config data.
 type ConfigDecoder struct{}
 
+// Decode unmarshalls a ConfigDecoder from a JSON byte array.
 func (*ConfigDecoder) Decode(jsonBytes []byte) (string, error) {
 	var conf struct {
 		CNIVersion string `json:"cniVersion"`

--- a/pkg/version/legacyexamples/example_runtime.go
+++ b/pkg/version/legacyexamples/example_runtime.go
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package legacy_examples
+package legacyexamples
 
-// An ExampleRuntime is a small program that uses libcni to invoke a network plugin.
+// ExampleRuntime is a small program that uses libcni to invoke a network plugin.
 // It should call ADD and DELETE, verifying all intermediate steps
 // and data structures.
 type ExampleRuntime struct {
@@ -23,7 +23,7 @@ type ExampleRuntime struct {
 }
 
 // NetConfs are various versioned network configuration files. Examples should
-// specify which version they expect
+// specify which version they expect.
 var NetConfs = map[string]string{
 	"unversioned": `{
 	"name": "default",
@@ -44,9 +44,9 @@ var NetConfs = map[string]string{
 }`,
 }
 
-// V010_Runtime creates a simple ptp network configuration, then
+// V010Runtime creates a simple ptp network configuration, then
 // executes libcni against the currently-built plugins.
-var V010_Runtime = ExampleRuntime{
+var V010Runtime = ExampleRuntime{
 	NetConfs: []string{"unversioned", "0.1.0"},
 	Example: Example{
 		Name:          "example_invoker_v010",

--- a/pkg/version/legacyexamples/examples.go
+++ b/pkg/version/legacyexamples/examples.go
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package legacy_examples contains sample code from prior versions of
+// Package legacyexamples contains sample code from prior versions of
 // the CNI library, for use in verifying backwards compatibility.
-package legacy_examples
+package legacyexamples
 
 import (
 	"io/ioutil"

--- a/pkg/version/legacyexamples/legacy_examples_suite_test.go
+++ b/pkg/version/legacyexamples/legacy_examples_suite_test.go
@@ -12,25 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package legacy_examples_test
+package legacyexamples_test
 
 import (
-	"os"
-	"path/filepath"
-
-	"github.com/containernetworking/cni/pkg/version/legacy_examples"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"testing"
 )
 
-var _ = Describe("The v0.1.0 Example", func() {
-	It("builds ok", func() {
-		example := legacy_examples.V010
-		pluginPath, err := example.Build()
-		Expect(err).NotTo(HaveOccurred())
-
-		Expect(filepath.Base(pluginPath)).To(Equal(example.Name))
-
-		Expect(os.RemoveAll(pluginPath)).To(Succeed())
-	})
-})
+func TestLegacyExamples(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "LegacyExamples Suite")
+}

--- a/pkg/version/legacyexamples/legacy_examples_test.go
+++ b/pkg/version/legacyexamples/legacy_examples_test.go
@@ -12,16 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package legacy_examples_test
+package legacyexamples_test
 
 import (
+	"os"
+	"path/filepath"
+
+	"github.com/containernetworking/cni/pkg/version/legacy_examples"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
-func TestLegacyExamples(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "LegacyExamples Suite")
-}
+var _ = Describe("The v0.1.0 Example", func() {
+	It("builds ok", func() {
+		example := legacy_examples.V010
+		pluginPath, err := example.Build()
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(filepath.Base(pluginPath)).To(Equal(example.Name))
+
+		Expect(os.RemoveAll(pluginPath)).To(Succeed())
+	})
+})

--- a/pkg/version/plugin.go
+++ b/pkg/version/plugin.go
@@ -48,7 +48,7 @@ func (p *pluginInfo) SupportedVersions() []string {
 }
 
 // PluginSupports returns a new PluginInfo that will report the given versions
-// as supported
+// as supported.
 func PluginSupports(supportedVersions ...string) PluginInfo {
 	if len(supportedVersions) < 1 {
 		panic("programmer error: you must support at least one version")
@@ -62,6 +62,7 @@ func PluginSupports(supportedVersions ...string) PluginInfo {
 // PluginDecoder can decode the response returned by a plugin's VERSION command
 type PluginDecoder struct{}
 
+// Decode unmarshalls a PluginDecoder from a JSON byte array.
 func (*PluginDecoder) Decode(jsonBytes []byte) (PluginInfo, error) {
 	var info pluginInfo
 	err := json.Unmarshal(jsonBytes, &info)

--- a/pkg/version/reconcile.go
+++ b/pkg/version/reconcile.go
@@ -16,25 +16,31 @@ package version
 
 import "fmt"
 
+// ErrorIncompatible represents a rich plugin incompatibility error.
 type ErrorIncompatible struct {
 	Config    string
 	Supported []string
 }
 
+// Details prints the erroneous configuration and the supported configuration of the plugin in use.
 func (e *ErrorIncompatible) Details() string {
 	return fmt.Sprintf("config is %q, plugin supports %q", e.Config, e.Supported)
 }
 
+// Error prints a rich plugin incompatibility error message.
 func (e *ErrorIncompatible) Error() string {
 	return fmt.Sprintf("incompatible CNI versions: %s", e.Details())
 }
 
+// Reconciler represents a plug-in configuration validator.
 type Reconciler struct{}
 
+// Check checks if a supported configuration version is in place.
 func (r *Reconciler) Check(configVersion string, pluginInfo PluginInfo) *ErrorIncompatible {
 	return r.CheckRaw(configVersion, pluginInfo.SupportedVersions())
 }
 
+// CheckRaw checks if a supported configuration version is in place.
 func (*Reconciler) CheckRaw(configVersion string, supportedVersions []string) *ErrorIncompatible {
 	for _, supportedVersion := range supportedVersions {
 		if configVersion == supportedVersion {

--- a/pkg/version/testhelpers/testhelpers.go
+++ b/pkg/version/testhelpers/testhelpers.go
@@ -80,6 +80,7 @@ func isRepoRoot(path string) bool {
 	return (err == nil) && (filepath.Base(path) == "cni")
 }
 
+// LocateCurrentGitRepo locates the current repository working directory.
 func LocateCurrentGitRepo() (string, error) {
 	dir, err := os.Getwd()
 	if err != nil {

--- a/pkg/version/testhelpers/testhelpers_test.go
+++ b/pkg/version/testhelpers/testhelpers_test.go
@@ -68,7 +68,7 @@ func main() { skel.PluginMain(c, c) }
 	})
 })
 
-var _ = Describe("LocateCurrentGitRepo", func() {
+var _ = Describe("locateCurrentGitRepo", func() {
 	It("returns the path to the root of the CNI git repo", func() {
 		path, err := testhelpers.LocateCurrentGitRepo()
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -35,6 +35,8 @@ func Current() string {
 // Any future CNI spec versions which meet this definition should be added to
 // this list.
 var Legacy = PluginSupports("0.1.0", "0.2.0")
+
+// All PluginInfo describes a plugin that is compatible all CNI spec versios.
 var All = PluginSupports("0.1.0", "0.2.0", "0.3.0")
 
 var resultFactories = []struct {
@@ -45,7 +47,7 @@ var resultFactories = []struct {
 	{types020.SupportedVersions, types020.NewResult},
 }
 
-// Finds a Result object matching the requested version (if any) and asks
+// NewResult finds a Result object matching the requested version (if any) and asks
 // that object to parse the plugin result, returning an error if parsing failed.
 func NewResult(version string, resultBytes []byte) (types.Result, error) {
 	reconciler := &Reconciler{}

--- a/plugins/ipam/dhcp/daemon.go
+++ b/plugins/ipam/dhcp/daemon.go
@@ -38,6 +38,7 @@ const resendCount = 3
 
 var errNoMoreTries = errors.New("no more tries")
 
+// DHCP represents a DHCP client daemon.
 type DHCP struct {
 	mux    sync.Mutex
 	leases map[string]*DHCPLease

--- a/plugins/ipam/host-local/backend/allocator/allocator.go
+++ b/plugins/ipam/host-local/backend/allocator/allocator.go
@@ -25,6 +25,7 @@ import (
 	"github.com/containernetworking/cni/plugins/ipam/host-local/backend"
 )
 
+// IPAllocator represents a mechanism for IP allocation.
 type IPAllocator struct {
 	// start is inclusive and may be allocated
 	start net.IP
@@ -34,6 +35,7 @@ type IPAllocator struct {
 	store backend.Store
 }
 
+// NewIPAllocator returns an IPAllocator from configuration.
 func NewIPAllocator(conf *IPAMConfig, store backend.Store) (*IPAllocator, error) {
 	// Can't create an allocator for a network with no addresses, eg
 	// a /32 or /31
@@ -129,7 +131,7 @@ func validateRangeIP(ip net.IP, ipnet *net.IPNet, start net.IP, end net.IP) erro
 	return nil
 }
 
-// Returns newly allocated IP along with its config
+// Get returns a newly allocated IP along with its config.
 func (a *IPAllocator) Get(id string) (*current.IPConfig, []*types.Route, error) {
 	a.store.Lock()
 	defer a.store.Unlock()
@@ -203,7 +205,7 @@ func (a *IPAllocator) Get(id string) (*current.IPConfig, []*types.Route, error) 
 	return nil, nil, fmt.Errorf("no IP addresses available in network: %s", a.conf.Name)
 }
 
-// Releases all IPs allocated for the container with given ID
+// Release releases all IPs allocated for the container with given ID.
 func (a *IPAllocator) Release(id string) error {
 	a.store.Lock()
 	defer a.store.Unlock()
@@ -212,7 +214,7 @@ func (a *IPAllocator) Release(id string) error {
 }
 
 // Return the start and end IP addresses of a given subnet, excluding
-// the broadcast address (eg, 192.168.1.255)
+// the broadcast address (eg, 192.168.1.255).
 func networkRange(ipnet *net.IPNet) (net.IP, net.IP, error) {
 	if ipnet.IP == nil {
 		return nil, nil, fmt.Errorf("missing field %q in IPAM configuration", "subnet")

--- a/plugins/ipam/host-local/backend/allocator/config.go
+++ b/plugins/ipam/host-local/backend/allocator/config.go
@@ -36,18 +36,20 @@ type IPAMConfig struct {
 	Args       *IPAMArgs     `json:"-"`
 }
 
+// IPAMArgs represents the args for the specified plugin.
 type IPAMArgs struct {
 	types.CommonArgs
 	IP net.IP `json:"ip,omitempty"`
 }
 
+// Net encapsulates configuration for an IP network.
 type Net struct {
 	Name       string      `json:"name"`
 	CNIVersion string      `json:"cniVersion"`
 	IPAM       *IPAMConfig `json:"ipam"`
 }
 
-// NewIPAMConfig creates a NetworkConfig from the given network name.
+// LoadIPAMConfig creates a NetworkConfig from the given network name.
 func LoadIPAMConfig(bytes []byte, args string) (*IPAMConfig, string, error) {
 	n := Net{}
 	if err := json.Unmarshal(bytes, &n); err != nil {

--- a/plugins/ipam/host-local/backend/disk/backend.go
+++ b/plugins/ipam/host-local/backend/disk/backend.go
@@ -29,6 +29,7 @@ const lastIPFile = "last_reserved_ip"
 
 var defaultDataDir = "/var/lib/cni/networks"
 
+// Store contains the information for file operations
 type Store struct {
 	FileLock
 	dataDir string
@@ -37,6 +38,7 @@ type Store struct {
 // Store implements the Store interface
 var _ backend.Store = &Store{}
 
+// New creates a new store.
 func New(network, dataDir string) (*Store, error) {
 	if dataDir == "" {
 		dataDir = defaultDataDir
@@ -53,6 +55,7 @@ func New(network, dataDir string) (*Store, error) {
 	return &Store{*lk, dir}, nil
 }
 
+// Reserve reserves the given IP address, associated with the given id.
 func (s *Store) Reserve(id string, ip net.IP) (bool, error) {
 	fname := filepath.Join(s.dataDir, ip.String())
 	f, err := os.OpenFile(fname, os.O_RDWR|os.O_EXCL|os.O_CREATE, 0644)
@@ -90,10 +93,12 @@ func (s *Store) LastReservedIP() (net.IP, error) {
 	return net.ParseIP(string(data)), nil
 }
 
+// Release removes any existing reservation of the given IP address.
 func (s *Store) Release(ip net.IP) error {
 	return os.Remove(filepath.Join(s.dataDir, ip.String()))
 }
 
+// ReleaseByID is like Release but through the parameter id
 // N.B. This function eats errors to be tolerant and
 // release as much as possible
 func (s *Store) ReleaseByID(id string) error {

--- a/plugins/ipam/host-local/backend/store.go
+++ b/plugins/ipam/host-local/backend/store.go
@@ -16,6 +16,7 @@ package backend
 
 import "net"
 
+// Store defines a collection of IP allocation operations.
 type Store interface {
 	Lock() error
 	Unlock() error

--- a/plugins/ipam/host-local/backend/testing/fake_store.go
+++ b/plugins/ipam/host-local/backend/testing/fake_store.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containernetworking/cni/plugins/ipam/host-local/backend"
 )
 
+// FakeStore represents a fake store.
 type FakeStore struct {
 	ipMap          map[string]string
 	lastReservedIP net.IP
@@ -28,22 +29,27 @@ type FakeStore struct {
 // FakeStore implements the Store interface
 var _ backend.Store = &FakeStore{}
 
+// NewFakeStore returns a new fake store.
 func NewFakeStore(ipmap map[string]string, lastIP net.IP) *FakeStore {
 	return &FakeStore{ipmap, lastIP}
 }
 
+// Lock is a no-op.
 func (s *FakeStore) Lock() error {
 	return nil
 }
 
+// Unlock is a no-op.
 func (s *FakeStore) Unlock() error {
 	return nil
 }
 
+// Close is a no-op.
 func (s *FakeStore) Close() error {
 	return nil
 }
 
+// Reserve reserves an IP in the fake store.
 func (s *FakeStore) Reserve(id string, ip net.IP) (bool, error) {
 	key := ip.String()
 	if _, ok := s.ipMap[key]; !ok {
@@ -54,15 +60,18 @@ func (s *FakeStore) Reserve(id string, ip net.IP) (bool, error) {
 	return false, nil
 }
 
+// LastReservedIP returns last reserved IP in the fake store.
 func (s *FakeStore) LastReservedIP() (net.IP, error) {
 	return s.lastReservedIP, nil
 }
 
+// Release releases all IPs in the fake store.
 func (s *FakeStore) Release(ip net.IP) error {
 	delete(s.ipMap, ip.String())
 	return nil
 }
 
+// ReleaseByID releases an IP identified by id, in the fake store.
 func (s *FakeStore) ReleaseByID(id string) error {
 	toDelete := []string{}
 	for k, v := range s.ipMap {

--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -35,6 +35,7 @@ import (
 
 const defaultBrName = "cni0"
 
+// NetConf contains configurations for creating a bridge
 type NetConf struct {
 	types.NetConf
 	BrName       string `json:"bridge"`

--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -408,9 +408,9 @@ var _ = Describe("bridge Operations", func() {
 	})
 
 	It("ensure bridge address", func() {
-		const IFNAME = "bridge0"
-		const EXPECTED_IP = "10.0.0.0/8"
-		const CHANGED_EXPECTED_IP = "10.1.2.3/16"
+		const IfName = "bridge0"
+		const ExpectedIP = "10.0.0.0/8"
+		const ChangedExpectedIP = "10.1.2.3/16"
 
 		conf := &NetConf{
 			NetConf: types.NetConf{
@@ -418,7 +418,7 @@ var _ = Describe("bridge Operations", func() {
 				Name:       "testConfig",
 				Type:       "bridge",
 			},
-			BrName: IFNAME,
+			BrName: IfName,
 			IsGW:   true,
 			IPMasq: false,
 			MTU:    5000,
@@ -449,7 +449,7 @@ var _ = Describe("bridge Operations", func() {
 			addrs, err := netlink.AddrList(bridge, syscall.AF_INET)
 			Expect(len(addrs)).To(Equal(1))
 			addr := addrs[0].IPNet.String()
-			Expect(addr).To(Equal(EXPECTED_IP))
+			Expect(addr).To(Equal(ExpectedIP))
 
 			//The bridge IP address has been changed. Error expected when ForceAddress is set to false.
 			err = ensureBridgeAddr(bridge, gwnSecond, false)
@@ -459,7 +459,7 @@ var _ = Describe("bridge Operations", func() {
 			addrs, err = netlink.AddrList(bridge, syscall.AF_INET)
 			Expect(len(addrs)).To(Equal(1))
 			addr = addrs[0].IPNet.String()
-			Expect(addr).To(Equal(EXPECTED_IP))
+			Expect(addr).To(Equal(ExpectedIP))
 
 			//Reconfigure IP when ForceAddress is set to true and IP address has been changed.
 			err = ensureBridgeAddr(bridge, gwnSecond, true)
@@ -469,7 +469,7 @@ var _ = Describe("bridge Operations", func() {
 			addrs, err = netlink.AddrList(bridge, syscall.AF_INET)
 			Expect(len(addrs)).To(Equal(1))
 			addr = addrs[0].IPNet.String()
-			Expect(addr).To(Equal(CHANGED_EXPECTED_IP))
+			Expect(addr).To(Equal(ChangedExpectedIP))
 
 			return nil
 		})

--- a/plugins/main/ipvlan/ipvlan.go
+++ b/plugins/main/ipvlan/ipvlan.go
@@ -30,6 +30,7 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+// NetConf contains configurations for creating an ipvlan
 type NetConf struct {
 	types.NetConf
 	Master string `json:"master"`

--- a/plugins/main/ipvlan/ipvlan_test.go
+++ b/plugins/main/ipvlan/ipvlan_test.go
@@ -31,7 +31,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const MASTER_NAME = "eth0"
+const MasterName = "eth0"
 
 var _ = Describe("ipvlan Operations", func() {
 	var originalNS ns.NetNS
@@ -48,11 +48,11 @@ var _ = Describe("ipvlan Operations", func() {
 			// Add master
 			err = netlink.LinkAdd(&netlink.Dummy{
 				LinkAttrs: netlink.LinkAttrs{
-					Name: MASTER_NAME,
+					Name: MasterName,
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			_, err = netlink.LinkByName(MASTER_NAME)
+			_, err = netlink.LinkByName(MasterName)
 			Expect(err).NotTo(HaveOccurred())
 			return nil
 		})
@@ -70,7 +70,7 @@ var _ = Describe("ipvlan Operations", func() {
 				Name:       "testConfig",
 				Type:       "ipvlan",
 			},
-			Master: MASTER_NAME,
+			Master: MasterName,
 			Mode:   "l2",
 			MTU:    1500,
 		}
@@ -114,7 +114,7 @@ var _ = Describe("ipvlan Operations", func() {
         "type": "host-local",
         "subnet": "10.1.2.0/24"
     }
-}`, MASTER_NAME)
+}`, MasterName)
 
 		targetNs, err := ns.NewNS()
 		Expect(err).NotTo(HaveOccurred())

--- a/plugins/main/macvlan/macvlan.go
+++ b/plugins/main/macvlan/macvlan.go
@@ -33,9 +33,11 @@ import (
 )
 
 const (
+	// IPv4InterfaceArpProxySysctlTemplate is a template string for a sysctl entry.
 	IPv4InterfaceArpProxySysctlTemplate = "net.ipv4.conf.%s.proxy_arp"
 )
 
+// NetConf contains configurations for creating a macvlan
 type NetConf struct {
 	types.NetConf
 	Master string `json:"master"`

--- a/plugins/main/macvlan/macvlan_test.go
+++ b/plugins/main/macvlan/macvlan_test.go
@@ -32,7 +32,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const MASTER_NAME = "eth0"
+const MasterName = "eth0"
 
 var _ = Describe("macvlan Operations", func() {
 	var originalNS ns.NetNS
@@ -49,11 +49,11 @@ var _ = Describe("macvlan Operations", func() {
 			// Add master
 			err = netlink.LinkAdd(&netlink.Dummy{
 				LinkAttrs: netlink.LinkAttrs{
-					Name: MASTER_NAME,
+					Name: MasterName,
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			_, err = netlink.LinkByName(MASTER_NAME)
+			_, err = netlink.LinkByName(MasterName)
 			Expect(err).NotTo(HaveOccurred())
 			return nil
 		})
@@ -71,7 +71,7 @@ var _ = Describe("macvlan Operations", func() {
 				Name:       "testConfig",
 				Type:       "macvlan",
 			},
-			Master: MASTER_NAME,
+			Master: MasterName,
 			Mode:   "bridge",
 			MTU:    1500,
 		}
@@ -113,7 +113,7 @@ var _ = Describe("macvlan Operations", func() {
         "type": "host-local",
         "subnet": "10.1.2.0/24"
     }
-}`, MASTER_NAME)
+}`, MasterName)
 
 		targetNs, err := ns.NewNS()
 		Expect(err).NotTo(HaveOccurred())

--- a/plugins/main/ptp/ptp.go
+++ b/plugins/main/ptp/ptp.go
@@ -41,6 +41,7 @@ func init() {
 	runtime.LockOSThread()
 }
 
+// NetConf contains configurations for ptp plugin
 type NetConf struct {
 	types.NetConf
 	IPMasq bool `json:"ipMasq"`

--- a/plugins/meta/flannel/flannel.go
+++ b/plugins/meta/flannel/flannel.go
@@ -40,6 +40,7 @@ const (
 	defaultDataDir    = "/var/lib/cni/flannel"
 )
 
+// NetConf contains configurations for flannel plugin
 type NetConf struct {
 	types.NetConf
 	SubnetFile string                 `json:"subnetFile"`

--- a/plugins/test/noop/debug/debug.go
+++ b/plugins/test/noop/debug/debug.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// debug supports tests that use the noop plugin
+// Package debug supports tests that use the noop plugin
 package debug
 
 import (
@@ -22,6 +22,7 @@ import (
 	"github.com/containernetworking/cni/pkg/skel"
 )
 
+// EmptyReportResultMessage represents a usage message.
 const EmptyReportResultMessage = "set debug.ReportResult and call debug.WriteDebug() before calling this plugin"
 
 // Debug is used to control and record the behavior of the noop plugin

--- a/plugins/test/noop/main.go
+++ b/plugins/test/noop/main.go
@@ -36,14 +36,14 @@ import (
 	noop_debug "github.com/containernetworking/cni/plugins/test/noop/debug"
 )
 
-type NetConf struct {
+type netConf struct {
 	types.NetConf
 	DebugFile  string          `json:"debugFile"`
 	PrevResult *current.Result `json:"prevResult,omitempty"`
 }
 
-func loadConf(bytes []byte) (*NetConf, error) {
-	n := &NetConf{}
+func loadConf(bytes []byte) (*netConf, error) {
+	n := &netConf{}
 	if err := json.Unmarshal(bytes, n); err != nil {
 		return nil, fmt.Errorf("failed to load netconf: %v %q", err, string(bytes))
 	}
@@ -68,7 +68,7 @@ func parseExtraArgs(args string) (map[string]string, error) {
 	return m, nil
 }
 
-func getConfig(stdinData []byte, args string) (string, *NetConf, error) {
+func getConfig(stdinData []byte, args string) (string, *netConf, error) {
 	netConf, err := loadConf(stdinData)
 	if err != nil {
 		return "", nil, err

--- a/test
+++ b/test
@@ -13,6 +13,7 @@ source ./build
 
 TESTABLE="libcni plugins/ipam/dhcp plugins/ipam/host-local plugins/ipam/host-local/backend/allocator plugins/main/loopback pkg/invoke pkg/ns pkg/skel pkg/types pkg/types/current pkg/types/020 pkg/utils plugins/main/ipvlan plugins/main/macvlan plugins/main/bridge plugins/main/ptp plugins/test/noop pkg/utils/hwaddr pkg/ip pkg/version pkg/version/testhelpers plugins/meta/flannel pkg/ipam"
 FORMATTABLE="$TESTABLE pkg/testutils plugins/meta/flannel plugins/meta/tuning"
+LINTABLE=(cnitool libcni plugins pkg)
 
 # user has not provided PKG override
 if [ -z "$PKG" ]; then
@@ -76,5 +77,12 @@ if [ -n "${licRes}" ]; then
        exit 255
 fi
 
+echo "Checking golint (informational only)..."
+for i in ${LINTABLE[@]}; do
+        lintRes=$(golint $i/...)
+        if [ -n "${lintRes}" ]; then
+        	echo -e "golint checking found errors:\n${lintRes}"
+        fi
+done
 
 echo "Success"


### PR DESCRIPTION
This PR ends what #136 started, run `golint` when running the `./test` script.

@steveeJ @zachgersh I've taken care of your concerns. I just left a few non-linted lines because I believe there's a reason why those shouldn't follow golint rules, e.g. constants imported from Linux source code.

And here's the result:
```
$ ./test 
Building API
Building reference CLI
Building plugins
   flannel
   tuning
   bridge
   ipvlan
   loopback
   macvlan
   ptp
   dhcp
   host-local
   noop
Running tests without coverage profile generation...
ok      github.com/containernetworking/cni/libcni       8.098s  coverage: 88.2% of statements
ok      github.com/containernetworking/cni/plugins/ipam/dhcp    0.020s  coverage: 10.2% of statements
ok      github.com/containernetworking/cni/plugins/ipam/host-local      0.064s  coverage: 0.0% of statements
ok      github.com/containernetworking/cni/plugins/ipam/host-local/backend/allocator    0.034s  coverage: 76.4% of statements
ok      github.com/containernetworking/cni/plugins/main/loopback        4.075s  coverage: 0.0% of statements
ok      github.com/containernetworking/cni/pkg/invoke   4.197s  coverage: 70.3% of statements
ok      github.com/containernetworking/cni/pkg/ns       3.432s  coverage: 77.7% of statements
ok      github.com/containernetworking/cni/pkg/skel     0.038s  coverage: 85.7% of statements
ok      github.com/containernetworking/cni/pkg/types    0.014s  coverage: 47.0% of statements
ok      github.com/containernetworking/cni/pkg/types/current    0.025s  coverage: 37.8% of statements
ok      github.com/containernetworking/cni/pkg/types/020        0.004s  coverage: 33.3% of statements
ok      github.com/containernetworking/cni/pkg/utils    0.016s  coverage: 75.0% of statements
ok      github.com/containernetworking/cni/plugins/main/ipvlan  0.744s  coverage: 70.1% of statements
ok      github.com/containernetworking/cni/plugins/main/macvlan 0.874s  coverage: 69.1% of statements
ok      github.com/containernetworking/cni/plugins/main/bridge  3.627s  coverage: 67.1% of statements
ok      github.com/containernetworking/cni/plugins/main/ptp     0.481s  coverage: 75.5% of statements
ok      github.com/containernetworking/cni/plugins/test/noop    1.222s  coverage: 0.0% of statements
ok      github.com/containernetworking/cni/pkg/utils/hwaddr     0.005s  coverage: 62.5% of statements
ok      github.com/containernetworking/cni/pkg/ip       4.236s  coverage: 45.2% of statements
ok      github.com/containernetworking/cni/pkg/version  0.009s  coverage: 75.7% of statements
ok      github.com/containernetworking/cni/pkg/version/testhelpers      0.754s  coverage: 76.2% of statements
ok      github.com/containernetworking/cni/plugins/meta/flannel 2.514s  coverage: 76.0% of statements
ok      github.com/containernetworking/cni/pkg/ipam     3.057s  coverage: 81.8% of statements
Checking gofmt...
Checking govet...
Checking license header...
Checking golint (informational only)...
golint checking found errors:
plugins/test/noop/main.go:64:27: error strings should not be capitalized or end with punctuation or a newline
golint checking found errors:
pkg/ns/ns.go:82:2: comment on exported const NSFS_MAGIC should be of the form "NSFS_MAGIC ..."
pkg/ns/ns.go:85:2: don't use ALL_CAPS in Go names; use CamelCase
pkg/ns/ns.go:86:2: don't use ALL_CAPS in Go names; use CamelCase
pkg/ns/ns.go:86:2: exported const PROCFS_MAGIC should have comment (or a comment on this block) or be unexported
pkg/version/plugin.go:35:2: don't use underscores in Go names; struct field CNIVersion_ should be CNIVersion
pkg/version/plugin.go:36:2: don't use underscores in Go names; struct field SupportedVersions_ should be SupportedVersions
Success
```