### PR TITLE
plugins/meta/flannel: If net config is missing do not return err on DEL

### DIFF
--- a/plugins/meta/flannel/flannel.go
+++ b/plugins/meta/flannel/flannel.go
@@ -142,6 +142,7 @@ func saveScratchNetConf(containerID, dataDir string, netconf []byte) error {
 
 func consumeScratchNetConf(containerID, dataDir string) ([]byte, error) {
 	path := filepath.Join(dataDir, containerID)
+	// Ignore errors when removing - Per spec safe to continue during DEL
 	defer os.Remove(path)
 
 	return ioutil.ReadFile(path)
@@ -245,6 +246,10 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	netconfBytes, err := consumeScratchNetConf(args.ContainerID, nc.DataDir)
 	if err != nil {
+		if os.IsNotExist(err) {
+			// Per spec should ignore error if resources are missing / already removed
+			return nil
+		}
 		return err
 	}
 

--- a/plugins/meta/flannel/flannel_test.go
+++ b/plugins/meta/flannel/flannel_test.go
@@ -140,6 +140,14 @@ FLANNEL_IPMASQ=true
 
 				By("check that plugin removes net config from state dir")
 				Expect(path).ShouldNot(BeAnExistingFile())
+
+				By("calling DEL again")
+				err = testutils.CmdDelWithResult(targetNs.Path(), IFNAME, func() error {
+					return cmdDel(args)
+				})
+				By("check that plugin does not fail due to missing net config")
+				Expect(err).NotTo(HaveOccurred())
+
 				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Based on the CNI spec, if resources are missing we should not always return error (https://github.com/containernetworking/cni/blob/master/SPEC.md#network-configuration-list-error-handling).

An open question on my end would be if that delegates would still need to be called. My thinking is that if we can't read the config - all information that would have been passed down doesn't exist - so we may as well exit early.

Additionally, other plugins may need to be checked for the same conformance against DEL spec expectations.