### PR TITLE
spec,plugins,core: convert Route gateway to an array of NextHops

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -121,7 +121,11 @@ Success is indicated by a return code of zero and the following JSON printed to 
   "routes": [                                                (optional)
       {
           "dst": "<ip-and-prefix-in-cidr>",
-          "gw": "<ip-of-next-hop>"                           (optional)
+          "nextHops": [                                      (optional)
+              "<ip-of-next-hop-1>",                          (optional)
+              "<ip-of-next-hop-2>",                          (optional)
+              ...
+          ]
       },
       ...
   ]
@@ -235,7 +239,7 @@ Plugins may define additional fields that they accept and may generate an error 
   // ipam specific
   "ipam": {
     "type": "dhcp",
-    "routes": [ { "dst": "10.0.0.0/8", "gw": "10.0.0.1" } ]
+    "routes": [ { "dst": "10.0.0.0/8", "nextHops": ["10.0.0.1"] } ]
   },
   "dns": {
     "nameservers": [ "10.0.0.1" ]
@@ -431,7 +435,11 @@ Success is indicated by a zero return code and the following JSON being printed 
   "routes": [                                       (optional)
       {
           "dst": "<ip-and-prefix-in-cidr>",
-          "gw": "<ip-of-next-hop>"                  (optional)
+          "nextHops": [                             (optional)
+              "<ip-of-next-hop-1>",                 (optional)
+              "<ip-of-next-hop-2>",                 (optional)
+              ...
+          ]
       },
       ...
   ]
@@ -498,7 +506,11 @@ All properties known to the plugin should be provided, even if not strictly requ
   "routes": [
       {
           "dst": "<ip-and-prefix-in-cidr>",
-          "gw": "<ip-of-next-hop>"               (optional)
+          "nextHops": [                          (optional)
+              "<ip-of-next-hop-1>",              (optional)
+              "<ip-of-next-hop-2>",              (optional)
+              ...
+          ]
       },
       ...
   ]
@@ -506,7 +518,7 @@ All properties known to the plugin should be provided, even if not strictly requ
 
 - Each `routes` entry is a dictionary with the following fields.  All IP addresses in the `routes` entry must be the same IP version, either 4 or 6.
   - `dst` (string): destination subnet specified in CIDR notation.
-  - `gw` (string): IP of the gateway. If omitted, a default gateway is assumed (as determined by the CNI plugin).
+  - `nextHops` (array of string): one or more IP addresses of gateways to which packets for the `dst` should be directed. If omitted, a default gateway is assumed (as determined by the CNI plugin).
 
 #### DNS
 

--- a/pkg/ip/route.go
+++ b/pkg/ip/route.go
@@ -23,5 +23,5 @@ import (
 // AddDefaultRoute sets the default route on the given gateway.
 func AddDefaultRoute(gw net.IP, dev netlink.Link) error {
 	_, defNet, _ := net.ParseCIDR("0.0.0.0/0")
-	return AddRoute(defNet, gw, dev)
+	return AddRoute(defNet, []net.IP{gw}, dev)
 }

--- a/pkg/types/020/types_test.go
+++ b/pkg/types/020/types_test.go
@@ -51,14 +51,14 @@ var _ = Describe("Ensures compatibility with the 0.1.0/0.2.0 spec", func() {
 			IP4: &types020.IPConfig{
 				IP:      *ipv4,
 				Gateway: net.ParseIP("1.2.3.1"),
-				Routes: []types.Route{
+				Routes: []types020.Route{
 					{Dst: *routev4, GW: routegwv4},
 				},
 			},
 			IP6: &types020.IPConfig{
 				IP:      *ipv6,
 				Gateway: net.ParseIP("abcd:1234:ffff::1"),
-				Routes: []types.Route{
+				Routes: []types020.Route{
 					{Dst: *routev6, GW: routegwv6},
 				},
 			},

--- a/pkg/types/current/types_test.go
+++ b/pkg/types/current/types_test.go
@@ -68,9 +68,9 @@ func testResult() *current.Result {
 				Gateway:   net.ParseIP("abcd:1234:ffff::1"),
 			},
 		},
-		Routes: []*types.Route{
-			{Dst: *routev4, GW: routegwv4},
-			{Dst: *routev6, GW: routegwv6},
+		Routes: []*current.Route{
+			{Dst: *routev4, NextHops: []net.IP{routegwv4}},
+			{Dst: *routev6, NextHops: []net.IP{routegwv6}},
 		},
 		DNS: types.DNS{
 			Nameservers: []string{"1.2.3.4", "1::cafe"},
@@ -85,7 +85,7 @@ var _ = Describe("Current types operations", func() {
 	It("correctly encodes a 0.3.0 Result", func() {
 		res := testResult()
 
-		Expect(res.String()).To(Equal("Interfaces:[{Name:eth0 Mac:00:11:22:33:44:55 Sandbox:/proc/3553/ns/net}], IP:[{Version:4 Interface:0 Address:{IP:1.2.3.30 Mask:ffffff00} Gateway:1.2.3.1} {Version:6 Interface:0 Address:{IP:abcd:1234:ffff::cdde Mask:ffffffffffffffff0000000000000000} Gateway:abcd:1234:ffff::1}], Routes:[{Dst:{IP:15.5.6.0 Mask:ffffff00} GW:15.5.6.8} {Dst:{IP:1111:dddd:: Mask:ffffffffffffffffffff000000000000} GW:1111:dddd::aaaa}], DNS:{Nameservers:[1.2.3.4 1::cafe] Domain:acompany.com Search:[somedomain.com otherdomain.net] Options:[foo bar]}"))
+		Expect(res.String()).To(Equal("Interfaces:[{Name:eth0 Mac:00:11:22:33:44:55 Sandbox:/proc/3553/ns/net}], IP:[{Version:4 Interface:0 Address:{IP:1.2.3.30 Mask:ffffff00} Gateway:1.2.3.1} {Version:6 Interface:0 Address:{IP:abcd:1234:ffff::cdde Mask:ffffffffffffffff0000000000000000} Gateway:abcd:1234:ffff::1}], Routes:[{Dst:{IP:15.5.6.0 Mask:ffffff00} NextHops:[15.5.6.8]} {Dst:{IP:1111:dddd:: Mask:ffffffffffffffffffff000000000000} NextHops:[1111:dddd::aaaa]}], DNS:{Nameservers:[1.2.3.4 1::cafe] Domain:acompany.com Search:[somedomain.com otherdomain.net] Options:[foo bar]}"))
 
 		// Redirect stdout to capture JSON result
 		oldStdout := os.Stdout
@@ -125,11 +125,15 @@ var _ = Describe("Current types operations", func() {
     "routes": [
         {
             "dst": "15.5.6.0/24",
-            "gw": "15.5.6.8"
+            "nextHops": [
+                "15.5.6.8"
+            ]
         },
         {
             "dst": "1111:dddd::/80",
-            "gw": "1111:dddd::aaaa"
+            "nextHops": [
+                "1111:dddd::aaaa"
+            ]
         }
     ],
     "dns": {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -17,7 +17,6 @@ package types
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net"
 	"os"
 )
@@ -111,15 +110,6 @@ type DNS struct {
 	Options     []string `json:"options,omitempty"`
 }
 
-type Route struct {
-	Dst net.IPNet
-	GW  net.IP
-}
-
-func (r *Route) String() string {
-	return fmt.Sprintf("%+v", *r)
-}
-
 // Well known error codes
 // see https://github.com/containernetworking/cni/blob/master/SPEC.md#well-known-error-codes
 const (
@@ -140,35 +130,6 @@ func (e *Error) Error() string {
 
 func (e *Error) Print() error {
 	return prettyPrint(e)
-}
-
-// net.IPNet is not JSON (un)marshallable so this duality is needed
-// for our custom IPNet type
-
-// JSON (un)marshallable types
-type route struct {
-	Dst IPNet  `json:"dst"`
-	GW  net.IP `json:"gw,omitempty"`
-}
-
-func (r *Route) UnmarshalJSON(data []byte) error {
-	rt := route{}
-	if err := json.Unmarshal(data, &rt); err != nil {
-		return err
-	}
-
-	r.Dst = net.IPNet(rt.Dst)
-	r.GW = rt.GW
-	return nil
-}
-
-func (r *Route) MarshalJSON() ([]byte, error) {
-	rt := route{
-		Dst: IPNet(r.Dst),
-		GW:  r.GW,
-	}
-
-	return json.Marshal(rt)
 }
 
 func prettyPrint(obj interface{}) error {

--- a/pkg/version/legacy_examples/examples.go
+++ b/pkg/version/legacy_examples/examples.go
@@ -122,8 +122,8 @@ var ExpectedResult = &types020.Result{
 			Mask: net.CIDRMask(24, 32),
 		},
 		Gateway: net.ParseIP("10.1.2.1"),
-		Routes: []types.Route{
-			types.Route{
+		Routes: []types020.Route{
+			types020.Route{
 				Dst: net.IPNet{
 					IP:   net.ParseIP("0.0.0.0"),
 					Mask: net.CIDRMask(0, 32),

--- a/plugins/ipam/dhcp/lease.go
+++ b/plugins/ipam/dhcp/lease.go
@@ -27,7 +27,7 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/containernetworking/cni/pkg/ns"
-	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/current"
 )
 
 // RFC 2131 suggests using exponential backoff, starting with 4sec
@@ -291,7 +291,7 @@ func (l *DHCPLease) Gateway() net.IP {
 	return parseRouter(l.opts)
 }
 
-func (l *DHCPLease) Routes() []*types.Route {
+func (l *DHCPLease) Routes() []*current.Route {
 	routes := parseRoutes(l.opts)
 	return append(routes, parseCIDRRoutes(l.opts)...)
 }

--- a/plugins/ipam/dhcp/options_test.go
+++ b/plugins/ipam/dhcp/options_test.go
@@ -18,25 +18,25 @@ import (
 	"net"
 	"testing"
 
-	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/d2g/dhcp4"
 )
 
-func validateRoutes(t *testing.T, routes []*types.Route) {
-	expected := []*types.Route{
-		&types.Route{
+func validateRoutes(t *testing.T, routes []*current.Route) {
+	expected := []*current.Route{
+		&current.Route{
 			Dst: net.IPNet{
 				IP:   net.IPv4(10, 0, 0, 0),
 				Mask: net.CIDRMask(8, 32),
 			},
-			GW: net.IPv4(10, 1, 2, 3),
+			NextHops: []net.IP{net.IPv4(10, 1, 2, 3)},
 		},
-		&types.Route{
+		&current.Route{
 			Dst: net.IPNet{
 				IP:   net.IPv4(192, 168, 1, 0),
 				Mask: net.CIDRMask(24, 32),
 			},
-			GW: net.IPv4(192, 168, 2, 3),
+			NextHops: []net.IP{net.IPv4(192, 168, 2, 3)},
 		},
 	}
 
@@ -52,8 +52,14 @@ func validateRoutes(t *testing.T, routes []*types.Route) {
 			t.Errorf("route.Dst mismatch: expected %v, got %v", e.Dst, a.Dst)
 		}
 
-		if !a.GW.Equal(e.GW) {
-			t.Errorf("route.GW mismatch: expected %v, got %v", e.GW, a.GW)
+		if len(a.NextHops) != len(e.NextHops) {
+			t.Errorf("route.NextHops length mismatch: expected %v, got %v", e.NextHops, a.NextHops)
+		}
+
+		for i, nh := range a.NextHops {
+			if !nh.Equal(e.NextHops[i]) {
+				t.Errorf("route.NextHops mismatch: expected %v, got %v", e.NextHops[i], nh)
+			}
 		}
 	}
 }

--- a/plugins/ipam/host-local/backend/allocator/allocator.go
+++ b/plugins/ipam/host-local/backend/allocator/allocator.go
@@ -20,7 +20,6 @@ import (
 	"net"
 
 	"github.com/containernetworking/cni/pkg/ip"
-	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/plugins/ipam/host-local/backend"
 )
@@ -130,7 +129,7 @@ func validateRangeIP(ip net.IP, ipnet *net.IPNet, start net.IP, end net.IP) erro
 }
 
 // Returns newly allocated IP along with its config
-func (a *IPAllocator) Get(id string) (*current.IPConfig, []*types.Route, error) {
+func (a *IPAllocator) Get(id string) (*current.IPConfig, []*current.Route, error) {
 	a.store.Lock()
 	defer a.store.Unlock()
 

--- a/plugins/ipam/host-local/backend/allocator/allocator_test.go
+++ b/plugins/ipam/host-local/backend/allocator/allocator_test.go
@@ -31,7 +31,7 @@ type AllocatorTestCase struct {
 	lastIP       string
 }
 
-func (t AllocatorTestCase) run() (*current.IPConfig, []*types.Route, error) {
+func (t AllocatorTestCase) run() (*current.IPConfig, []*current.Route, error) {
 	subnet, err := types.ParseCIDR(t.subnet)
 	if err != nil {
 		return nil, nil, err
@@ -351,6 +351,44 @@ var _ = Describe("host-local ip allocator", func() {
 			store := fakestore.NewFakeStore(map[string]string{}, net.ParseIP(""))
 			_, err = NewIPAllocator(&conf, store)
 			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("when config is given", func() {
+		It("requires IPAM configuration", func() {
+			conf := []byte(`{
+	"name": "foobar",
+	"type": "some-plugin"
+}`)
+			_, _, err := LoadIPAMConfig(conf, "")
+			Expect(err).To(MatchError("IPAM config missing 'ipam' key"))
+		})
+
+		It("moves route gateways into NextHops", func() {
+			conf := []byte(`{
+	"name": "foobar",
+	"type": "some-plugin",
+	"ipam": {
+		"type": "host-local",
+		"routes": [
+			{
+				"dst": "1.2.3.0/24",
+				"gw": "1.2.3.1"
+			},
+			{
+				"dst": "10.25.0.0/32",
+				"gw": "192.168.0.1"
+			}
+		]
+	}
+}`)
+			ipc, _, err := LoadIPAMConfig(conf, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(ipc.Routes)).To(Equal(2))
+			Expect(len(ipc.Routes[0].NextHops)).To(Equal(1))
+			Expect(ipc.Routes[0].NextHops[0].Equal(net.ParseIP("1.2.3.1"))).Should(BeTrue())
+			Expect(len(ipc.Routes[1].NextHops)).To(Equal(1))
+			Expect(ipc.Routes[1].NextHops[0].Equal(net.ParseIP("192.168.0.1"))).Should(BeTrue())
 		})
 	})
 })

--- a/plugins/meta/flannel/flannel.go
+++ b/plugins/meta/flannel/flannel.go
@@ -32,6 +32,7 @@ import (
 	"github.com/containernetworking/cni/pkg/invoke"
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
 )
 
@@ -227,8 +228,8 @@ func cmdAdd(args *skel.CmdArgs) error {
 	n.Delegate["ipam"] = map[string]interface{}{
 		"type":   "host-local",
 		"subnet": fenv.sn.String(),
-		"routes": []types.Route{
-			types.Route{
+		"routes": []*current.Route{
+			&current.Route{
 				Dst: *fenv.nw,
 			},
 		},


### PR DESCRIPTION
Multiple route next hops can be used for multipath routing or for
gateway redundancy.  Instead of allowing only one gateway for each
route, allow one or more via the NextHops array of gateway IP
addresses.

@containernetworking/cni-maintainers @tgraf 