### PR TITLE
cnitool: support capablity args

### DIFF
--- a/cnitool/cni.go
+++ b/cnitool/cni.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -23,8 +24,9 @@ import (
 )
 
 const (
-	EnvCNIPath = "CNI_PATH"
-	EnvNetDir  = "NETCONFPATH"
+	EnvCNIPath        = "CNI_PATH"
+	EnvNetDir         = "NETCONFPATH"
+	EnvCapabilityArgs = "CAP_ARGS"
 
 	DefaultNetDir = "/etc/cni/net.d"
 
@@ -47,6 +49,14 @@ func main() {
 		exit(err)
 	}
 
+	var capabilityArgs map[string]interface{}
+	args := os.Getenv(EnvCapabilityArgs)
+	if len(args) > 0 {
+		if err = json.Unmarshal([]byte(args), &capabilityArgs); err != nil {
+			exit(err)
+		}
+	}
+
 	netns := os.Args[3]
 
 	cninet := &libcni.CNIConfig{
@@ -54,9 +64,10 @@ func main() {
 	}
 
 	rt := &libcni.RuntimeConf{
-		ContainerID: "cni",
-		NetNS:       netns,
-		IfName:      "eth0",
+		ContainerID:    "cni",
+		NetNS:          netns,
+		IfName:         "eth0",
+		CapabilityArgs: capabilityArgs,
 	}
 
 	switch os.Args[1] {


### PR DESCRIPTION
This PR adds capability args to cnitool, which will help to pass capability args for portmapping plugin (https://github.com/containernetworking/plugins/pull/1).

```
$ export CAP_ARGS='{
	"portMappings": [
		{
			"hostPort":      9090,
			"containerPort": 80,
			"protocol":      "tcp",
			"hostIP":        "127.0.0.1"
		}
	]
}'
$ cnitool add mynet /var/run/netns/myns
```

cc/ @squeed @dcbw 