### PR TITLE
README: build the plugins using ./build.sh, not ./build

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The directory `/etc/cni/net.d` is the default location in which the scripts will
 Next, build the plugins:
 
 ```bash
-$ ./build
+$ ./build.sh
 ```
 
 Finally, execute a command (`ifconfig` in this example) in a private network namespace that has joined the `mynet` network:


### PR DESCRIPTION
Hi, I'm following the README to get familiar with CNI, and then find out a typo in sectio `How do I use the CNI`. See `git diff` for details.