### PR TITLE
spec,libcni: add support for injecting runtimeConfig into plugin stdin data

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -29,18 +29,18 @@ This method of passing information to a plugin is recommended when the following
 * The configuration has specific meaning to the plugin (i.e. it's not just general meta data)
 * the plugin is expected to act on the configuration or return an error if it can't
 
-Dynamic information (i.e. data that a runtime fills out) should be placed in a `runtime_config` section.
+Dynamic information (i.e. data that a runtime fills out) should be placed in a `runtimeConfig` section.
 
 | Area  | Purpose| Spec and Example | Runtime implementations | Plugin Implementations |
 | ------ | ------ | ------             | ------  | ------                  | ------                 |  
-| port mappings | Pass mapping from ports on the host to ports in the container network namespace. | Operators can ask runtimes to pass port mapping information to plugins, by setting the following in the CNI config <pre>"capabilities": {port_mappings": true} </pre> Runtimes should fill in the actual port mappings when the config is passed to plugins. It should be placed in a new section of the config "runtime_config" e.g. <pre>"runtime_config": {<br />  "port_mappings" : [<br />    { "host_port": 8080, "container_port": 80, "protocol": "tcp" },<br />    { "host_port": 8000, "container_port": 8001, "protocol": "udp" }<br />  ]<br />}</pre> | none | none |
+| port mappings | Pass mapping from ports on the host to ports in the container network namespace. | Operators can ask runtimes to pass port mapping information to plugins, by setting the following in the CNI config <pre>"capabilities": {"portMappings": true} </pre> Runtimes should fill in the actual port mappings when the config is passed to plugins. It should be placed in a new section of the config "runtimeConfig" e.g. <pre>"runtimeConfig": {<br />  "portMappings" : [<br />    { "hostPort": 8080, "containerPort": 80, "protocol": "tcp" },<br />    { "hostPort": 8000, "containerPort": 8001, "protocol": "udp" }<br />  ]<br />}</pre> | none | none |
 
 For example, the configuration for a port mapping plugin might look like this to an operator (it should be included as part of a [network configuration list](https://github.com/containernetworking/cni/blob/master/SPEC.md#network-configuration-lists).
 ```json
 {
   "name" : "ExamplePlugin",
   "type" : "port-mapper",
-  "capabilities": {"port_mappings": true}  
+  "capabilities": {"portMappings": true}
 }
 ```
 
@@ -49,9 +49,9 @@ But the runtime would fill in the mappings so the plugin itself would receive so
 {
   "name" : "ExamplePlugin",
   "type" : "port-mapper",
-  "runtime_config": {
-    "port_mappings": [
-      {"host_port": 8080, "container_port": 80, "protocol": "tcp"}
+  "runtimeConfig": {
+    "portMappings": [
+      {"hostPort": 8080, "containerPort": 80, "protocol": "tcp"}
     ]
   }
 }

--- a/SPEC.md
+++ b/SPEC.md
@@ -253,8 +253,8 @@ The list is described in JSON form, and can be stored on disk or generated from 
 - `name` (string): Network name. This should be unique across all containers on the host (or other administrative domain).
 - `plugins` (list): A list of standard CNI network configuration dictionaries (see above).
 
-When executing a plugin list, the runtime MUST replace the `name` and `cniVersion` fields in each individual network configuration in the list with the `name` and `cniVersion` field of the list itself.
-This ensures that the name and CNI version is the same for all plugin executions in the list, preventing versioning conflicts between plugins.
+When executing a plugin list, the runtime MUST replace the `name` and `cniVersion` fields in each individual network configuration in the list with the `name` and `cniVersion` field of the list itself. This ensures that the name and CNI version is the same for all plugin executions in the list, preventing versioning conflicts between plugins.
+The runtime may also pass capability-based keys as a map in the top-level `runtimeConfig` key of the plugin's config JSON if a plugin advertises it supports a specific capability via the `capabilities` key of its network configuration.  The key passed in `runtimeConfig` MUST match the name of the specific capability from the `capabilities` key of the plugins network configuration. See CONVENTIONS.md for more information on capabilities and how they are sent to plugins via the `runtimeConfig` key.
 
 For the ADD action, the runtime MUST also add a `prevResult` field to the configuration JSON of any plugin after the first one, which MUST be the Result of the previous plugin (if any) in JSON format ([see below](#network-configuration-list-runtime-examples)).
 For the ADD action, plugins SHOULD echo the contents of the `prevResult` field to their stdout to allow subsequent plugins (and the runtime) to receive the result, unless they wish to modify or suppress a previous result.

--- a/libcni/conf.go
+++ b/libcni/conf.go
@@ -201,22 +201,24 @@ func LoadConfList(dir, name string) (*NetworkConfigList, error) {
 	return ConfListFromConf(singleConf)
 }
 
-func InjectConf(original *NetworkConfig, key string, newValue interface{}) (*NetworkConfig, error) {
+func InjectConf(original *NetworkConfig, newValues map[string]interface{}) (*NetworkConfig, error) {
 	config := make(map[string]interface{})
 	err := json.Unmarshal(original.Bytes, &config)
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal existing network bytes: %s", err)
 	}
 
-	if key == "" {
-		return nil, fmt.Errorf("key value can not be empty")
-	}
+	for key, value := range newValues {
+		if key == "" {
+			return nil, fmt.Errorf("keys cannot be empty")
+		}
 
-	if newValue == nil {
-		return nil, fmt.Errorf("newValue must be specified")
-	}
+		if value == nil {
+			return nil, fmt.Errorf("key '%s' value must not be nil", key)
+		}
 
-	config[key] = newValue
+		config[key] = value
+	}
 
 	newBytes, err := json.Marshal(config)
 	if err != nil {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -60,9 +60,10 @@ func (n *IPNet) UnmarshalJSON(data []byte) error {
 type NetConf struct {
 	CNIVersion string `json:"cniVersion,omitempty"`
 
-	Name string `json:"name,omitempty"`
-	Type string `json:"type,omitempty"`
-	IPAM struct {
+	Name         string          `json:"name,omitempty"`
+	Type         string          `json:"type,omitempty"`
+	Capabilities map[string]bool `json:"capabilities,omitempty"`
+	IPAM         struct {
 		Type string `json:"type,omitempty"`
 	} `json:"ipam,omitempty"`
 	DNS DNS `json:"dns"`


### PR DESCRIPTION
And "runtime_config"->"runtimeConfig" to make capitalizatoin consistent
with other CNI config keys like "cniVersion" and such.

@containernetworking/cni-maintainers 