### PR TITLE
pkg/ip: do not leak types from vendored netlink package

### DIFF
--- a/pkg/ip/link.go
+++ b/pkg/ip/link.go
@@ -109,9 +109,10 @@ func ifaceFromNetlinkLink(l netlink.Link) net.Interface {
 	}
 }
 
-// SetupVeth sets up a virtual ethernet link.
-// Should be in container netns, and will switch back to hostNS to set the host
-// veth end up.
+// SetupVeth sets up a pair of virtual ethernet devices.
+// Call SetupVeth from inside the container netns.  It will create both veth
+// devices and move the host-side veth into the provided hostNS namespace.
+// On success, SetupVeth returns (hostVeth, containerVeth, nil)
 func SetupVeth(contVethName string, mtu int, hostNS ns.NetNS) (net.Interface, net.Interface, error) {
 	hostVethName, contVeth, err := makeVeth(contVethName, mtu)
 	if err != nil {

--- a/pkg/ip/link_test.go
+++ b/pkg/ip/link_test.go
@@ -46,8 +46,8 @@ var _ = Describe("Link", func() {
 		hostNetNS         ns.NetNS
 		containerNetNS    ns.NetNS
 		ifaceCounter      int = 0
-		hostVeth          netlink.Link
-		containerVeth     netlink.Link
+		hostVeth          ip.Link
+		containerVeth     ip.Link
 		hostVethName      string
 		containerVethName string
 

--- a/pkg/ip/link_test.go
+++ b/pkg/ip/link_test.go
@@ -46,8 +46,8 @@ var _ = Describe("Link", func() {
 		hostNetNS         ns.NetNS
 		containerNetNS    ns.NetNS
 		ifaceCounter      int = 0
-		hostVeth          ip.Link
-		containerVeth     ip.Link
+		hostVeth          net.Interface
+		containerVeth     net.Interface
 		hostVethName      string
 		containerVethName string
 
@@ -78,8 +78,8 @@ var _ = Describe("Link", func() {
 			}
 			Expect(err).NotTo(HaveOccurred())
 
-			hostVethName = hostVeth.Attrs().Name
-			containerVethName = containerVeth.Attrs().Name
+			hostVethName = hostVeth.Name
+			containerVethName = containerVeth.Name
 
 			return nil
 		})
@@ -98,7 +98,7 @@ var _ = Describe("Link", func() {
 
 			containerVethFromName, err := netlink.LinkByName(containerVethName)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(containerVethFromName.Attrs().Index).To(Equal(containerVeth.Attrs().Index))
+			Expect(containerVethFromName.Attrs().Index).To(Equal(containerVeth.Index))
 
 			return nil
 		})
@@ -108,7 +108,7 @@ var _ = Describe("Link", func() {
 
 			hostVethFromName, err := netlink.LinkByName(hostVethName)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(hostVethFromName.Attrs().Index).To(Equal(hostVeth.Attrs().Index))
+			Expect(hostVethFromName.Attrs().Index).To(Equal(hostVeth.Index))
 
 			return nil
 		})
@@ -156,7 +156,7 @@ var _ = Describe("Link", func() {
 
 				hostVeth, _, err := ip.SetupVeth(containerVethName, mtu, hostNetNS)
 				Expect(err).NotTo(HaveOccurred())
-				hostVethName = hostVeth.Attrs().Name
+				hostVethName = hostVeth.Name
 				return nil
 			})
 

--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -168,10 +168,10 @@ func setupVeth(netns ns.NetNS, br *netlink.Bridge, ifName string, mtu int, hairp
 		if err != nil {
 			return err
 		}
-		contIface.Name = containerVeth.Attrs().Name
-		contIface.Mac = containerVeth.Attrs().HardwareAddr.String()
+		contIface.Name = containerVeth.Name
+		contIface.Mac = containerVeth.HardwareAddr.String()
 		contIface.Sandbox = netns.Path()
-		hostIface.Name = hostVeth.Attrs().Name
+		hostIface.Name = hostVeth.Name
 		return nil
 	})
 	if err != nil {

--- a/plugins/main/ptp/ptp.go
+++ b/plugins/main/ptp/ptp.go
@@ -63,14 +63,14 @@ func setupContainerVeth(netns ns.NetNS, ifName string, mtu int, pr *current.Resu
 	containerInterface := &current.Interface{}
 
 	err := netns.Do(func(hostNS ns.NetNS) error {
-		hostVeth, contVeth, err := ip.SetupVeth(ifName, mtu, hostNS)
+		hostVeth, contVeth0, err := ip.SetupVeth(ifName, mtu, hostNS)
 		if err != nil {
 			return err
 		}
 		hostInterface.Name = hostVeth.Attrs().Name
 		hostInterface.Mac = hostVeth.Attrs().HardwareAddr.String()
-		containerInterface.Name = contVeth.Attrs().Name
-		containerInterface.Mac = contVeth.Attrs().HardwareAddr.String()
+		containerInterface.Name = contVeth0.Attrs().Name
+		containerInterface.Mac = contVeth0.Attrs().HardwareAddr.String()
 		containerInterface.Sandbox = netns.Path()
 
 		var firstV4Addr net.IP
@@ -103,12 +103,12 @@ func setupContainerVeth(netns ns.NetNS, ifName string, mtu int, pr *current.Resu
 			return err
 		}
 
-		if err := ip.SetHWAddrByIP(contVeth.Attrs().Name, firstV4Addr, nil /* TODO IPv6 */); err != nil {
+		if err := ip.SetHWAddrByIP(contVeth0.Attrs().Name, firstV4Addr, nil /* TODO IPv6 */); err != nil {
 			return fmt.Errorf("failed to set hardware addr by IP: %v", err)
 		}
 
 		// Re-fetch container veth to update attributes
-		contVeth, err = netlink.LinkByName(ifName)
+		contVeth, err := netlink.LinkByName(ifName)
 		if err != nil {
 			return fmt.Errorf("failed to look up %q: %v", ifName, err)
 		}

--- a/plugins/main/ptp/ptp.go
+++ b/plugins/main/ptp/ptp.go
@@ -67,10 +67,10 @@ func setupContainerVeth(netns ns.NetNS, ifName string, mtu int, pr *current.Resu
 		if err != nil {
 			return err
 		}
-		hostInterface.Name = hostVeth.Attrs().Name
-		hostInterface.Mac = hostVeth.Attrs().HardwareAddr.String()
-		containerInterface.Name = contVeth0.Attrs().Name
-		containerInterface.Mac = contVeth0.Attrs().HardwareAddr.String()
+		hostInterface.Name = hostVeth.Name
+		hostInterface.Mac = hostVeth.HardwareAddr.String()
+		containerInterface.Name = contVeth0.Name
+		containerInterface.Mac = contVeth0.HardwareAddr.String()
 		containerInterface.Sandbox = netns.Path()
 
 		var firstV4Addr net.IP
@@ -87,7 +87,7 @@ func setupContainerVeth(netns ns.NetNS, ifName string, mtu int, pr *current.Resu
 
 		if firstV4Addr != nil {
 			err = hostNS.Do(func(_ ns.NetNS) error {
-				hostVethName := hostVeth.Attrs().Name
+				hostVethName := hostVeth.Name
 				if err := ip.SetHWAddrByIP(hostVethName, firstV4Addr, nil /* TODO IPv6 */); err != nil {
 					return fmt.Errorf("failed to set hardware addr by IP: %v", err)
 				}
@@ -103,7 +103,7 @@ func setupContainerVeth(netns ns.NetNS, ifName string, mtu int, pr *current.Resu
 			return err
 		}
 
-		if err := ip.SetHWAddrByIP(contVeth0.Attrs().Name, firstV4Addr, nil /* TODO IPv6 */); err != nil {
+		if err := ip.SetHWAddrByIP(contVeth0.Name, firstV4Addr, nil /* TODO IPv6 */); err != nil {
 			return fmt.Errorf("failed to set hardware addr by IP: %v", err)
 		}
 


### PR DESCRIPTION
The exported function SetupVeth now returns a package-defined type.

Addresses #395.

cc: @rosenhouse