### PR TITLE
Check n.IPAM before use it in LoadIPAMConfig function

### DIFF
--- a/plugins/ipam/host-local/backend/allocator/config.go
+++ b/plugins/ipam/host-local/backend/allocator/config.go
@@ -54,16 +54,16 @@ func LoadIPAMConfig(bytes []byte, args string) (*IPAMConfig, string, error) {
 		return nil, "", err
 	}
 
+	if n.IPAM == nil {
+		return nil, "", fmt.Errorf("IPAM config missing 'ipam' key")
+	}
+
 	if args != "" {
 		n.IPAM.Args = &IPAMArgs{}
 		err := types.LoadArgs(args, n.IPAM.Args)
 		if err != nil {
 			return nil, "", err
 		}
-	}
-
-	if n.IPAM == nil {
-		return nil, "", fmt.Errorf("IPAM config missing 'ipam' key")
 	}
 
 	// Copy net name into IPAM so not to drag Net struct around


### PR DESCRIPTION
If we don't check it, crash will be observed like this:
`cat /etc/cni/net.d/10-mynet.conf
{
    "cniVersion": "0.2.0",
    "name": "mynet",
    "type": "bridge",
    "bridge": "cni0",
    "isGateway": true,
    "ipMasq": true
}

$ export  CNI_PATH=$GOPATH/src/github.com/containernetworking/cni/bin/
$ export CNI_COMMAND=ADD
$ export CNI_NETNS=/var/run/test
$ export CNI_IFNAME=eth0
$ export CNI_ARGS="FOO=BAR;ABC=123"
$ $GOPATH/src/github.com/containernetworking/cni/bin/host-local < /etc/cni/net.d/10-mynet.conf

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x461416]

goroutine 1 [running]:
panic(0x50e620, 0xc42000c120)
        /usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/containernetworking/cni/plugins/ipam/host-local/backend/allocator.LoadIPAMConfig(0xc420014600, 0x8c, 0x600, 0xc420010009, 0xf, 0x531544, 0x5, 0xc4200c2001, 0x1, 0x466cfd)
        /home/tangle3/development/src/github.com/containernetworking/cni/gopath/src/github.com/containernetworking/cni/plugins/ipam/host-local/backend/allocator/config.go:58 +0x1e6
main.cmdAdd(0xc42007e070, 0x0, 0x0)
        /home/tangle3/development/src/github.com/containernetworking/cni/gopath/src/github.com/containernetworking/cni/plugins/ipam/host-local/main.go:32 +0x80
github.com/containernetworking/cni/pkg/skel.(*dispatcher).checkVersionAndCall(0xc420048200, 0xc42007e070, 0x7c2360, 0xc420016810, 0x5413f0, 0x0, 0x18)
        /home/tangle3/development/src/github.com/containernetworking/cni/gopath/src/github.com/containernetworking/cni/pkg/skel/skel.go:162 +0x175
github.com/containernetworking/cni/pkg/skel.(*dispatcher).pluginMain(0xc420048200, 0x5413f0, 0x5413f8, 0x7c2360, 0xc420016810, 0xc42001a0b8)
        /home/tangle3/development/src/github.com/containernetworking/cni/gopath/src/github.com/containernetworking/cni/pkg/skel/skel.go:173 +0x372
github.com/containernetworking/cni/pkg/skel.PluginMainWithError(0x5413f0, 0x5413f8, 0x7c2360, 0xc420016810, 0x40584b)
        /home/tangle3/development/src/github.com/containernetworking/cni/gopath/src/github.com/containernetworking/cni/pkg/skel/skel.go:210 +0xf0
github.com/containernetworking/cni/pkg/skel.PluginMain(0x5413f0, 0x5413f8, 0x7c2360, 0xc420016810)
        /home/tangle3/development/src/github.com/containernetworking/cni/gopath/src/github.com/containernetworking/cni/pkg/skel/skel.go:222 +0x63
main.main()
        /home/tangle3/development/src/github.com/containernetworking/cni/gopath/src/github.com/containernetworking/cni/plugins/ipam/host-local/main.go:28 +0x51
`
Signed-off-by: Tang Le <tangle3@wanda.cn>