### PR TITLE
CONVENTIONS.md: Update details on port-mappings

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -10,9 +10,11 @@ Establishing these conventions allows plugins to work across multiple runtimes. 
 
 ## Plugins
 * Plugin authors should aim to support these conventions where it makes sense for their plugin. This means they are more likely to "just work" with a wider range of runtimes.
+* Plugins should accept arguments according to these conventions if they implement the same basic functionality as other plugins. If plugins have shared functionality that isn't coverered by these conventions then a PR should be opened against this document.
 
 ## Runtimes
 * Runtime authors should follow these conventions if they want to pass additional information to plugins. This will allow the extra information to be consumed by the widest range of plugins.
+* These conventions serve as an abstraction for the runtime. For example, port forwarding is highly implementation specific, but users should be able to select the plugin of their choice without changing the runtime.
 
 # Current conventions
 Additional conventions can be created by creating PRs which modify this document.
@@ -23,7 +25,9 @@ Additional conventions can be created by creating PRs which modify this document
 
 A plugin can define any additional fields it needs to work properly. It is expected that it will return an error if it can't act on fields that were expected or where the field values were malformed.
 
-This method of passing information to a plugin is recommended when the information has specific meaning to the plugin that it's passed to and when the plugin should act on it or return an error if it can't.
+This method of passing information to a plugin is recommended when the following conditions hold
+* The configuration has specific meaning to the plugin (i.e. it's not just general meta data)
+* the plugin is expected to act on the configuration or return an error if it can't
 
 Dynamic information (i.e. data that a runtime fills out) should be placed in a `runtime_config` section.
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -29,14 +29,14 @@ Dynamic information (i.e. data that a runtime fills out) should be placed in a `
 
 | Area  | Purpose| Spec and Example | Runtime implementations | Plugin Implementations |
 | ------ | ------ | ------             | ------  | ------                  | ------                 |  
-| port mappings | Pass mapping from ports on the host to ports in the container network namespace. | Runtimes should receive the follow plugin config <pre>"runtime_config": {port_mappings": []} </pre> Runtimes should fill in the actual port mappings when the config is passed to plugins e.g. <pre>"runtime_config": {<br />  "port_mappings" : [<br />    { "host_port": 8080, "container_port": 80, "protocol": "tcp" },<br />    { "host_port": 8000, "container_port": 8001, "protocol": "udp" }<br />  ]<br />}</pre> | none | none |
+| port mappings | Pass mapping from ports on the host to ports in the container network namespace. | Operators can ask runtimes to pass port mapping information to plugins, by setting the following in the CNI config <pre>"capabilities": {port_mappings": true} </pre> Runtimes should fill in the actual port mappings when the config is passed to plugins. It should be placed in a new section of the config "runtime_config" e.g. <pre>"runtime_config": {<br />  "port_mappings" : [<br />    { "host_port": 8080, "container_port": 80, "protocol": "tcp" },<br />    { "host_port": 8000, "container_port": 8001, "protocol": "udp" }<br />  ]<br />}</pre> | none | none |
 
 For example, the configuration for a port mapping plugin might look like this to an operator (it should be included as part of a [network configuration list](https://github.com/containernetworking/cni/blob/master/SPEC.md#network-configuration-lists).
 ```json
 {
   "name" : "ExamplePlugin",
   "type" : "port-mapper",
-  "runtime_config": {"port_mappings": []}  
+  "capabilities": {"port_mappings": true}  
 }
 ```
 


### PR DESCRIPTION
After discussion with the CNI maintainers and representatives from Mesos and Kubernetes we've settled on this approach for passing the dynamic port mapping information from runtimes to plugins.

Including it in the plugin config allows "operators" to signal that they expect port mapping information to be passed to a specific plugin (or plugins). This follows the model that config passed in the plugin config should be acted upon by a plugin.

Runtimes can optionally return an error to users if they find no plugin in the chain that supports port mappings.

I'm sure we'd all like to see this merged soon so I'll try to turn any feedback quickly (and I'm happy to get any and all feedback - spellings, unclear working, wrong JSON terminology etc..)