### PR TITLE
Do not error if last reserved not found after initial creation

### DIFF
--- a/plugins/ipam/host-local/backend/allocator/allocator.go
+++ b/plugins/ipam/host-local/backend/allocator/allocator.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
 
 	"github.com/containernetworking/cni/pkg/ip"
 	"github.com/containernetworking/cni/pkg/types"
@@ -253,7 +254,7 @@ func (a *IPAllocator) getSearchRange() (net.IP, net.IP) {
 	var endIP net.IP
 	startFromLastReservedIP := false
 	lastReservedIP, err := a.store.LastReservedIP()
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		log.Printf("Error retriving last reserved ip: %v", err)
 	} else if lastReservedIP != nil {
 		subnet := net.IPNet{

--- a/plugins/ipam/host-local/backend/disk/backend.go
+++ b/plugins/ipam/host-local/backend/disk/backend.go
@@ -15,7 +15,6 @@
 package disk
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -85,7 +84,7 @@ func (s *Store) LastReservedIP() (net.IP, error) {
 	ipfile := filepath.Join(s.dataDir, lastIPFile)
 	data, err := ioutil.ReadFile(ipfile)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to retrieve last reserved ip: %v", err)
+		return nil, err
 	}
 	return net.ParseIP(string(data)), nil
 }

--- a/plugins/ipam/host-local/host_local_suite_test.go
+++ b/plugins/ipam/host-local/host_local_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestHostLocal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "HostLocal Suite")
+}

--- a/plugins/ipam/host-local/host_local_test.go
+++ b/plugins/ipam/host-local/host_local_test.go
@@ -109,6 +109,9 @@ var _ = Describe("host-local Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		defer os.RemoveAll(tmpDir)
 
+		err = ioutil.WriteFile(filepath.Join(tmpDir, "resolv.conf"), []byte("nameserver 192.0.2.3"), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
 		conf := fmt.Sprintf(`{
     "cniVersion": "0.1.0",
     "name": "mynet",
@@ -117,9 +120,10 @@ var _ = Describe("host-local Operations", func() {
     "ipam": {
         "type": "host-local",
         "subnet": "10.1.2.0/24",
-        "dataDir": "%s"
+        "dataDir": "%s",
+	"resolvConf": "%s/resolv.conf"
     }
-}`, tmpDir)
+}`, tmpDir, tmpDir)
 
 		args := &skel.CmdArgs{
 			ContainerID: "dummy",
@@ -175,7 +179,7 @@ var _ = Describe("host-local Operations", func() {
 		defer os.RemoveAll(tmpDir)
 
 		conf := fmt.Sprintf(`{
-    "cniVersion": "0.2.0",
+    "cniVersion": "0.3.0",
     "name": "mynet",
     "type": "ipvlan",
     "master": "foo0",


### PR DESCRIPTION
When using the `host-local` IPAM plugin, after initial network creation the following error is printed due to missing file:

```
2017/02/03 17:50:08 Error retriving last reserved ip: Failed to retrieve last reserved ip: open /var/lib/cni/networks/external/last_reserved_ip: no such file or directory
```

This fixes to not return an error when the file does not exist.