### PR TITLE
Validate rangeStart and rangeEnd specified in conf

### DIFF
--- a/plugins/ipam/host-local/backend/allocator/allocator.go
+++ b/plugins/ipam/host-local/backend/allocator/allocator.go
@@ -56,13 +56,13 @@ func NewIPAllocator(conf *IPAMConfig, store backend.Store) (*IPAllocator, error)
 	start = ip.NextIP(start)
 
 	if conf.RangeStart != nil {
-		if err := validateRangeIP(conf.RangeStart, (*net.IPNet)(&conf.Subnet), nil, nil); err != nil {
+		if err := validateRangeIP(conf.RangeStart, (*net.IPNet)(&conf.Subnet), start, end); err != nil {
 			return nil, err
 		}
 		start = conf.RangeStart
 	}
 	if conf.RangeEnd != nil {
-		if err := validateRangeIP(conf.RangeEnd, (*net.IPNet)(&conf.Subnet), start, nil); err != nil {
+		if err := validateRangeIP(conf.RangeEnd, (*net.IPNet)(&conf.Subnet), start, end); err != nil {
 			return nil, err
 		}
 		end = conf.RangeEnd


### PR DESCRIPTION
If we run plugin like this, 10.1.0.0 is allocated for use. which is the wrong way：
`
{
    "cniVersion": "0.2.0",
    "name": "mynet",
    "type": "bridge",
    "bridge": "cni10",
    "isGateway": true,
    "ipMasq": true,
    "ipam": {
        "type": "host-local",
        "subnet": "10.1.0.0/16",
        "rangeStart": "10.1.0.0",
        "rangeEnd": "10.1.255.255",
        "gateway": "10.1.0.1"
    }
}

 export CNI_PATH=$GOPATH/src/github.com/containernetworking/cni/bin/
 export CNI_COMMAND=ADD
 export CNI_NETNS=/var/run/test
 export CNI_IFNAME=eth0
 export CNI_ARGS="FOO=BAR;ABC=123"
 $GOPATH/src/github.com/containernetworking/cni/bin/host-local < /etc/cni/net.d/10-mynet.conf
2017/03/06 16:44:55 Error retriving last reserved ip: Failed to retrieve last reserved ip: open /var/lib/cni/networks/mynet/last_reserved_ip: no such file or directory
{
    "ip4": {
        "ip": "10.1.0.0/16",                      <== We should skip this address.
        "gateway": "10.1.0.1"
    },
    "dns": {}
}
`





Signed-off-by: Tang Le <tangle3@wanda.cn>