### PR TITLE
hwaddr: Generate MAC address for IPv6-only pods

### DIFF
--- a/pkg/ip/link.go
+++ b/pkg/ip/link.go
@@ -172,28 +172,52 @@ func DelLinkByNameAddr(ifName string, family int) (*net.IPNet, error) {
 	return addrs[0].IPNet, nil
 }
 
+// SetHWAddrByIP sets the hardware address of an interface/link. If an IPv4
+// address is provided (for IPv4-only or dual-stack operation), then the
+// that IPv4 address is assumed to be locally unique, and the hardware
+// address that is configured comprises the 4 bytes of IPv4 address preceded
+// by a hard-coded 2-byte prefix (0a:58). If only an IPv6 address is
+// provided, then the last 4 bytes of the interface/link's current hardware
+// address are assumed to be random, and the hardware address that is
+// configured is derived by overwriting the first two bytes of the
+// current hardware address with a different hard-coded prefix (6a:58).
 func SetHWAddrByIP(ifName string, ip4 net.IP, ip6 net.IP) error {
 	iface, err := netlink.LinkByName(ifName)
 	if err != nil {
 		return fmt.Errorf("failed to lookup %q: %v", ifName, err)
 	}
+	startHWAddr := iface.Attrs().HardwareAddr.String()
 
+	var hwAddr net.HardwareAddr
 	switch {
-	case ip4 == nil && ip6 == nil:
-		return fmt.Errorf("neither ip4 or ip6 specified")
-
 	case ip4 != nil:
-		{
-			hwAddr, err := hwaddr.GenerateHardwareAddr4(ip4, hwaddr.PrivateMACPrefix)
-			if err != nil {
-				return fmt.Errorf("failed to generate hardware addr: %v", err)
-			}
-			if err = netlink.LinkSetHardwareAddr(iface, hwAddr); err != nil {
-				return fmt.Errorf("failed to add hardware addr to %q: %v", ifName, err)
-			}
+		hwAddr, err = hwaddr.GenerateHardwareAddr4(ip4, hwaddr.PrivateMACPrefix)
+		if err != nil {
+			return fmt.Errorf("failed to generate hardware addr: %v", err)
 		}
 	case ip6 != nil:
-		// TODO: IPv6
+		attrs := iface.Attrs()
+		hwAddr, err = hwaddr.GenerateHardwareAddr6(attrs.HardwareAddr,
+			hwaddr.PrivateMACPrefix6)
+		if err != nil {
+			return fmt.Errorf("failed to generate hardware addr: %v", err)
+		}
+	default:
+		return fmt.Errorf("unable to generate hardware address as neither IPv4 nor IPv6 address specified")
+	}
+
+	if hwAddr.String() != startHWAddr {
+		// Toggle the interface while changing the hardware address
+		// so that a new IPv6 link local address gets generated.
+		if err := netlink.LinkSetDown(iface); err != nil {
+			return fmt.Errorf("failed to set down %q: %v", ifName, err)
+		}
+		if err = netlink.LinkSetHardwareAddr(iface, hwAddr); err != nil {
+			return fmt.Errorf("failed to add hardware addr to %q: %v", ifName, err)
+		}
+		if err := netlink.LinkSetUp(iface); err != nil {
+			return fmt.Errorf("failed to set up %q: %v", ifName, err)
+		}
 	}
 
 	return nil

--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -302,11 +302,11 @@ func cmdAdd(args *skel.CmdArgs) error {
 			}
 		}
 
-		if err := ipam.ConfigureIface(args.IfName, result); err != nil {
+		if err := ip.SetHWAddrByIP(args.IfName, result.IPs[0].Address.IP, nil /* TODO IPv6 */); err != nil {
 			return err
 		}
 
-		if err := ip.SetHWAddrByIP(args.IfName, result.IPs[0].Address.IP, nil /* TODO IPv6 */); err != nil {
+		if err := ipam.ConfigureIface(args.IfName, result); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
This change adds logic to set the MAC (hardware) address for IPv6-only
containers.

Currently, the SetHWAddrByIP depends on an IPv4 IP address being
configured, and it generates the 48-bit MAC address by wrapping the
4-byte IPv4 address with a special, hard-coded 2-byte prefix:
    [0a:58] + [IPv4-address]
The IPv6-only case is not being handled.

What's being proposed with this change set is to modify SetHWAddrByIP
behavior as follows:
**- IPv4-only or Dual-Stack (IPv4 + IPv6):**
  No change in behavior, MAC address is based on IPv4 address:
    [0a:58] + [IPv4-address]
**- IPv6-only:**
  Generate a MAC address using a different hard-coded prefix
  (to make the V6 MAC address space separate from the
  V4 MAC address space):
    [6a:58] + [four-random-octets]
  Here, the four random octets are derived by taking the last 4 bytes
  of the original MAC address as assigned by the OS when the intf/link
  is created. These are assumed to be random.

In both cases, the IPv6 address is assigned independently (uncoupled)
from the IPv4 and MAC address assignments.

There was some concern expressed about whether the IPv6 Neighbor Discovery (ND) cache
will be subject to some "thrashing" or collisions as containers are rapidly cycled
and IPv6 addresses eventually get recycled. After all, this is why, in the IPv4 case,
the MAC address was generated based on the IPv4 address: see squeed's
explanation in the comments below. However, the IPv6 ND cache
will be resilient to IPv6 unicast addresses getting recycled/reused by containers
with different MAC addresses. The source of this resiliency is that when a node/container
sends an IPv6 Neighbor Advertisement (NA) claiming that it "owns" an IPv6 unicast address,
it will set the "ovr" flag (or "o-bit"), indicating that any existing ND cache entries should be
overwritten based on this NA message (see [tshark trace](https://gist.github.com/leblancd/e550d41cad5a1c0ecb81837dfbc93cc5)).

Fixes #370