### PR TITLE
Fix unmarshall of results for interface index 0

### DIFF
--- a/pkg/types/current/types.go
+++ b/pkg/types/current/types.go
@@ -261,7 +261,7 @@ func (i *IPConfig) String() string {
 // JSON (un)marshallable types
 type ipConfig struct {
 	Version   string      `json:"version"`
-	Interface int         `json:"interface,omitempty"`
+	Interface int         `json:"interface"`
 	Address   types.IPNet `json:"address"`
 	Gateway   net.IP      `json:"gateway,omitempty"`
 }


### PR DESCRIPTION
In the "ips" struct, if the plugin passes interface index as 0 to
cni unmarshalling api, index index gets omitted in the result.

fixes #404

Signed-off-by: vikaschoudhary16 <vichoudh@redhat.com>