### PR TITLE
Add ability to specify a bridge be placed into promiscuous mode.

### DIFF
--- a/Documentation/bridge.md
+++ b/Documentation/bridge.md
@@ -39,4 +39,5 @@ If the bridge is missing, the plugin will create one on first use and, if gatewa
 * `ipMasq` (boolean, optional): set up IP Masquerade on the host for traffic originating from this network and destined outside of it. Defaults to false.
 * `mtu` (integer, optional): explicitly set MTU to the specified value. Defaults to the value chosen by the kernel.
 * `hairpinMode` (boolean, optional): set hairpin mode for interfaces on the bridge. Defaults to false.
+* `promiscMode` (boolean, optional): set promiscuous mode on the bridge. Defaults to false.
 * `ipam` (dictionary, required): IPAM configuration to be used for this network.

--- a/Documentation/bridge.md
+++ b/Documentation/bridge.md
@@ -39,5 +39,5 @@ If the bridge is missing, the plugin will create one on first use and, if gatewa
 * `ipMasq` (boolean, optional): set up IP Masquerade on the host for traffic originating from this network and destined outside of it. Defaults to false.
 * `mtu` (integer, optional): explicitly set MTU to the specified value. Defaults to the value chosen by the kernel.
 * `hairpinMode` (boolean, optional): set hairpin mode for interfaces on the bridge. Defaults to false.
-* `promiscMode` (boolean, optional): set promiscuous mode on the bridge. Defaults to false.
+* `promiscMode` (boolean, optional): set promiscuous mode on the bridge. Defaults to false. Note that setting both hairpin and prosmiscuous mode to true is invalid.
 * `ipam` (dictionary, required): IPAM configuration to be used for this network.

--- a/plugins/main/bridge/bridge_test.go
+++ b/plugins/main/bridge/bridge_test.go
@@ -225,6 +225,7 @@ var _ = Describe("bridge Operations", func() {
 			link, err := netlink.LinkByName(IFNAME)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(link.Attrs().Name).To(Equal(IFNAME))
+			Expect(link.Attrs().Promisc).To(Equal(0))
 			return nil
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -521,6 +522,44 @@ var _ = Describe("bridge Operations", func() {
 			Expect(len(addrs)).To(Equal(1))
 			addr = addrs[0].IPNet.String()
 			Expect(addr).To(Equal(CHANGED_EXPECTED_IP))
+
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("ensure promiscuous mode on bridge", func() {
+		const IFNAME = "bridge0"
+		const EXPECTED_IP = "10.0.0.0/8"
+		const CHANGED_EXPECTED_IP = "10.1.2.3/16"
+
+		conf := &NetConf{
+			NetConf: types.NetConf{
+				CNIVersion: "0.3.1",
+				Name:       "testConfig",
+				Type:       "bridge",
+			},
+			BrName:      IFNAME,
+			IsGW:        true,
+			IPMasq:      false,
+			HairpinMode: false,
+			PromiscMode: true,
+			MTU:         5000,
+		}
+
+		err := originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			_, _, err := setupBridge(conf)
+			Expect(err).NotTo(HaveOccurred())
+			// Check if ForceAddress has default value
+			Expect(conf.ForceAddress).To(Equal(false))
+
+			//Check if promiscuous mode is set correctly
+			link, err := netlink.LinkByName("bridge0")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(link.Attrs().Promisc).To(Equal(1))
 
 			return nil
 		})


### PR DESCRIPTION
This is a work around for kubernetes issue 20096 which it allows
the bridge to accept hairpin packets.
https://github.com/kubernetes/kubernetes/issues/20096

Update documentation

Update test to reflect new changes.