### PR TITLE
Add option to disable default route inside container namespace

### DIFF
--- a/Documentation/bridge.md
+++ b/Documentation/bridge.md
@@ -40,3 +40,4 @@ If the bridge is missing, the plugin will create one on first use and, if gatewa
 * `mtu` (integer, optional): explicitly set MTU to the specified value. Defaults to the value chosen by the kernel.
 * `hairpinMode` (boolean, optional): set hairpin mode for interfaces on the bridge. Defaults to false.
 * `ipam` (dictionary, required): IPAM configuration to be used for this network.
+* `noVethDefaultRt`(boolean, optional): Indicate if the default route inside the veth namespace should be removed. Defaults to false.

--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -123,7 +123,7 @@ var _ = Describe("bridge Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("configures and deconfigures a bridge and veth with default route with ADD/DEL", func() {
+	It("configures and deconfigures a bridge and veth with default route and gateway with ADD/DEL", func() {
 		const BRNAME = "cni0"
 		const IFNAME = "eth0"
 
@@ -227,13 +227,19 @@ var _ = Describe("bridge Operations", func() {
 			routes, err := netlink.RouteList(link, 0)
 			Expect(err).NotTo(HaveOccurred())
 
-			var defaultRouteFound bool
+			defaultGwFound := false
+			defaultRouteFound := false
 			for _, route := range routes {
-				defaultRouteFound = (route.Dst == nil && route.Src == nil && route.Gw.Equal(gwaddr))
-				if defaultRouteFound {
+				if !defaultGwFound && route.Dst == nil {
+					defaultGwFound = (route.Dst == nil && route.Src == nil && route.Gw.Equal(gwaddr))
+				} else if !defaultRouteFound {
+					defaultRouteFound = (route.Dst.String() == subnet.String() && route.Gw == nil)
+				}
+				if defaultRouteFound && defaultGwFound {
 					break
 				}
 			}
+			Expect(defaultGwFound).To(Equal(true))
 			Expect(defaultRouteFound).To(Equal(true))
 
 			return nil
@@ -371,13 +377,19 @@ var _ = Describe("bridge Operations", func() {
 			routes, err := netlink.RouteList(link, 0)
 			Expect(err).NotTo(HaveOccurred())
 
-			var defaultRouteFound bool
+			defaultGwFound := false
+			defaultRouteFound := false
 			for _, route := range routes {
-				defaultRouteFound = (route.Dst == nil && route.Src == nil && route.Gw.Equal(gwaddr))
-				if defaultRouteFound {
+				if !defaultGwFound && route.Dst == nil {
+					defaultGwFound = (route.Dst == nil && route.Src == nil && route.Gw.Equal(gwaddr))
+				} else if !defaultRouteFound {
+					defaultRouteFound = (route.Dst.String() == subnet.String() && route.Gw == nil)
+				}
+				if defaultRouteFound && defaultGwFound {
 					break
 				}
 			}
+			Expect(defaultGwFound).To(Equal(true))
 			Expect(defaultRouteFound).To(Equal(true))
 
 			return nil
@@ -474,5 +486,318 @@ var _ = Describe("bridge Operations", func() {
 			return nil
 		})
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("configures and deconfigures a bridge and veth with default route but without default gateway with ADD/DEL", func() {
+		const BRNAME = "cni0"
+		const IFNAME = "eth0"
+
+		gwaddr, subnet, err := net.ParseCIDR("10.1.2.1/24")
+		Expect(err).NotTo(HaveOccurred())
+
+		conf := fmt.Sprintf(`{
+    "cniVersion": "0.3.0",
+    "name": "mynet",
+    "type": "bridge",
+    "bridge": "%s",
+	"isGateway": true,
+    "ipMasq": false,
+    "ipam": {
+        "type": "host-local",
+        "subnet": "%s"
+    }
+}`, BRNAME, subnet.String())
+
+		targetNs, err := ns.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+		defer targetNs.Close()
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       targetNs.Path(),
+			IfName:      IFNAME,
+			StdinData:   []byte(conf),
+		}
+
+		var result *current.Result
+		err = originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			r, raw, err := testutils.CmdAddWithResult(targetNs.Path(), IFNAME, []byte(conf), func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.Index(string(raw), "\"interfaces\":")).Should(BeNumerically(">", 0))
+
+			result, err = current.GetResult(r)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(result.Interfaces)).To(Equal(3))
+			Expect(result.Interfaces[0].Name).To(Equal(BRNAME))
+			Expect(result.Interfaces[2].Name).To(Equal(IFNAME))
+
+			// Make sure bridge link exists
+			link, err := netlink.LinkByName(result.Interfaces[0].Name)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link.Attrs().Name).To(Equal(BRNAME))
+			Expect(link).To(BeAssignableToTypeOf(&netlink.Bridge{}))
+			Expect(link.Attrs().HardwareAddr.String()).To(Equal(result.Interfaces[0].Mac))
+			hwAddr := fmt.Sprintf("%s", link.Attrs().HardwareAddr)
+			Expect(hwAddr).To(HavePrefix(hwaddr.PrivateMACPrefixString))
+
+			// Ensure bridge has gateway address
+			addrs, err := netlink.AddrList(link, syscall.AF_INET)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(addrs)).To(BeNumerically(">", 0))
+			found := false
+			subnetPrefix, subnetBits := subnet.Mask.Size()
+			for _, a := range addrs {
+				aPrefix, aBits := a.IPNet.Mask.Size()
+				if a.IPNet.IP.Equal(gwaddr) && aPrefix == subnetPrefix && aBits == subnetBits {
+					found = true
+					break
+				}
+			}
+			Expect(found).To(Equal(true))
+
+			// Check for the veth link in the main namespace
+			links, err := netlink.LinkList()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(links)).To(Equal(3)) // Bridge, veth, and loopback
+
+			link, err = netlink.LinkByName(result.Interfaces[1].Name)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link).To(BeAssignableToTypeOf(&netlink.Veth{}))
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Find the veth peer in the container namespace and the default route
+		err = targetNs.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			link, err := netlink.LinkByName(IFNAME)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link.Attrs().Name).To(Equal(IFNAME))
+			Expect(link).To(BeAssignableToTypeOf(&netlink.Veth{}))
+
+			addrs, err := netlink.AddrList(link, syscall.AF_INET)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(addrs)).To(Equal(1))
+
+			hwAddr := fmt.Sprintf("%s", link.Attrs().HardwareAddr)
+			Expect(hwAddr).To(HavePrefix(hwaddr.PrivateMACPrefixString))
+
+			// Ensure the default route
+			routes, err := netlink.RouteList(link, 0)
+			Expect(err).NotTo(HaveOccurred())
+
+			defaultGwFound := false
+			defaultRouteFound := false
+			for _, route := range routes {
+				if !defaultGwFound && route.Dst == nil {
+					defaultGwFound = (route.Dst == nil && route.Src == nil && route.Gw.Equal(gwaddr))
+				} else if !defaultRouteFound {
+					defaultRouteFound = (route.Dst.String() == subnet.String() && route.Gw == nil)
+				}
+				if defaultRouteFound && defaultGwFound {
+					break
+				}
+			}
+			Expect(defaultGwFound).To(Equal(false))
+			Expect(defaultRouteFound).To(Equal(true))
+
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		err = originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			err := testutils.CmdDelWithResult(targetNs.Path(), IFNAME, func() error {
+				return cmdDel(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Make sure the host veth has been deleted
+		err = targetNs.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			link, err := netlink.LinkByName(IFNAME)
+			Expect(err).To(HaveOccurred())
+			Expect(link).To(BeNil())
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Make sure the container veth has been deleted
+		err = originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			link, err := netlink.LinkByName(result.Interfaces[1].Name)
+			Expect(err).To(HaveOccurred())
+			Expect(link).To(BeNil())
+			return nil
+		})
+	})
+
+	It("configures and deconfigures a bridge and veth without default route or default gateway with ADD/DEL", func() {
+		const BRNAME = "cni0"
+		const IFNAME = "eth0"
+
+		gwaddr, subnet, err := net.ParseCIDR("10.1.2.1/24")
+		Expect(err).NotTo(HaveOccurred())
+
+		conf := fmt.Sprintf(`{
+    "cniVersion": "0.3.0",
+    "name": "mynet",
+    "type": "bridge",
+    "bridge": "%s",
+	"isGateway": true,
+	"noVethDefaultRt": true,
+    "ipMasq": false,
+    "ipam": {
+        "type": "host-local",
+        "subnet": "%s"
+    }
+}`, BRNAME, subnet.String())
+
+		targetNs, err := ns.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+		defer targetNs.Close()
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       targetNs.Path(),
+			IfName:      IFNAME,
+			StdinData:   []byte(conf),
+		}
+
+		var result *current.Result
+		err = originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			r, raw, err := testutils.CmdAddWithResult(targetNs.Path(), IFNAME, []byte(conf), func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.Index(string(raw), "\"interfaces\":")).Should(BeNumerically(">", 0))
+
+			result, err = current.GetResult(r)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(result.Interfaces)).To(Equal(3))
+			Expect(result.Interfaces[0].Name).To(Equal(BRNAME))
+			Expect(result.Interfaces[2].Name).To(Equal(IFNAME))
+
+			// Make sure bridge link exists
+			link, err := netlink.LinkByName(result.Interfaces[0].Name)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link.Attrs().Name).To(Equal(BRNAME))
+			Expect(link).To(BeAssignableToTypeOf(&netlink.Bridge{}))
+			Expect(link.Attrs().HardwareAddr.String()).To(Equal(result.Interfaces[0].Mac))
+			hwAddr := fmt.Sprintf("%s", link.Attrs().HardwareAddr)
+			Expect(hwAddr).To(HavePrefix(hwaddr.PrivateMACPrefixString))
+
+			// Ensure bridge has gateway address
+			addrs, err := netlink.AddrList(link, syscall.AF_INET)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(addrs)).To(BeNumerically(">", 0))
+			found := false
+			subnetPrefix, subnetBits := subnet.Mask.Size()
+			for _, a := range addrs {
+				aPrefix, aBits := a.IPNet.Mask.Size()
+				if a.IPNet.IP.Equal(gwaddr) && aPrefix == subnetPrefix && aBits == subnetBits {
+					found = true
+					break
+				}
+			}
+			Expect(found).To(Equal(true))
+
+			// Check for the veth link in the main namespace
+			links, err := netlink.LinkList()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(links)).To(Equal(3)) // Bridge, veth, and loopback
+
+			link, err = netlink.LinkByName(result.Interfaces[1].Name)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link).To(BeAssignableToTypeOf(&netlink.Veth{}))
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Find the veth peer in the container namespace and the default route
+		err = targetNs.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			link, err := netlink.LinkByName(IFNAME)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link.Attrs().Name).To(Equal(IFNAME))
+			Expect(link).To(BeAssignableToTypeOf(&netlink.Veth{}))
+
+			addrs, err := netlink.AddrList(link, syscall.AF_INET)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(addrs)).To(Equal(1))
+
+			hwAddr := fmt.Sprintf("%s", link.Attrs().HardwareAddr)
+			Expect(hwAddr).To(HavePrefix(hwaddr.PrivateMACPrefixString))
+
+			// Ensure the default route
+			routes, err := netlink.RouteList(link, 0)
+			Expect(err).NotTo(HaveOccurred())
+
+			defaultGwFound := false
+			defaultRouteFound := false
+			for _, route := range routes {
+				if !defaultGwFound && route.Dst == nil {
+					defaultGwFound = (route.Dst == nil && route.Src == nil && route.Gw.Equal(gwaddr))
+				} else if !defaultRouteFound {
+					defaultRouteFound = (route.Dst.String() == subnet.String() && route.Gw == nil)
+				}
+				if defaultRouteFound && defaultGwFound {
+					break
+				}
+			}
+			Expect(defaultGwFound).To(Equal(false))
+			Expect(defaultRouteFound).To(Equal(false))
+
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		err = originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			err := testutils.CmdDelWithResult(targetNs.Path(), IFNAME, func() error {
+				return cmdDel(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Make sure the host veth has been deleted
+		err = targetNs.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			link, err := netlink.LinkByName(IFNAME)
+			Expect(err).To(HaveOccurred())
+			Expect(link).To(BeNil())
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Make sure the container veth has been deleted
+		err = originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			link, err := netlink.LinkByName(result.Interfaces[1].Name)
+			Expect(err).To(HaveOccurred())
+			Expect(link).To(BeNil())
+			return nil
+		})
 	})
 })


### PR DESCRIPTION
### Summary
Adding a new option to remove the default route in the container namespace when using the bridge plugin. For security concerns, users may only want specific, white-listed routes where even having the default route is a security vulnerability for their application. Enable this option will remove both IPV4 and IPV6 default routes and left only the routes specified in the configuration file.

### Test done
Added new test in `bridge_test.go` to cover this change.
`./test` ran successfully, apart from the `macvlan` Operations suite. I tested this on Amazon Linux and there's no support for `macvlan` on that platform. The failure log is pasted next:
```
• Failure [0.053 seconds]
macvlan Operations
/home/ec2-user/cni/gopath/src/github.com/containernetworking/cni/plugins/main/macvlan/macvlan_test.go:192
  creates an macvlan link in a non-default namespace [It]
  /home/ec2-user/cni/gopath/src/github.com/containernetworking/cni/plugins/main/macvlan/macvlan_test.go:102

  Expected error:
      <*errors.errorString | 0xc82000bf70>: {
          s: "failed to create macvlan: operation not supported",
      }
      failed to create macvlan: operation not supported
  not to have occurred

  /home/ec2-user/cni/gopath/src/github.com/containernetworking/cni/plugins/main/macvlan/macvlan_test.go:87
```