### PR TITLE
Return cni.type.Error instead of plain error

### DIFF
--- a/pkg/invoke/raw_exec.go
+++ b/pkg/invoke/raw_exec.go
@@ -50,13 +50,9 @@ func pluginErr(err error, output []byte) error {
 	if _, ok := err.(*exec.ExitError); ok {
 		emsg := types.Error{}
 		if perr := json.Unmarshal(output, &emsg); perr != nil {
-			return fmt.Errorf("netplugin failed but error parsing its diagnostic message %q: %v", string(output), perr)
+			emsg.Msg = fmt.Sprintf("netplugin failed but error parsing its diagnostic message %q: %v", string(output), perr)
 		}
-		details := ""
-		if emsg.Details != "" {
-			details = fmt.Sprintf("; %v", emsg.Details)
-		}
-		return fmt.Errorf("%v%v", emsg.Msg, details)
+		return &emsg
 	}
 
 	return err

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -136,7 +136,11 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
-	return e.Msg
+	details := ""
+	if e.Details != "" {
+		details = fmt.Sprintf("; %v", e.Details)
+	}
+	return fmt.Sprintf("%v%v", e.Msg, details)
 }
 
 func (e *Error) Print() error {


### PR DESCRIPTION
This way, we can use Error.Code attribute to check error type without
needing to regexp the message string

kubernetes/kubernetes#43014