### PR TITLE
RFC: CNI Runtime hint: Provide hints regarding the runtime in use

### DIFF
--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -123,6 +123,142 @@ var _ = Describe("bridge Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("configures and deconfigures a bridge and tap with default route with ADD/DEL", func() {
+		const BRNAME = "cni0"
+		const IFNAME = "eth0"
+
+		gwaddr, subnet, err := net.ParseCIDR("10.1.2.1/24")
+		Expect(err).NotTo(HaveOccurred())
+
+		conf := fmt.Sprintf(`{
+    "cniVersion": "0.3.0",
+    "name": "mynet",
+    "type": "bridge",
+    "bridge": "%s",
+    "isDefaultGateway": true,
+    "ipMasq": false,
+    "ipam": {
+        "type": "host-local",
+        "subnet": "%s"
+    },
+    "runtimeConfig": {
+        "configureVM": true
+    }
+}`, BRNAME, subnet.String())
+
+		targetNs, err := ns.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+		defer targetNs.Close()
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       targetNs.Path(),
+			IfName:      IFNAME,
+			StdinData:   []byte(conf),
+		}
+
+		var result *current.Result
+		err = originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			r, raw, err := testutils.CmdAddWithResult(targetNs.Path(), IFNAME, []byte(conf), func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.Index(string(raw), "\"interfaces\":")).Should(BeNumerically(">", 0))
+
+			result, err = current.GetResult(r)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(result.Interfaces)).To(Equal(3))
+			Expect(result.Interfaces[0].Name).To(Equal(BRNAME))
+			Expect(result.Interfaces[2].Name).To(Equal(IFNAME))
+
+			// Make sure bridge link exists
+			link, err := netlink.LinkByName(result.Interfaces[0].Name)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link.Attrs().Name).To(Equal(BRNAME))
+			Expect(link).To(BeAssignableToTypeOf(&netlink.Bridge{}))
+			Expect(link.Attrs().HardwareAddr.String()).To(Equal(result.Interfaces[0].Mac))
+			hwAddr := fmt.Sprintf("%s", link.Attrs().HardwareAddr)
+			Expect(hwAddr).To(HavePrefix(hwaddr.PrivateMACPrefixString))
+
+			// Ensure bridge has gateway address
+			addrs, err := netlink.AddrList(link, syscall.AF_INET)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(addrs)).To(BeNumerically(">", 0))
+			found := false
+			subnetPrefix, subnetBits := subnet.Mask.Size()
+			for _, a := range addrs {
+				aPrefix, aBits := a.IPNet.Mask.Size()
+				if a.IPNet.IP.Equal(gwaddr) && aPrefix == subnetPrefix && aBits == subnetBits {
+					found = true
+					break
+				}
+			}
+			Expect(found).To(Equal(true))
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Find the tap interface in the container namespace and the default route
+		err = targetNs.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			link, err := netlink.LinkByName(IFNAME)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link.Attrs().Name).To(Equal(IFNAME))
+			// tap interfaces are reported back today as GenericLink
+			Expect(link).To(BeAssignableToTypeOf(&netlink.GenericLink{}))
+			Expect(link.Type()).To(Equal("tun"))
+			Expect(link.Attrs().Flags & syscall.IFF_TAP).To(BeNumerically("==", syscall.IFF_TAP))
+
+			addrs, err := netlink.AddrList(link, syscall.AF_INET)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(addrs)).To(Equal(1))
+
+			hwAddr := fmt.Sprintf("%s", link.Attrs().HardwareAddr)
+			Expect(hwAddr).To(HavePrefix(hwaddr.PrivateMACPrefixString))
+
+			// Ensure the default route
+			routes, err := netlink.RouteList(link, 0)
+			Expect(err).NotTo(HaveOccurred())
+
+			var defaultRouteFound bool
+			for _, route := range routes {
+				defaultRouteFound = (route.Dst == nil && route.Src == nil && route.Gw.Equal(gwaddr))
+				if defaultRouteFound {
+					break
+				}
+			}
+			Expect(defaultRouteFound).To(Equal(true))
+
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		err = originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			err := testutils.CmdDelWithResult(targetNs.Path(), IFNAME, func() error {
+				return cmdDel(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Make sure the tap interface has been deleted
+		err = originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			link, err := netlink.LinkByName(result.Interfaces[1].Name)
+			Expect(err).To(HaveOccurred())
+			Expect(link).To(BeNil())
+			return nil
+		})
+	})
+
 	It("configures and deconfigures a bridge and veth with default route with ADD/DEL", func() {
 		const BRNAME = "cni0"
 		const IFNAME = "eth0"


### PR DESCRIPTION
All main CNI plugins assume they have to deal with namespaces as the primary form of isolation in the case of containers. However with CRI-O adding support for multiple runtimes including virtual machines, it makes sense to provide an option to support these runtimes without breaking backward compatibility.

https://github.com/kubernetes/kubernetes/pull/40662

In the case of runtimes that use virtual machines as the isolation implementation, this information can be passed into CNI as an ***optional*** parameter.  

The VM runtimes have tried to address this by using integration bridges in some cases. However this approach does not always work (e.g macvlan)

When the runtime hint is present the network plugin can choose an interface setup that is optimal for that runtime type. The plugin is free to completely ignore the hint and assume it only supports namespace centric runtimes. This also means that runtimes should not assume that the hint will result in a interface that is optimal, and will need to handle the cases where a namespace friendly interface is created.

This is by no means mandatory and the runtime should be able to detect and support the case where an namespace centic interface is created.

This PR attempts to seek feedback on this approach using the bridge plugin.

If this runtime hint CNI_RUNTIME_TYPE is acceptable I will add support for the same for all other plugins.

For a quick test to observe the default behavior vs the behavior when the hint is accepted.

```
sudo CNI_PATH=$CNI_PATH CNI_RUNTIME_TYPE="vm" ./priv-net-run.sh ip -d l
sudo CNI_PATH=$CNI_PATH ./priv-net-run.sh ip -d l

```

cc @sameo @mrunalp @thockin