### PR TITLE
Added entry for CNI-Genie

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ To avoid duplication, we think it is prudent to define a common interface betwee
 - [Infoblox - enterprise IP address management for containers](https://github.com/infobloxopen/cni-infoblox)
 - [Multus - a Multi plugin](https://github.com/Intel-Corp/multus-cni)
 - [Romana - Layer 3 CNI plugin supporting network policy for Kubernetes](https://github.com/romana/kube)
+- [CNI-Genie - generic CNI network plugin](https://github.com/Huawei-PaaS/CNI-Genie)
 
 The CNI team also maintains some [core plugins](plugins).
 


### PR DESCRIPTION
CNI-Genie enables orchestrators (kubernetes, mesos) for seamless connectivity to choice of CNI plugins (calico, canal, romana, weave) configured on a Node. Without CNI-Genie, kubelet is bound to a signle CNI plugin passed to kubelet on start. CNI-Genie allows for multiple CNI plugins being available to kubelet simultaneously.