### PR TITLE
scripts: cleanup() should rm net container in docker-run.sh

### DIFF
--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -13,7 +13,7 @@ netnspath=/proc/$pid/ns/net
 
 function cleanup() {
 	./exec-plugins.sh del $contid $netnspath
-	docker kill $contid >/dev/null
+	docker rm -f $contid >/dev/null
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
Hi, if users do `Running a Docker container with network namespace set up by CNI plugins` by following steps in README, then after this, they'll get a dead net container (busybox) left on their environments.

I'm thinking that it would be better if we clean that dead container up and leave the users' environments as clean as before. See `git diff`.