### PR TITLE
Added current cni spec version to error code

### DIFF
--- a/pkg/skel/skel_test.go
+++ b/pkg/skel/skel_test.go
@@ -93,8 +93,9 @@ var _ = Describe("dispatching to the correct callback", func() {
 		err := dispatch.pluginMain(cmdAdd.Func, cmdDel.Func, versionInfo)
 		if isRequired {
 			Expect(err).To(Equal(&types.Error{
-				Code: 100,
-				Msg:  "required env variables missing",
+				CniVersion: version.Current(),
+				Code:       100,
+				Msg:        "required env variables missing",
 			}))
 			Expect(stderr.String()).To(ContainSubstring(envVar + " env variable missing\n"))
 		} else {
@@ -281,8 +282,9 @@ var _ = Describe("dispatching to the correct callback", func() {
 			err := dispatch.pluginMain(cmdAdd.Func, cmdDel.Func, versionInfo)
 
 			Expect(err).To(Equal(&types.Error{
-				Code: 100,
-				Msg:  "unknown CNI_COMMAND: NOPE",
+				CniVersion: version.Current(),
+				Code:       100,
+				Msg:        "unknown CNI_COMMAND: NOPE",
 			}))
 		})
 	})
@@ -303,8 +305,9 @@ var _ = Describe("dispatching to the correct callback", func() {
 			err := dispatch.pluginMain(cmdAdd.Func, cmdDel.Func, versionInfo)
 
 			Expect(err).To(Equal(&types.Error{
-				Code: 100,
-				Msg:  "error reading from stdin: banana",
+				CniVersion: version.Current(),
+				Code:       100,
+				Msg:        "error reading from stdin: banana",
 			}))
 		})
 	})
@@ -313,8 +316,9 @@ var _ = Describe("dispatching to the correct callback", func() {
 		Context("when it is a typed Error", func() {
 			BeforeEach(func() {
 				cmdAdd.Returns.Error = &types.Error{
-					Code: 1234,
-					Msg:  "insufficient something",
+					CniVersion: version.Current(),
+					Code:       1234,
+					Msg:        "insufficient something",
 				}
 			})
 
@@ -322,8 +326,9 @@ var _ = Describe("dispatching to the correct callback", func() {
 				err := dispatch.pluginMain(cmdAdd.Func, cmdDel.Func, versionInfo)
 
 				Expect(err).To(Equal(&types.Error{
-					Code: 1234,
-					Msg:  "insufficient something",
+					CniVersion: version.Current(),
+					Code:       1234,
+					Msg:        "insufficient something",
 				}))
 			})
 		})
@@ -337,8 +342,9 @@ var _ = Describe("dispatching to the correct callback", func() {
 				err := dispatch.pluginMain(cmdAdd.Func, cmdDel.Func, versionInfo)
 
 				Expect(err).To(Equal(&types.Error{
-					Code: 100,
-					Msg:  "potato",
+					CniVersion: "9.8.7",
+					Code:       100,
+					Msg:        "potato",
 				}))
 			})
 		})

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -130,9 +130,10 @@ const (
 )
 
 type Error struct {
-	Code    uint   `json:"code"`
-	Msg     string `json:"msg"`
-	Details string `json:"details,omitempty"`
+	CniVersion string `json:"cniversion,omitempty"`
+	Code       uint   `json:"code"`
+	Msg        string `json:"msg"`
+	Details    string `json:"details,omitempty"`
 }
 
 func (e *Error) Error() string {

--- a/plugins/test/noop/noop_test.go
+++ b/plugins/test/noop/noop_test.go
@@ -196,7 +196,8 @@ var _ = Describe("No-op plugin", func() {
 			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(session).Should(gexec.Exit(1))
-			Expect(session.Out.Contents()).To(MatchJSON(`{ "code": 100, "msg": "banana" }`))
+			str := fmt.Sprintf("{\"cniversion\": %q, \"code\": 100, \"msg\": \"banana\" }", version.Current())
+			Expect(session.Out.Contents()).To(MatchJSON(str))
 		})
 	})
 


### PR DESCRIPTION
According to the CNI 3.0 spec:

'''
Errors are indicated by a non-zero return code and the following JSON being printed to stdout:

{
  "cniVersion": "0.2.0",
  "code": <numeric-error-code>,
  "msg": <short-error-message>,
  "details": <long-error-message> (optional)
}
cniVersion specifies a Semantic Version 2.0 of CNI specification used by the plugin.
'''

We were omitting it. Use the current version and fix the required tests to pas.