### PR TITLE
Can we specify with network interface here?

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -408,7 +408,7 @@ Also note that plugins are executed in reverse order from the ADD action.
 
 ### IP Allocation
 
-As part of its operation, a CNI plugin is expected to assign (and maintain) an IP address to the interface and install any necessary routes relevant for that interface. This gives the CNI plugin great flexibility but also places a large burden on it. Many CNI plugins would need to have the same code to support several IP management schemes that users may desire (e.g. dhcp, host-local). 
+As part of its operation, a CNI plugin is expected to assign (and maintain) an IP address to the container's interface and install any necessary routes relevant for that interface. This gives the CNI plugin great flexibility but also places a large burden on it. Many CNI plugins would need to have the same code to support several IP management schemes that users may desire (e.g. dhcp, host-local). 
 
 To lessen the burden and make IP management strategy be orthogonal to the type of CNI plugin, we define a second type of plugin -- IP Address Management Plugin (IPAM plugin). It is however the responsibility of the CNI plugin to invoke the IPAM plugin at the proper moment in its execution. The IPAM plugin is expected to determine the interface IP/subnet, Gateway and Routes and return this information to the "main" plugin to apply. The IPAM plugin may obtain the information via a protocol (e.g. dhcp), data stored on a local filesystem, the "ipam" section of the Network Configuration file or a combination of the above.
 


### PR DESCRIPTION
Sorry, I was just reading through the spec. So my question here is:

Am I reading the spec correctly? Is this in fact the *container's interface* being referenced here?

If so, can we merge this in so we explicitly call this out. 