### PR TITLE
README: List multus as 3rd party plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ To avoid duplication, we think it is prudent to define a common interface betwee
 - [SR-IOV](https://github.com/hustcat/sriov-cni)
 - [Cilium - BPF & XDP for containers](https://github.com/cilium/cilium)
 - [Infoblox - enterprise IP address management for containers](https://github.com/infobloxopen/cni-infoblox)
+- [Multus - a Multi plugin](https://github.com/Intel-Corp/multus-cni)
 
 The CNI team also maintains some [core plugins](plugins).
 


### PR DESCRIPTION
refer #343 issue. Blog regarding Multus CNI usage http://dougbtv.com/nfvpe/2017/02/22/multus-cni/ 