### PR TITLE
scripts: Add support for invoking plugin chains

### DIFF
--- a/scripts/exec-plugins.sh
+++ b/scripts/exec-plugins.sh
@@ -4,6 +4,16 @@ if [[ ${DEBUG} -gt 0 ]]; then set -x; fi
 
 NETCONFPATH=${NETCONFPATH-/etc/cni/net.d}
 
+function process_error() {
+	errmsg=$(echo $1 | jq -r '.msg')
+	if [ -z "$errmsg" ]; then
+		errmsg=$res
+	fi
+
+	echo "${name} : error executing $CNI_COMMAND: $errmsg"
+	exit 1
+}
+
 function exec_plugins() {
 	i=0
 	contid=$2
@@ -14,25 +24,39 @@ function exec_plugins() {
 	export CNI_NETNS=$netns
 
 	for netconf in $(echo $NETCONFPATH/*.conf | sort); do
+		cniVersion=$(jq -r '.cniVersion' <$netconf)
 		name=$(jq -r '.name' <$netconf)
-		plugin=$(jq -r '.type' <$netconf)
 		export CNI_IFNAME=$(printf eth%d $i)
+		numPlugins=$(jq '.plugins | length' <$netconf)
 
-		res=$($plugin <$netconf)
-		if [ $? -ne 0 ]; then
-			errmsg=$(echo $res | jq -r '.msg')
-			if [ -z "$errmsg" ]; then
-				errmsg=$res
+
+		if [ $numPlugins -eq 0 ]; then
+			plugin=$(jq -r '.type' <$netconf)
+			res=$($plugin <$netconf)
+
+			if [ $? -ne 0 ]; then
+				process_error "$res"
+			elif [[ ${DEBUG} -gt 0 ]]; then
+				echo ${res} | jq -r .
 			fi
+		else
+			for ((j=0; j<numPlugins; j++)); do
+				partConfig=$(jq -r --arg index "$j" '.plugins[$index | tonumber]' < $netconf)
+				plugin=$(jq -r --arg index "$j" '.plugins[$index | tonumber].type' < $netconf)
+				pluginConfig=$(echo $partConfig | jq -r --arg version "$cniVersion" --arg name "$name" \
+					'{"cniVersion": $version} + {"name": $name} + .')
 
-			echo "${name} : error executing $CNI_COMMAND: $errmsg"
-			exit 1
-		elif [[ ${DEBUG} -gt 0 ]]; then
-			echo ${res} | jq -r .
+				res=$(echo $pluginConfig | $plugin)
+				if [ $? -ne 0 ]; then
+					process_error "$res"
+				elif [[ ${DEBUG} -gt 0 ]]; then
+					echo ${res} | jq -r .
+				fi
+			done
 		fi
 
 		let "i=i+1"
-	done
+		done
 }
 
 if [ $# -ne 3 ]; then


### PR DESCRIPTION
Add support to the command line test script to support invoking
plugin configurations which have plugin chains and those that
do not use plugin chains.

This is useful for exercising plugin chains from the command line.
This is also needed to be able to test 
https://github.com/containernetworking/cni/issues/388

To test the chaining implementation implemented in  https://github.com/containernetworking/cni/pull/420 the following configuration file can be used.

Longer term we should consider adding capability enabling as part of the script invocation. 

```
 /etc/cni/net.d/10-mynet.conf
{
        "cniVersion": "0.3.0",
        "name": "mynet",
        "plugins": [
        {
                "type": "bridge",
                "bridge": "cni0"
        },
        {
                "type": "veth",
                "bridge": "cni0",
                "isGateway": true,
                "ipMasq": true,
                "ipam": {
                        "type": "host-local",
                        "subnet": "10.22.0.0/16",
                        "routes": [
                                { "dst": "0.0.0.0/0" }
                        ]
                }
        },
        {
                "type": "tap",
                "bridge": "cni0",
                "isGateway": true,
                "ipMasq": true,
                "ipam": {
                        "type": "host-local",
                        "subnet": "10.22.0.0/16",
                        "routes": [
                                { "dst": "0.0.0.0/0" }
                        ]
                }
        }
        ]
}

```

/cc @dcbw 

Signed-off-by: Manohar Castelino <manohar.r.castelino@intel.com>