### PR TITLE
pkg/bridge: factor out bridge and veth setup into a module

### DIFF
--- a/pkg/bridge/bridge.go
+++ b/pkg/bridge/bridge.go
@@ -1,0 +1,127 @@
+// Copyright 2017 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bridge
+
+import (
+	"fmt"
+	"syscall"
+
+	"github.com/containernetworking/cni/pkg/ip"
+	"github.com/containernetworking/cni/pkg/ns"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/vishvananda/netlink"
+)
+
+// Setup sets up a bridge with a given name and MTU size. A new bridge is
+// created if one doesn't already exist with the given name
+func Setup(bridgeName string, mtu int) (*netlink.Bridge, *current.Interface, error) {
+	// create bridge if necessary
+	br, err := ensureBridge(bridgeName, mtu)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create bridge %q: %v", bridgeName, err)
+	}
+
+	return br, &current.Interface{
+		Name: br.Attrs().Name,
+		Mac:  br.Attrs().HardwareAddr.String(),
+	}, nil
+}
+
+func ensureBridge(brName string, mtu int) (*netlink.Bridge, error) {
+	br := &netlink.Bridge{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: brName,
+			MTU:  mtu,
+			// Let kernel use default txqueuelen; leaving it unset
+			// means 0, and a zero-length TX queue messes up FIFO
+			// traffic shapers which use TX queue length as the
+			// default packet limit
+			TxQLen: -1,
+		},
+	}
+
+	err := netlink.LinkAdd(br)
+	if err != nil && err != syscall.EEXIST {
+		return nil, fmt.Errorf("could not add %q: %v", brName, err)
+	}
+
+	// Re-fetch link to read all attributes and if it already existed,
+	// ensure it's really a bridge with similar configuration
+	br, err = FindByName(brName)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := netlink.LinkSetUp(br); err != nil {
+		return nil, err
+	}
+
+	return br, nil
+}
+
+// FindByName gets a handle to the bridge device with a specified name
+func FindByName(name string) (*netlink.Bridge, error) {
+	l, err := netlink.LinkByName(name)
+	if err != nil {
+		return nil, fmt.Errorf("could not lookup %q: %v", name, err)
+	}
+	br, ok := l.(*netlink.Bridge)
+	if !ok {
+		return nil, fmt.Errorf("%q already exists but is not a bridge", name)
+	}
+	return br, nil
+}
+
+// SetupVeth creates a new veth pair inside the given network namespace and
+// assigns one end of the same to the specified bridge
+func SetupVeth(netns ns.NetNS, br *netlink.Bridge, ifName string, mtu int, hairpinMode bool) (*current.Interface, *current.Interface, error) {
+	contIface := &current.Interface{}
+	hostIface := &current.Interface{}
+
+	err := netns.Do(func(hostNS ns.NetNS) error {
+		// create the veth pair in the container and move host end into host netns
+		hostVeth, containerVeth, err := ip.SetupVeth(ifName, mtu, hostNS)
+		if err != nil {
+			return err
+		}
+		contIface.Name = containerVeth.Name
+		contIface.Mac = containerVeth.HardwareAddr.String()
+		contIface.Sandbox = netns.Path()
+		hostIface.Name = hostVeth.Name
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// need to lookup hostVeth again as its index has changed during ns move
+	hostVeth, err := netlink.LinkByName(hostIface.Name)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to lookup %q: %v", hostIface.Name, err)
+	}
+	hostIface.Mac = hostVeth.Attrs().HardwareAddr.String()
+
+	// connect host veth end to the bridge
+	if err := netlink.LinkSetMaster(hostVeth, br); err != nil {
+		return nil, nil, fmt.Errorf("failed to connect %q to bridge %v: %v", hostVeth.Attrs().Name, br.Attrs().Name, err)
+	}
+
+	// set hairpin mode
+	if err = netlink.LinkSetHairpin(hostVeth, hairpinMode); err != nil {
+		return nil, nil, fmt.Errorf("failed to setup hairpin mode for %v: %v", hostVeth.Attrs().Name, err)
+	}
+
+	return hostIface, contIface, nil
+}

--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/containernetworking/cni/pkg/bridge"
 	"github.com/containernetworking/cni/pkg/ns"
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/testutils"
@@ -67,7 +68,7 @@ var _ = Describe("bridge Operations", func() {
 		err := originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
-			bridge, _, err := setupBridge(conf)
+			bridge, _, err := bridge.Setup(conf.BrName, conf.MTU)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bridge.Attrs().Name).To(Equal(IFNAME))
 
@@ -108,7 +109,7 @@ var _ = Describe("bridge Operations", func() {
 				IPMasq: false,
 			}
 
-			bridge, _, err := setupBridge(conf)
+			bridge, _, err := bridge.Setup(conf.BrName, conf.MTU)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bridge.Attrs().Name).To(Equal(IFNAME))
 			Expect(bridge.Attrs().Index).To(Equal(ifindex))
@@ -480,7 +481,7 @@ var _ = Describe("bridge Operations", func() {
 		err := originalNS.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 
-			bridge, _, err := setupBridge(conf)
+			bridge, _, err := bridge.Setup(conf.BrName, conf.MTU)
 			Expect(err).NotTo(HaveOccurred())
 			// Check if ForceAddress has default value
 			Expect(conf.ForceAddress).To(Equal(false))


### PR DESCRIPTION
#### Summary
* pkg/bridge: factor out bridge and veth setup into a module
* plugins/main/bridge: refactor to use the pkg/bridge package

#### Details
This refactors the bridge plugin so that the bridge and veth device setup is
extracted into a globally accessible package. This makes it so that any package
that relies on setting up a bridge or a veth device to a bridge can take
advantage of this common code.

#### Testing Done
`./test` ran successfully, apart from the `macvlan Operations` suite. I tested this on Amazon Linux and there's no support for macvlan on that platform. The failure log is pasted next:

```
$ ./test
Building API
Building reference CLI
Building plugins
   flannel
   tuning
   bridge
   ipvlan
   loopback
   macvlan
   ptp
   dhcp
   host-local
   noop
Running tests without coverage profile generation...
ok  	github.com/containernetworking/cni/libcni	17.054s	coverage: 87.9% of statements
ok  	github.com/containernetworking/cni/plugins/ipam/dhcp	0.034s	coverage: 10.2% of statements
ok  	github.com/containernetworking/cni/plugins/ipam/host-local	0.012s	coverage: 78.2% of statements
ok  	github.com/containernetworking/cni/plugins/ipam/host-local/backend/allocator	0.018s	coverage: 76.4% of statements
ok  	github.com/containernetworking/cni/plugins/main/loopback	5.195s	coverage: 0.0% of statements
ok  	github.com/containernetworking/cni/pkg/invoke	8.013s	coverage: 69.0% of statements
ok  	github.com/containernetworking/cni/pkg/ns	2.523s	coverage: 77.7% of statements
ok  	github.com/containernetworking/cni/pkg/skel	0.055s	coverage: 85.7% of statements
ok  	github.com/containernetworking/cni/pkg/types	0.010s	coverage: 47.0% of statements
ok  	github.com/containernetworking/cni/pkg/types/current	0.013s	coverage: 37.8% of statements
ok  	github.com/containernetworking/cni/pkg/types/020	0.004s	coverage: 33.3% of statements
ok  	github.com/containernetworking/cni/pkg/utils	0.005s	coverage: 75.0% of statements
ok  	github.com/containernetworking/cni/plugins/main/ipvlan	0.560s	coverage: 70.4% of statements
Running Suite: macvlan Suite
============================
Random Seed: 1491259217
Will run 3 of 3 specs

• Failure [0.212 seconds]
macvlan Operations
/home/ec2-user/workspace/src/github.com/containernetworking/cni/gopath/src/github.com/containernetworking/cni/plugins/main/macvlan/macvlan_test.go:230
  creates an macvlan link in a non-default namespace [It]
  /home/ec2-user/workspace/src/github.com/containernetworking/cni/gopath/src/github.com/containernetworking/cni/plugins/main/macvlan/macvlan_test.go:102

  Expected error:
      <*errors.errorString | 0xc82016c060>: {
          s: "failed to create macvlan: operation not supported",
      }
      failed to create macvlan: operation not supported
  not to have occurred

  /home/ec2-user/workspace/src/github.com/containernetworking/cni/gopath/src/github.com/containernetworking/cni/plugins/main/macvlan/macvlan_test.go:87
------------------------------
• Failure [0.304 seconds]
macvlan Operations
/home/ec2-user/workspace/src/github.com/containernetworking/cni/gopath/src/github.com/containernetworking/cni/plugins/main/macvlan/macvlan_test.go:230
  configures and deconfigures a macvlan link with ADD/DEL [It]
  /home/ec2-user/workspace/src/github.com/containernetworking/cni/gopath/src/github.com/containernetworking/cni/plugins/main/macvlan/macvlan_test.go:191

  Expected error:
      <*errors.errorString | 0xc82016d2c0>: {
          s: "failed to create macvlan: operation not supported",
      }
      failed to create macvlan: operation not supported
  not to have occurred

  /home/ec2-user/workspace/src/github.com/containernetworking/cni/gopath/src/github.com/containernetworking/cni/plugins/main/macvlan/macvlan_test.go:136
------------------------------
•

Summarizing 2 Failures:

[Fail] macvlan Operations [It] creates an macvlan link in a non-default namespace
/home/ec2-user/workspace/src/github.com/containernetworking/cni/gopath/src/github.com/containernetworking/cni/plugins/main/macvlan/macvlan_test.go:87

[Fail] macvlan Operations [It] configures and deconfigures a macvlan link with ADD/DEL
/home/ec2-user/workspace/src/github.com/containernetworking/cni/gopath/src/github.com/containernetworking/cni/plugins/main/macvlan/macvlan_test.go:136

Ran 3 of 3 Specs in 0.852 seconds
FAIL! -- 1 Passed | 2 Failed | 0 Pending | 0 Skipped --- FAIL: TestMacvlan (0.85s)
FAIL
coverage: 34.7% of statements
FAIL	github.com/containernetworking/cni/plugins/main/macvlan	0.857s
ok  	github.com/containernetworking/cni/plugins/main/bridge	2.016s	coverage: 66.7% of statements
ok  	github.com/containernetworking/cni/plugins/main/ptp	0.396s	coverage: 76.8% of statements
ok  	github.com/containernetworking/cni/plugins/test/noop	2.185s	coverage: 0.0% of statements
ok  	github.com/containernetworking/cni/pkg/utils/hwaddr	0.005s	coverage: 62.5% of statements
ok  	github.com/containernetworking/cni/pkg/ip	2.275s	coverage: 47.0% of statements
ok  	github.com/containernetworking/cni/pkg/version	0.009s	coverage: 75.7% of statements
ok  	github.com/containernetworking/cni/pkg/version/testhelpers	1.309s	coverage: 76.2% of statements
ok  	github.com/containernetworking/cni/plugins/meta/flannel	1.222s	coverage: 76.5% of statements
ok  	github.com/containernetworking/cni/pkg/ipam	1.220s	coverage: 81.8% of statements
```