### PR TITLE
Add cniVersion to Result

### DIFF
--- a/libcni/api_test.go
+++ b/libcni/api_test.go
@@ -297,6 +297,7 @@ var _ = Describe("Invoking plugins", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(result).To(Equal(&current.Result{
+					CNIVersion: current.ImplementedSpecVersion,
 					IPs: []*current.IPConfig{
 						{
 							Version: "4",
@@ -479,6 +480,7 @@ var _ = Describe("Invoking plugins", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(result).To(Equal(&current.Result{
+					CNIVersion: current.ImplementedSpecVersion,
 					// IP4 added by first plugin
 					IPs: []*current.IPConfig{
 						{

--- a/pkg/types/020/types.go
+++ b/pkg/types/020/types.go
@@ -23,9 +23,9 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 )
 
-const implementedSpecVersion string = "0.2.0"
+const ImplementedSpecVersion string = "0.2.0"
 
-var SupportedVersions = []string{"", "0.1.0", implementedSpecVersion}
+var SupportedVersions = []string{"", "0.1.0", ImplementedSpecVersion}
 
 // Compatibility types for CNI version 0.1.0 and 0.2.0
 
@@ -39,7 +39,7 @@ func NewResult(data []byte) (types.Result, error) {
 
 func GetResult(r types.Result) (*Result, error) {
 	// We expect version 0.1.0/0.2.0 results
-	result020, err := r.GetAsVersion(implementedSpecVersion)
+	result020, err := r.GetAsVersion(ImplementedSpecVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -52,18 +52,20 @@ func GetResult(r types.Result) (*Result, error) {
 
 // Result is what gets returned from the plugin (via stdout) to the caller
 type Result struct {
-	IP4 *IPConfig `json:"ip4,omitempty"`
-	IP6 *IPConfig `json:"ip6,omitempty"`
-	DNS types.DNS `json:"dns,omitempty"`
+	CNIVersion string    `json:"cniVersion,omitempty"`
+	IP4        *IPConfig `json:"ip4,omitempty"`
+	IP6        *IPConfig `json:"ip6,omitempty"`
+	DNS        types.DNS `json:"dns,omitempty"`
 }
 
 func (r *Result) Version() string {
-	return implementedSpecVersion
+	return ImplementedSpecVersion
 }
 
 func (r *Result) GetAsVersion(version string) (types.Result, error) {
 	for _, supportedVersion := range SupportedVersions {
 		if version == supportedVersion {
+			r.CNIVersion = version
 			return r, nil
 		}
 	}

--- a/pkg/types/020/types_test.go
+++ b/pkg/types/020/types_test.go
@@ -48,6 +48,7 @@ var _ = Describe("Ensures compatibility with the 0.1.0/0.2.0 spec", func() {
 
 		// Set every field of the struct to ensure source compatibility
 		res := types020.Result{
+			CNIVersion: types020.ImplementedSpecVersion,
 			IP4: &types020.IPConfig{
 				IP:      *ipv4,
 				Gateway: net.ParseIP("1.2.3.1"),
@@ -88,6 +89,7 @@ var _ = Describe("Ensures compatibility with the 0.1.0/0.2.0 spec", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(string(out)).To(Equal(`{
+    "cniVersion": "0.2.0",
     "ip4": {
         "ip": "1.2.3.30/24",
         "gateway": "1.2.3.1",

--- a/pkg/types/current/types.go
+++ b/pkg/types/current/types.go
@@ -24,9 +24,9 @@ import (
 	"github.com/containernetworking/cni/pkg/types/020"
 )
 
-const implementedSpecVersion string = "0.3.1"
+const ImplementedSpecVersion string = "0.3.1"
 
-var SupportedVersions = []string{"0.3.0", implementedSpecVersion}
+var SupportedVersions = []string{"0.3.0", ImplementedSpecVersion}
 
 func NewResult(data []byte) (types.Result, error) {
 	result := &Result{}
@@ -37,7 +37,7 @@ func NewResult(data []byte) (types.Result, error) {
 }
 
 func GetResult(r types.Result) (*Result, error) {
-	resultCurrent, err := r.GetAsVersion(implementedSpecVersion)
+	resultCurrent, err := r.GetAsVersion(ImplementedSpecVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func convertFrom020(result types.Result) (*Result, error) {
 	}
 
 	newResult := &Result{
-		CNIVersion: implementedSpecVersion,
+		CNIVersion: ImplementedSpecVersion,
 		DNS:        oldResult.DNS,
 		Routes:     []*types.Route{},
 	}
@@ -118,7 +118,7 @@ func convertFrom030(result types.Result) (*Result, error) {
 	if !ok {
 		return nil, fmt.Errorf("failed to convert result")
 	}
-	newResult.CNIVersion = implementedSpecVersion
+	newResult.CNIVersion = ImplementedSpecVersion
 	return newResult, nil
 }
 
@@ -193,12 +193,12 @@ func (r *Result) convertTo020() (*types020.Result, error) {
 }
 
 func (r *Result) Version() string {
-	return implementedSpecVersion
+	return ImplementedSpecVersion
 }
 
 func (r *Result) GetAsVersion(version string) (types.Result, error) {
 	switch version {
-	case "0.3.0", implementedSpecVersion:
+	case "0.3.0", ImplementedSpecVersion:
 		r.CNIVersion = version
 		return r, nil
 	case types020.SupportedVersions[0], types020.SupportedVersions[1], types020.SupportedVersions[2]:

--- a/pkg/types/current/types.go
+++ b/pkg/types/current/types.go
@@ -63,8 +63,9 @@ func convertFrom020(result types.Result) (*Result, error) {
 	}
 
 	newResult := &Result{
-		DNS:    oldResult.DNS,
-		Routes: []*types.Route{},
+		CNIVersion: implementedSpecVersion,
+		DNS:        oldResult.DNS,
+		Routes:     []*types.Route{},
 	}
 
 	if oldResult.IP4 != nil {
@@ -117,6 +118,7 @@ func convertFrom030(result types.Result) (*Result, error) {
 	if !ok {
 		return nil, fmt.Errorf("failed to convert result")
 	}
+	newResult.CNIVersion = implementedSpecVersion
 	return newResult, nil
 }
 
@@ -134,6 +136,7 @@ func NewResultFromResult(result types.Result) (*Result, error) {
 
 // Result is what gets returned from the plugin (via stdout) to the caller
 type Result struct {
+	CNIVersion string         `json:"cniVersion,omitempty"`
 	Interfaces []*Interface   `json:"interfaces,omitempty"`
 	IPs        []*IPConfig    `json:"ips,omitempty"`
 	Routes     []*types.Route `json:"routes,omitempty"`
@@ -143,7 +146,8 @@ type Result struct {
 // Convert to the older 0.2.0 CNI spec Result type
 func (r *Result) convertTo020() (*types020.Result, error) {
 	oldResult := &types020.Result{
-		DNS: r.DNS,
+		CNIVersion: types020.ImplementedSpecVersion,
+		DNS:        r.DNS,
 	}
 
 	for _, ip := range r.IPs {
@@ -195,6 +199,7 @@ func (r *Result) Version() string {
 func (r *Result) GetAsVersion(version string) (types.Result, error) {
 	switch version {
 	case "0.3.0", implementedSpecVersion:
+		r.CNIVersion = version
 		return r, nil
 	case types020.SupportedVersions[0], types020.SupportedVersions[1], types020.SupportedVersions[2]:
 		return r.convertTo020()

--- a/pkg/types/current/types_test.go
+++ b/pkg/types/current/types_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Current types operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(string(out)).To(Equal(`{
-    "cniVersion": "0.1.0",
+    "cniVersion": "0.2.0",
     "ip4": {
         "ip": "1.2.3.30/24",
         "gateway": "1.2.3.1",

--- a/pkg/types/current/types_test.go
+++ b/pkg/types/current/types_test.go
@@ -47,6 +47,7 @@ func testResult() *current.Result {
 
 	// Set every field of the struct to ensure source compatibility
 	return &current.Result{
+		CNIVersion: "0.3.1",
 		Interfaces: []*current.Interface{
 			{
 				Name:    "eth0",
@@ -103,6 +104,7 @@ var _ = Describe("Current types operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(string(out)).To(Equal(`{
+    "cniVersion": "0.3.1",
     "interfaces": [
         {
             "name": "eth0",
@@ -172,6 +174,7 @@ var _ = Describe("Current types operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(string(out)).To(Equal(`{
+    "cniVersion": "0.1.0",
     "ip4": {
         "ip": "1.2.3.30/24",
         "gateway": "1.2.3.1",

--- a/plugins/test/noop/noop_test.go
+++ b/plugins/test/noop/noop_test.go
@@ -130,6 +130,7 @@ var _ = Describe("No-op plugin", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(session).Should(gexec.Exit(0))
 		Expect(session.Out.Contents()).To(MatchJSON(`{
+  "cniVersion": "0.3.1",
 	"ips": [{"version": "4", "address": "10.1.2.3/24"}],
 	"dns": {"nameservers": ["1.2.3.4"]}
 }`))


### PR DESCRIPTION
According to [spec](https://github.com/containernetworking/cni/blob/master/SPEC.md#result), plugins should report cniVersion in Result.

Fixes #444.


```sh
$echo '{"cniVersion": "0.3.1","name": "mynet","type": "macvlan","bridge": "cni0","isGateway": true,"ipMasq": true,"ipam": {"type": "host-local","subnet": "10.244.1.0/24","routes": [{ "dst": "0.0.0.0/0" }]}}' | sudo CNI_COMMAND=ADD CNI_NETNS=/var/run/netns/a CNI_PATH=./bin CNI_IFNAME=eth0 CNI_CONTAINERID=a CNI_VERSION=0.3.1 ./bin/bridge
{
    "cniVersion": "0.3.1",
    "interfaces": [
        {
            "name": "cni0",
            "mac": "0a:58:0a:f4:01:01"
        },
        {
            "name": "veth7c5a44d1",
            "mac": "ae:4b:be:d5:7e:88"
        },
        {
            "name": "eth0",
            "mac": "0a:58:0a:f4:01:06",
            "sandbox": "/var/run/netns/a"
        }
    ],
    "ips": [
        {
            "version": "4",
            "interface": 2,
            "address": "10.244.1.6/24",
            "gateway": "10.244.1.1"
        }
    ],
    "routes": [
        {
            "dst": "0.0.0.0/0"
        }
    ],
    "dns": {}
}

$ echo '{"cniVersion": "0.2.0","name": "mynet","type": "macvlan","bridge": "cni0","isGateway": true,"ipMasq": true,"ipam": {"type": "host-local","subnet": "10.244.1.0/24","routes": [{ "dst": "0.0.0.0/0" }]}}' | sudo CNI_COMMAND=ADD CNI_NETNS=/var/run/netns/a CNI_PATH=./bin CNI_IFNAME=eth1 CNI_CONTAINERID=a CNI_VERSION=0.2.0 ./bin/bridge
{
    "cniVersion": "0.2.0",
    "ip4": {
        "ip": "10.244.1.5/24",
        "gateway": "10.244.1.1",
        "routes": [
            {
                "dst": "0.0.0.0/0",
                "gw": "10.244.1.1"
            }
        ]
    },
    "dns": {}
}

$ echo '{"cniVersion": "0.3.1","type":"IGNORED", "name": "a","ipam": {"type": "host-local", "subnet":"10.1.2.3/24"}}' | sudo CNI_COMMAND=ADD CNI_NETNS=/var/run/netns/a CNI_PATH=./bin CNI_IFNAME=a CNI_CONTAINERID=a CNI_VERSION=0.3.1 ./bin/host-local
{
    "cniVersion": "0.3.1",
    "ips": [
        {
            "version": "4",
            "address": "10.1.2.9/24",
            "gateway": "10.1.2.4"
        }
    ],
    "dns": {}
}
```