### PR TITLE
ipam/host-local: support multiple IP ranges

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -89,6 +89,7 @@ For example:
 | Area  | Purpose| Spec and Example | Runtime implementations | Plugin Implementations |
 | ----- | ------ | ------------     | ----------------------- | ---------------------- |
 | labels | Pass`key=value` labels to plugins | <pre>"labels" : [<br />  { "key" : "app", "value" : "myapp" },<br />  { "key" : "env", "value" : "prod" }<br />] </pre> | none | none |
+| ips   | Request custom IPs from an IPAM allocator | <pre>"ips": [ "10.0.0.42", "2001:db8:1::42"]</pre> | none | `host-local` |
 
 ## CNI_ARGS
 CNI_ARGS formed part of the original CNI spec and have been present since the initial release.

--- a/Documentation/host-local.md
+++ b/Documentation/host-local.md
@@ -5,30 +5,41 @@ it can include a DNS configuration from a `resolv.conf` file on the host.
 
 ## Overview
 
-host-local IPAM plugin allocates IPv4 addresses out of a specified address range.
+host-local IPAM plugin allocates ip addresses out of a set of address ranges.
 It stores the state locally on the host filesystem, therefore ensuring uniqueness of IP addresses on a single host.
 
 ## Example configurations
 
-IPv4:
 ```json
 {
 	"ipam": {
 		"type": "host-local",
-		"subnet": "10.10.0.0/16",
-		"rangeStart": "10.10.1.20",
-		"rangeEnd": "10.10.3.50",
-		"gateway": "10.10.0.254",
+		"ranges": [
+			{
+				"subnet": "10.10.0.0/16",
+				"rangeStart": "10.10.1.20",
+				"rangeEnd": "10.10.3.50",
+				"gateway": "10.10.0.254"
+			},
+			{
+				"subnet": "3ffe:ffff:0:01ff::/64",
+				"rangeStart": "3ffe:ffff:0:01ff::0010",
+				"rangeEnd": "3ffe:ffff:0:01ff::0020",
+			}
+		],
 		"routes": [
 			{ "dst": "0.0.0.0/0" },
-			{ "dst": "192.168.0.0/16", "gw": "10.10.5.1" }
+			{ "dst": "192.168.0.0/16", "gw": "10.10.5.1" },
+			{ "dst": "3ffe:ffff:0:01ff::1/64" }
 		],
-		"dataDir": "/var/my-orchestrator/container-ipam-state"
+		"dataDir": "/run/my-orchestrator/container-ipam-state"
 	}
 }
 ```
 
-IPv6:
+Previous versions of the `host-local` allocator did not support the `ranges`
+property, and instead expected a single range on the top level. This is
+deprecated but still supported.
 ```json
 {
   "ipam": {
@@ -49,34 +60,66 @@ We can test it out on the command-line:
 ```bash
 $ export CNI_COMMAND=ADD
 $ export CNI_CONTAINERID=f81d4fae-7dec-11d0-a765-00a0c91e6bf6
-$ echo '{ "name": "default", "ipam": { "type": "host-local", "subnet": "203.0.113.0/24" } }' | ./host-local
+$ echo '{ "cniVersion": "0.3.1", "name": "examplenet", "ipam": { "type": "host-local", "ranges": [ {"subnet": "203.0.113.0/24"}, {"subnet": "2001:db8:1::/64"}], "dataDir": "/tmp/cni-example"  } }' | CNI_COMMAND=ADD CNI_CONTAINERID=example CNI_NETNS=/dev/null CNI_IFNAME=dummy0 CNI_PATH=. ./host-local
+
 ```
 
 ```json
 {
-    "ip4": {
-        "ip": "203.0.113.1/24"
-    }
+    "ips": [
+        {
+            "version": "4",
+            "address": "203.0.113.2/24",
+            "gateway": "203.0.113.1"
+        },
+        {
+            "version": "6",
+            "address": "2001:db8:1::2/64",
+            "gateway": "2001:db8:1::1"
+        }
+    ],
+    "dns": {}
 }
 ```
 
 ## Network configuration reference
 
 * `type` (string, required): "host-local".
-* `subnet` (string, required): CIDR block to allocate out of.
-* `rangeStart` (string, optional): IP inside of "subnet" from which to start allocating addresses. Defaults to ".2" IP inside of the "subnet" block.
-* `rangeEnd` (string, optional): IP inside of "subnet" with which to end allocating addresses. Defaults to ".254" IP inside of the "subnet" block.
-* `gateway` (string, optional): IP inside of "subnet" to designate as the gateway. Defaults to ".1" IP inside of the "subnet" block.
 * `routes` (string, optional): list of routes to add to the container namespace. Each route is a dictionary with "dst" and optional "gw" fields. If "gw" is omitted, value of "gateway" will be used.
 * `resolvConf` (string, optional): Path to a `resolv.conf` on the host to parse and return as the DNS configuration
 * `dataDir` (string, optional): Path to a directory to use for maintaining state, e.g. which IPs have been allocated to which containers
+* `ranges`, (array, required, nonempty) an array of range objects:
+	* `subnet` (string, required): CIDR block to allocate out of.
+	* `rangeStart` (string, optional): IP inside of "subnet" from which to start allocating addresses. Defaults to ".2" IP inside of the "subnet" block.
+	* `rangeEnd` (string, optional): IP inside of "subnet" with which to end allocating addresses. Defaults to ".254" IP inside of the "subnet" block for ipv4, ".255" for IPv6
+	* `gateway` (string, optional): IP inside of "subnet" to designate as the gateway. Defaults to ".1" IP inside of the "subnet" block.
 
+Older versions of the `host-local` plugin did not support the `ranges` array. Instead,
+all the properties in  the `range` object were top-level. This is still supported but deprecated.
 
 ## Supported arguments
 The following [CNI_ARGS](https://github.com/containernetworking/cni/blob/master/SPEC.md#parameters) are supported:
 
-* `ip`: request a specific IP address from the subnet. If it's not available, the plugin will exit with an error
+* `ip`: request a specific IP address from a subnet.
+
+The following [args conventions](https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md)  are supported:
+
+* `ips` (array of strings): A list of custom IPs to attempt to allocate
+
+### Custom IP allocation
+For every requested custom IP, the `host-local` allocator will request that IP
+if it falls within one of the `range` objects. Thus it is possible to specify
+multiple custom IPs and multiple ranges.
+
+If any requested IPs cannot be reserved, either because they are already in use
+or are not part of a specified range, the plugin will return an error.
+
+
 
 ## Files
 
-Allocated IP addresses are stored as files in `/var/lib/cni/networks/$NETWORK_NAME`.  The prefix can be customized with the `dataDir` option listed above.
+Allocated IP addresses are stored as files in `/var/lib/cni/networks/$NETWORK_NAME`.
+The path can be customized with the `dataDir` option listed above. Environments
+where IPs are released automatically on reboot (e.g. running containers are not
+restored) may wish to specify `/var/run/cni` or another tmpfs mounted directory
+instead.

--- a/pkg/ip/cidr.go
+++ b/pkg/ip/cidr.go
@@ -31,6 +31,16 @@ func PrevIP(ip net.IP) net.IP {
 	return intToIP(i.Sub(i, big.NewInt(1)))
 }
 
+// Cmp compares two IPs, returning the usual ordering:
+// a < b : -1
+// a == b : 0
+// a > b : 1
+func Cmp(a, b net.IP) int {
+	aa := ipToInt(a)
+	bb := ipToInt(b)
+	return aa.Cmp(bb)
+}
+
 func ipToInt(ip net.IP) *big.Int {
 	if v := ip.To4(); v != nil {
 		return big.NewInt(0).SetBytes(v)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -56,6 +56,10 @@ func (n *IPNet) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n *IPNet) String() string {
+	return (*net.IPNet)(n).String()
+}
+
 // NetConf describes a network.
 type NetConf struct {
 	CNIVersion string `json:"cniVersion,omitempty"`

--- a/plugins/ipam/host-local/backend/allocator/config.go
+++ b/plugins/ipam/host-local/backend/allocator/config.go
@@ -23,32 +23,47 @@ import (
 )
 
 // IPAMConfig represents the IP related network configuration.
+// This nests Range because we initially only supported a single
+// range directly, and wish to preserve backwards compatability
 type IPAMConfig struct {
+	*Range
 	Name       string
-	Type       string        `json:"type"`
-	RangeStart net.IP        `json:"rangeStart"`
-	RangeEnd   net.IP        `json:"rangeEnd"`
-	Subnet     types.IPNet   `json:"subnet"`
-	Gateway    net.IP        `json:"gateway"`
-	Routes     []types.Route `json:"routes"`
-	DataDir    string        `json:"dataDir"`
-	ResolvConf string        `json:"resolvConf"`
-	Args       *IPAMArgs     `json:"-"`
+	Type       string         `json:"type"`
+	Routes     []*types.Route `json:"routes"`
+	DataDir    string         `json:"dataDir"`
+	ResolvConf string         `json:"resolvConf"`
+	Ranges     []Range        `json:"ranges"`
+	IPArgs     []net.IP       `json:"-"` // Requested IPs from CNI_ARGS and args
 }
 
-type IPAMArgs struct {
+type IPAMEnvArgs struct {
 	types.CommonArgs
 	IP net.IP `json:"ip,omitempty"`
 }
 
+type IPAMArgs struct {
+	IPs []net.IP `json:"ips"`
+}
+
+// The top-level network config, just so we can get the IPAM block
 type Net struct {
 	Name       string      `json:"name"`
 	CNIVersion string      `json:"cniVersion"`
 	IPAM       *IPAMConfig `json:"ipam"`
+	Args       *struct {
+		A *IPAMArgs `json:"cni"`
+	} `json:"args"`
+}
+
+type Range struct {
+	RangeStart net.IP      `json:"rangeStart,omitempty"` // The first ip, inclusive
+	RangeEnd   net.IP      `json:"rangeEnd,omitempty"`   // The last ip, inclusive
+	Subnet     types.IPNet `json:"subnet"`
+	Gateway    net.IP      `json:"gateway,omitempty"`
 }
 
 // NewIPAMConfig creates a NetworkConfig from the given network name.
-func LoadIPAMConfig(bytes []byte, args string) (*IPAMConfig, string, error) {
+func LoadIPAMConfig(bytes []byte, envArgs string) (*IPAMConfig, string, error) {
 	n := Net{}
 	if err := json.Unmarshal(bytes, &n); err != nil {
 		return nil, "", err
@@ -58,11 +73,44 @@ func LoadIPAMConfig(bytes []byte, args string) (*IPAMConfig, string, error) {
 		return nil, "", fmt.Errorf("IPAM config missing 'ipam' key")
 	}
 
-	if args != "" {
-		n.IPAM.Args = &IPAMArgs{}
-		err := types.LoadArgs(args, n.IPAM.Args)
+	// Parse custom IP from both env args *and* the top-level args config
+	if envArgs != "" {
+		e := IPAMEnvArgs{}
+		err := types.LoadArgs(envArgs, &e)
 		if err != nil {
 			return nil, "", err
+		}
+
+		if e.IP != nil {
+			n.IPAM.IPArgs = []net.IP{e.IP}
+		}
+	}
+
+	if n.Args != nil && n.Args.A != nil && len(n.Args.A.IPs) != 0 {
+		n.IPAM.IPArgs = append(n.IPAM.IPArgs, n.Args.A.IPs...)
+	}
+
+	for idx, _ := range n.IPAM.IPArgs {
+		if err := canonicalizeIP(&n.IPAM.IPArgs[idx]); err != nil {
+			return nil, "", fmt.Errorf("cannot understand ip: %v", err)
+		}
+	}
+
+	// If a single range (old-style config) is specified, move it to
+	// the Ranges array
+	if n.IPAM.Range != nil && n.IPAM.Range.Subnet.IP != nil {
+		n.IPAM.Ranges = append([]Range{*n.IPAM.Range}, n.IPAM.Ranges...)
+	}
+	n.IPAM.Range = nil
+
+	if len(n.IPAM.Ranges) == 0 {
+		return nil, "", fmt.Errorf("no IP ranges specified")
+	}
+
+	// Validate all ranges
+	for i, _ := range n.IPAM.Ranges {
+		if err := n.IPAM.Ranges[i].Canonicalize(); err != nil {
+			return nil, "", fmt.Errorf("Cannot understand range %d: %v", i, err)
 		}
 	}
 
@@ -70,15 +118,4 @@ func LoadIPAMConfig(bytes []byte, args string) (*IPAMConfig, string, error) {
 	n.IPAM.Name = n.Name
 
 	return n.IPAM, n.CNIVersion, nil
-}
-
-func convertRoutesToCurrent(routes []types.Route) []*types.Route {
-	var currentRoutes []*types.Route
-	for _, r := range routes {
-		currentRoutes = append(currentRoutes, &types.Route{
-			Dst: r.Dst,
-			GW:  r.GW,
-		})
-	}
-	return currentRoutes
 }

--- a/plugins/ipam/host-local/backend/allocator/config_test.go
+++ b/plugins/ipam/host-local/backend/allocator/config_test.go
@@ -1,0 +1,235 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package allocator
+
+import (
+	"net"
+
+	"github.com/containernetworking/cni/pkg/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("IPAM config", func() {
+	It("Should parse an old-style config", func() {
+		input := `{
+    "cniVersion": "0.3.1",
+    "name": "mynet",
+    "type": "ipvlan",
+    "master": "foo0",
+    "ipam": {
+        "type": "host-local",
+        "subnet": "10.1.2.0/24",
+		"rangeStart": "10.1.2.9",
+		"rangeEnd": "10.1.2.20",
+		"gateway": "10.1.2.30"
+    }
+}`
+		conf, version, err := LoadIPAMConfig([]byte(input), "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(version).Should(Equal("0.3.1"))
+
+		Expect(conf).To(Equal(&IPAMConfig{
+			Name: "mynet",
+			Type: "host-local",
+			Ranges: []Range{
+				{
+					RangeStart: net.IP{10, 1, 2, 9},
+					RangeEnd:   net.IP{10, 1, 2, 20},
+					Gateway:    net.IP{10, 1, 2, 30},
+					Subnet: types.IPNet{
+						IP:   net.IP{10, 1, 2, 0},
+						Mask: net.CIDRMask(24, 32),
+					},
+				},
+			},
+		}))
+	})
+	It("Should parse a new-style config", func() {
+		input := `{
+    "cniVersion": "0.3.1",
+    "name": "mynet",
+    "type": "ipvlan",
+    "master": "foo0",
+    "ipam": {
+        "type": "host-local",
+		"ranges": [
+			{
+				"subnet": "10.1.2.0/24",
+				"rangeStart": "10.1.2.9",
+				"rangeEnd": "10.1.2.20",
+				"gateway": "10.1.2.30"
+			},
+			{
+				"subnet": "11.1.2.0/24",
+				"rangeStart": "11.1.2.9",
+				"rangeEnd": "11.1.2.20",
+				"gateway": "11.1.2.30"
+			}
+		]
+    }
+}`
+		conf, version, err := LoadIPAMConfig([]byte(input), "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(version).Should(Equal("0.3.1"))
+
+		Expect(conf).To(Equal(&IPAMConfig{
+			Name: "mynet",
+			Type: "host-local",
+			Ranges: []Range{
+				{
+					RangeStart: net.IP{10, 1, 2, 9},
+					RangeEnd:   net.IP{10, 1, 2, 20},
+					Gateway:    net.IP{10, 1, 2, 30},
+					Subnet: types.IPNet{
+						IP:   net.IP{10, 1, 2, 0},
+						Mask: net.CIDRMask(24, 32),
+					},
+				},
+				{
+					RangeStart: net.IP{11, 1, 2, 9},
+					RangeEnd:   net.IP{11, 1, 2, 20},
+					Gateway:    net.IP{11, 1, 2, 30},
+					Subnet: types.IPNet{
+						IP:   net.IP{11, 1, 2, 0},
+						Mask: net.CIDRMask(24, 32),
+					},
+				},
+			},
+		}))
+	})
+
+	It("Should parse a mixed config", func() {
+		input := `{
+    "cniVersion": "0.3.1",
+    "name": "mynet",
+    "type": "ipvlan",
+    "master": "foo0",
+    "ipam": {
+        "type": "host-local",
+        "subnet": "10.1.2.0/24",
+		"rangeStart": "10.1.2.9",
+		"rangeEnd": "10.1.2.20",
+		"gateway": "10.1.2.30",
+		"ranges": [
+			{
+				"subnet": "11.1.2.0/24",
+				"rangeStart": "11.1.2.9",
+				"rangeEnd": "11.1.2.20",
+				"gateway": "11.1.2.30"
+			}
+		]
+    }
+}`
+		conf, version, err := LoadIPAMConfig([]byte(input), "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(version).Should(Equal("0.3.1"))
+
+		Expect(conf).To(Equal(&IPAMConfig{
+			Name: "mynet",
+			Type: "host-local",
+			Ranges: []Range{
+				{
+					RangeStart: net.IP{10, 1, 2, 9},
+					RangeEnd:   net.IP{10, 1, 2, 20},
+					Gateway:    net.IP{10, 1, 2, 30},
+					Subnet: types.IPNet{
+						IP:   net.IP{10, 1, 2, 0},
+						Mask: net.CIDRMask(24, 32),
+					},
+				},
+				{
+					RangeStart: net.IP{11, 1, 2, 9},
+					RangeEnd:   net.IP{11, 1, 2, 20},
+					Gateway:    net.IP{11, 1, 2, 30},
+					Subnet: types.IPNet{
+						IP:   net.IP{11, 1, 2, 0},
+						Mask: net.CIDRMask(24, 32),
+					},
+				},
+			},
+		}))
+	})
+
+	It("Should parse CNI_ARGS env", func() {
+		input := `{
+    "cniVersion": "0.3.1",
+    "name": "mynet",
+    "type": "ipvlan",
+    "master": "foo0",
+    "ipam": {
+        "type": "host-local",
+		"ranges": [
+			{
+				"subnet": "10.1.2.0/24",
+				"rangeStart": "10.1.2.9",
+				"rangeEnd": "10.1.2.20",
+				"gateway": "10.1.2.30"
+			},
+			{
+				"subnet": "11.1.2.0/24",
+				"rangeStart": "11.1.2.9",
+				"rangeEnd": "11.1.2.20",
+				"gateway": "11.1.2.30"
+			}
+		]
+    }
+}`
+
+		envArgs := "IP=10.1.2.10"
+
+		conf, _, err := LoadIPAMConfig([]byte(input), envArgs)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(conf.IPArgs).To(Equal([]net.IP{{10, 1, 2, 10}}))
+
+	})
+	It("Should parse config args", func() {
+		input := `{
+    "cniVersion": "0.3.1",
+    "name": "mynet",
+    "type": "ipvlan",
+    "master": "foo0",
+	"args": {
+		"cni": {
+			"ips": [ "10.1.2.11", "11.11.11.11"]
+		}
+	},
+    "ipam": {
+        "type": "host-local",
+		"ranges": [
+			{
+				"subnet": "10.1.2.0/24",
+				"rangeStart": "10.1.2.9",
+				"rangeEnd": "10.1.2.20",
+				"gateway": "10.1.2.30"
+			},
+			{
+				"subnet": "11.1.2.0/24",
+				"rangeStart": "11.1.2.9",
+				"rangeEnd": "11.1.2.20",
+				"gateway": "11.1.2.30"
+			}
+		]
+    }
+}`
+
+		envArgs := "IP=10.1.2.10"
+
+		conf, _, err := LoadIPAMConfig([]byte(input), envArgs)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(conf.IPArgs).To(Equal([]net.IP{{10, 1, 2, 10}, {10, 1, 2, 11}, {11, 11, 11, 11}}))
+
+	})
+})

--- a/plugins/ipam/host-local/backend/allocator/range.go
+++ b/plugins/ipam/host-local/backend/allocator/range.go
@@ -1,0 +1,145 @@
+// Copyright 2017 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package allocator
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/containernetworking/cni/pkg/ip"
+	"github.com/containernetworking/cni/pkg/types"
+)
+
+// Validate takes a given range and ensures that all information is consistent,
+// filling out Start, End, and Gateway with sane values if missing
+func (r *Range) Canonicalize() error {
+	if err := canonicalizeIP(&r.Subnet.IP); err != nil {
+		return err
+	}
+
+	// Can't create an allocator for a network with no addresses, eg
+	// a /32 or /31
+	ones, masklen := r.Subnet.Mask.Size()
+	if ones > masklen-2 {
+		return fmt.Errorf("Network %s too small to allocate from", r.Subnet.String())
+	}
+
+	if len(r.Subnet.IP) != len(r.Subnet.Mask) {
+		return fmt.Errorf("IPNet IP and Mask version mismatch")
+	}
+
+	// If the gateway is nil, claim .1
+	if r.Gateway == nil {
+		r.Gateway = ip.NextIP(r.Subnet.IP)
+	} else {
+		if err := canonicalizeIP(&r.Gateway); err != nil {
+			return err
+		}
+		subnet := (net.IPNet)(r.Subnet)
+		if !subnet.Contains(r.Gateway) {
+			return fmt.Errorf("gateway %s not in network %s", r.Gateway.String(), subnet.String())
+		}
+	}
+
+	// RangeStart: If specified, make sure it's sane (inside the subnet),
+	// otherwise use .2
+	if r.RangeStart != nil {
+		if err := canonicalizeIP(&r.RangeStart); err != nil {
+			return err
+		}
+
+		if err := r.IPInRange(r.RangeStart); err != nil {
+			return err
+		}
+	} else {
+		r.RangeStart = ip.NextIP(ip.NextIP(r.Subnet.IP))
+	}
+
+	// RangeEnd: If specified, verify sanity. Otherwise, add a sensible default
+	// (e.g. for a /24: .254 if IPv4, ::255 if IPv6)
+	if r.RangeEnd != nil {
+		if err := canonicalizeIP(&r.RangeEnd); err != nil {
+			return err
+		}
+
+		if err := r.IPInRange(r.RangeEnd); err != nil {
+			return err
+		}
+	} else {
+		r.RangeEnd = lastIP(r.Subnet)
+	}
+
+	return nil
+}
+
+// IsValidIP checks if a given ip is a valid, allocatable address in a given Range
+func (r *Range) IPInRange(addr net.IP) error {
+	if err := canonicalizeIP(&addr); err != nil {
+		return err
+	}
+
+	subnet := (net.IPNet)(r.Subnet)
+
+	if len(addr) != len(r.Subnet.IP) {
+		return fmt.Errorf("IP %s is not the same protocol as subnet %s",
+			addr, subnet.String())
+	}
+
+	if !subnet.Contains(addr) {
+		return fmt.Errorf("%s not in network %s", addr, subnet.String())
+	}
+
+	// We ignore nils here so we can use this function as we initialize the range.
+	if r.RangeStart != nil {
+		if ip.Cmp(addr, r.RangeStart) < 0 {
+			return fmt.Errorf("%s is in network %s but before start %s",
+				addr, r.Subnet.String(), r.RangeStart)
+		}
+	}
+
+	if r.RangeEnd != nil {
+		if ip.Cmp(addr, r.RangeEnd) > 0 {
+			return fmt.Errorf("%s is in network %s but after end %s",
+				addr, r.Subnet.String(), r.RangeEnd)
+		}
+	}
+
+	return nil
+}
+
+// canonicalizeIP makes sure a provided ip is in standard form
+func canonicalizeIP(ip *net.IP) error {
+	if ip.To4() != nil {
+		*ip = ip.To4()
+		return nil
+	} else if ip.To16() != nil {
+		*ip = ip.To16()
+		return nil
+	}
+	return fmt.Errorf("IP %s not v4 nor v6", *ip)
+}
+
+// Determine the last IP of a subnet, excluding the broadcast if IPv4
+func lastIP(subnet types.IPNet) net.IP {
+	var end net.IP
+	for i := 0; i < len(subnet.IP); i++ {
+		end = append(end, subnet.IP[i]|^subnet.Mask[i])
+	}
+	if subnet.IP.To4() != nil {
+		end[3]--
+	}
+
+	return end
+}

--- a/plugins/ipam/host-local/backend/allocator/range_test.go
+++ b/plugins/ipam/host-local/backend/allocator/range_test.go
@@ -1,0 +1,146 @@
+// Copyright 2017 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package allocator
+
+import (
+	"net"
+
+	"github.com/containernetworking/cni/pkg/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("IP ranges", func() {
+	It("should generate sane defaults for ipv4", func() {
+		snstr := "192.0.2.0/24"
+		r := Range{Subnet: mustSubnet(snstr)}
+
+		err := r.Canonicalize()
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(r).To(Equal(Range{
+			Subnet:     mustSubnet(snstr),
+			RangeStart: net.IP{192, 0, 2, 2},
+			RangeEnd:   net.IP{192, 0, 2, 254},
+			Gateway:    net.IP{192, 0, 2, 1},
+		}))
+	})
+	It("should generate sane defaults for a smaller ipv4 subnet", func() {
+		snstr := "192.0.2.0/25"
+		r := Range{Subnet: mustSubnet(snstr)}
+
+		err := r.Canonicalize()
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(r).To(Equal(Range{
+			Subnet:     mustSubnet(snstr),
+			RangeStart: net.IP{192, 0, 2, 2},
+			RangeEnd:   net.IP{192, 0, 2, 126},
+			Gateway:    net.IP{192, 0, 2, 1},
+		}))
+	})
+	It("should generate sane defaults for ipv6", func() {
+		snstr := "2001:DB8:1::/64"
+		r := Range{Subnet: mustSubnet(snstr)}
+
+		err := r.Canonicalize()
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(r).To(Equal(Range{
+			Subnet:     mustSubnet(snstr),
+			RangeStart: net.ParseIP("2001:DB8:1::2"),
+			RangeEnd:   net.ParseIP("2001:DB8:1::ffff:ffff:ffff:ffff"),
+			Gateway:    net.ParseIP("2001:DB8:1::1"),
+		}))
+	})
+
+	It("Should reject a network that's too small", func() {
+		r := Range{Subnet: mustSubnet("192.0.2.0/31")}
+		err := r.Canonicalize()
+		Expect(err).Should(MatchError("Network 192.0.2.0/31 too small to allocate from"))
+	})
+
+	It("should reject invalid RangeStart and RangeEnd specifications", func() {
+		r := Range{Subnet: mustSubnet("192.0.2.0/24"), RangeStart: net.ParseIP("192.0.3.0")}
+		err := r.Canonicalize()
+		Expect(err).Should(MatchError("192.0.3.0 not in network 192.0.2.0/24"))
+
+		r = Range{Subnet: mustSubnet("192.0.2.0/24"), RangeEnd: net.ParseIP("192.0.4.0")}
+		err = r.Canonicalize()
+		Expect(err).Should(MatchError("192.0.4.0 not in network 192.0.2.0/24"))
+
+		r = Range{
+			Subnet:     mustSubnet("192.0.2.0/24"),
+			RangeStart: net.ParseIP("192.0.2.50"),
+			RangeEnd:   net.ParseIP("192.0.2.40"),
+		}
+		err = r.Canonicalize()
+		Expect(err).Should(MatchError("192.0.2.50 is in network 192.0.2.0/24 but after end 192.0.2.40"))
+	})
+
+	It("should reject invalid gateways", func() {
+		r := Range{Subnet: mustSubnet("192.0.2.0/24"), Gateway: net.ParseIP("192.0.3.0")}
+		err := r.Canonicalize()
+		Expect(err).Should(MatchError("gateway 192.0.3.0 not in network 192.0.2.0/24"))
+	})
+
+	It("should parse all fields correctly", func() {
+		r := Range{
+			Subnet:     mustSubnet("192.0.2.0/24"),
+			RangeStart: net.ParseIP("192.0.2.40"),
+			RangeEnd:   net.ParseIP("192.0.2.50"),
+			Gateway:    net.ParseIP("192.0.2.254"),
+		}
+		err := r.Canonicalize()
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(r).To(Equal(Range{
+			Subnet:     mustSubnet("192.0.2.0/24"),
+			RangeStart: net.IP{192, 0, 2, 40},
+			RangeEnd:   net.IP{192, 0, 2, 50},
+			Gateway:    net.IP{192, 0, 2, 254},
+		}))
+	})
+
+	It("should accept IPs in range and reject IPs out of range", func() {
+		r := Range{
+			Subnet:     mustSubnet("192.0.2.0/24"),
+			RangeStart: net.ParseIP("192.0.2.40"),
+			RangeEnd:   net.ParseIP("192.0.2.50"),
+			Gateway:    net.ParseIP("192.0.2.254"),
+		}
+		err := r.Canonicalize()
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(r.IPInRange(net.ParseIP("192.0.3.0"))).Should(MatchError(
+			"192.0.3.0 not in network 192.0.2.0/24"))
+
+		Expect(r.IPInRange(net.ParseIP("192.0.2.39"))).Should(MatchError(
+			"192.0.2.39 is in network 192.0.2.0/24 but before start 192.0.2.40"))
+		Expect(r.IPInRange(net.ParseIP("192.0.2.40"))).Should(BeNil())
+		Expect(r.IPInRange(net.ParseIP("192.0.2.50"))).Should(BeNil())
+		Expect(r.IPInRange(net.ParseIP("192.0.2.51"))).Should(MatchError(
+			"192.0.2.51 is in network 192.0.2.0/24 but after end 192.0.2.50"))
+	})
+})
+
+func mustSubnet(s string) types.IPNet {
+	n, err := types.ParseCIDR(s)
+	if err != nil {
+		Fail(err.Error())
+	}
+	canonicalizeIP(&n.IP)
+	return types.IPNet(*n)
+}

--- a/plugins/ipam/host-local/backend/store.go
+++ b/plugins/ipam/host-local/backend/store.go
@@ -20,8 +20,8 @@ type Store interface {
 	Lock() error
 	Unlock() error
 	Close() error
-	Reserve(id string, ip net.IP) (bool, error)
-	LastReservedIP() (net.IP, error)
+	Reserve(id string, ip net.IP, rangeIdx int) (bool, error)
+	LastReservedIP(rangeIdx int) (net.IP, error)
 	Release(ip net.IP) error
 	ReleaseByID(id string) error
 }

--- a/plugins/ipam/host-local/host_local_test.go
+++ b/plugins/ipam/host-local/host_local_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 var _ = Describe("host-local Operations", func() {
-	It("allocates and releases an address with ADD/DEL", func() {
+	It("allocates and releases addresses with ADD/DEL", func() {
 		const ifname string = "eth0"
 		const nspath string = "/some/where"
 
@@ -51,9 +51,18 @@ var _ = Describe("host-local Operations", func() {
     "master": "foo0",
     "ipam": {
         "type": "host-local",
-        "subnet": "10.1.2.0/24",
         "dataDir": "%s",
-		"resolvConf": "%s/resolv.conf"
+		"resolvConf": "%s/resolv.conf",
+		"ranges": [
+			{ "subnet": "10.1.2.0/24" },
+			{ "subnet": "2001:db8:1::0/64" }
+		],
+		"routes": [
+			{"dst": "0.0.0.0/0"},
+			{"dst": "::/0"},
+			{"dst": "192.168.0.0/16", "gw": "1.1.1.1"},
+			{"dst": "2001:db8:2::0/64", "gw": "2001:db8:3::1"}
+		]
     }
 }`, tmpDir, tmpDir)
 
@@ -74,30 +83,55 @@ var _ = Describe("host-local Operations", func() {
 		result, err := current.GetResult(r)
 		Expect(err).NotTo(HaveOccurred())
 
-		expectedAddress, err := types.ParseCIDR("10.1.2.2/24")
+		expectedAddress1, err := types.ParseCIDR("10.1.2.2/24")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(len(result.IPs)).To(Equal(1))
-		expectedAddress.IP = expectedAddress.IP.To16()
-		Expect(result.IPs[0].Address).To(Equal(*expectedAddress))
-		Expect(result.IPs[0].Gateway).To(Equal(net.ParseIP("10.1.2.1")))
+		expectedAddress2, err := types.ParseCIDR("2001:db8:1::2/64")
+		Expect(err).NotTo(HaveOccurred())
 
-		ipFilePath := filepath.Join(tmpDir, "mynet", "10.1.2.2")
-		contents, err := ioutil.ReadFile(ipFilePath)
+		Expect(len(result.IPs)).To(Equal(2))
+		Expect(result.IPs[0].Address).To(Equal(*expectedAddress1))
+		Expect(result.IPs[0].Gateway).To(Equal(net.ParseIP("10.1.2.1")))
+		Expect(result.IPs[0].Version).To(Equal("4"))
+
+		Expect(result.IPs[1].Address).To(Equal(*expectedAddress2))
+		Expect(result.IPs[1].Gateway).To(Equal(net.ParseIP("2001:db8:1::1")))
+		Expect(result.IPs[1].Version).To(Equal("6"))
+
+		Expect(result.Routes).To(Equal([]*types.Route{
+			&types.Route{Dst: mustCIDR("0.0.0.0/0"), GW: nil},
+			&types.Route{Dst: mustCIDR("::/0"), GW: nil},
+			&types.Route{Dst: mustCIDR("192.168.0.0/16"), GW: net.ParseIP("1.1.1.1")},
+			&types.Route{Dst: mustCIDR("2001:db8:2::0/64"), GW: net.ParseIP("2001:db8:3::1")},
+		}))
+
+		ipFilePath1 := filepath.Join(tmpDir, "mynet", "10.1.2.2")
+		contents, err := ioutil.ReadFile(ipFilePath1)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(contents)).To(Equal("dummy"))
 
-		lastFilePath := filepath.Join(tmpDir, "mynet", "last_reserved_ip")
-		contents, err = ioutil.ReadFile(lastFilePath)
+		ipFilePath2 := filepath.Join(tmpDir, "mynet", "2001:db8:1::2")
+		contents, err = ioutil.ReadFile(ipFilePath2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(contents)).To(Equal("dummy"))
+
+		lastFilePath1 := filepath.Join(tmpDir, "mynet", "last_reserved_ip")
+		contents, err = ioutil.ReadFile(lastFilePath1)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(contents)).To(Equal("10.1.2.2"))
 
+		lastFilePath2 := filepath.Join(tmpDir, "mynet", "last_reserved_ip.1")
+		contents, err = ioutil.ReadFile(lastFilePath2)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(contents)).To(Equal("2001:db8:1::2"))
 		// Release the IP
 		err = testutils.CmdDelWithResult(nspath, ifname, func() error {
 			return cmdDel(args)
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		_, err = os.Stat(ipFilePath)
+		_, err = os.Stat(ipFilePath1)
+		Expect(err).To(HaveOccurred())
+		_, err = os.Stat(ipFilePath2)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -289,4 +323,203 @@ var _ = Describe("host-local Operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(strings.Index(string(out), "Error retriving last reserved ip")).To(Equal(-1))
 	})
+
+	It("allocates a custom IP when requested by config args", func() {
+		const ifname string = "eth0"
+		const nspath string = "/some/where"
+
+		tmpDir, err := ioutil.TempDir("", "host_local_artifacts")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+
+		conf := fmt.Sprintf(`{
+    "cniVersion": "0.3.1",
+    "name": "mynet",
+    "type": "ipvlan",
+    "master": "foo0",
+    "ipam": {
+        "type": "host-local",
+        "dataDir": "%s",
+		"ranges": [
+			{ "subnet": "10.1.2.0/24" }
+		]
+    },
+	"args": {
+		"cni": {
+			"ips": ["10.1.2.88"]
+		}
+	}
+}`, tmpDir)
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       nspath,
+			IfName:      ifname,
+			StdinData:   []byte(conf),
+		}
+
+		// Allocate the IP
+		r, _, err := testutils.CmdAddWithResult(nspath, ifname, []byte(conf), func() error {
+			return cmdAdd(args)
+		})
+		Expect(err).NotTo(HaveOccurred())
+		result, err := current.GetResult(r)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.IPs).To(HaveLen(1))
+		Expect(result.IPs[0].Address.IP).To(Equal(net.ParseIP("10.1.2.88")))
+	})
+
+	It("allocates custom IPs from multiple ranges", func() {
+		const ifname string = "eth0"
+		const nspath string = "/some/where"
+
+		tmpDir, err := ioutil.TempDir("", "host_local_artifacts")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+
+		err = ioutil.WriteFile(filepath.Join(tmpDir, "resolv.conf"), []byte("nameserver 192.0.2.3"), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		conf := fmt.Sprintf(`{
+    "cniVersion": "0.3.1",
+    "name": "mynet",
+    "type": "ipvlan",
+    "master": "foo0",
+    "ipam": {
+        "type": "host-local",
+        "dataDir": "%s",
+		"ranges": [
+			{ "subnet": "10.1.2.0/24" },
+			{ "subnet": "10.1.3.0/24" }
+		]
+    },
+	"args": {
+		"cni": {
+			"ips": ["10.1.2.88", "10.1.3.77"]
+		}
+	}
+}`, tmpDir)
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       nspath,
+			IfName:      ifname,
+			StdinData:   []byte(conf),
+		}
+
+		// Allocate the IP
+		r, _, err := testutils.CmdAddWithResult(nspath, ifname, []byte(conf), func() error {
+			return cmdAdd(args)
+		})
+		Expect(err).NotTo(HaveOccurred())
+		result, err := current.GetResult(r)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.IPs).To(HaveLen(2))
+		Expect(result.IPs[0].Address.IP).To(Equal(net.ParseIP("10.1.2.88")))
+		Expect(result.IPs[1].Address.IP).To(Equal(net.ParseIP("10.1.3.77")))
+	})
+
+	It("allocates custom IPs from multiple protocols", func() {
+		const ifname string = "eth0"
+		const nspath string = "/some/where"
+
+		tmpDir, err := ioutil.TempDir("", "host_local_artifacts")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+
+		err = ioutil.WriteFile(filepath.Join(tmpDir, "resolv.conf"), []byte("nameserver 192.0.2.3"), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		conf := fmt.Sprintf(`{
+    "cniVersion": "0.3.1",
+    "name": "mynet",
+    "type": "ipvlan",
+    "master": "foo0",
+    "ipam": {
+        "type": "host-local",
+        "dataDir": "%s",
+		"ranges": [
+			{ "subnet": "10.1.2.0/24" },
+			{ "subnet": "2001:db8:1::/24" }
+		]
+    },
+	"args": {
+		"cni": {
+			"ips": ["10.1.2.88", "2001:db8:1::999"]
+		}
+	}
+}`, tmpDir)
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       nspath,
+			IfName:      ifname,
+			StdinData:   []byte(conf),
+		}
+
+		// Allocate the IP
+		r, _, err := testutils.CmdAddWithResult(nspath, ifname, []byte(conf), func() error {
+			return cmdAdd(args)
+		})
+		Expect(err).NotTo(HaveOccurred())
+		result, err := current.GetResult(r)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.IPs).To(HaveLen(2))
+		Expect(result.IPs[0].Address.IP).To(Equal(net.ParseIP("10.1.2.88")))
+		Expect(result.IPs[1].Address.IP).To(Equal(net.ParseIP("2001:db8:1::999")))
+	})
+
+	It("fails if a requested custom IP is not used", func() {
+		const ifname string = "eth0"
+		const nspath string = "/some/where"
+
+		tmpDir, err := ioutil.TempDir("", "host_local_artifacts")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+
+		conf := fmt.Sprintf(`{
+    "cniVersion": "0.3.1",
+    "name": "mynet",
+    "type": "ipvlan",
+    "master": "foo0",
+    "ipam": {
+        "type": "host-local",
+        "dataDir": "%s",
+		"ranges": [
+			{ "subnet": "10.1.2.0/24" },
+			{ "subnet": "10.1.3.0/24" }
+		]
+    },
+	"args": {
+		"cni": {
+			"ips": ["10.1.2.88", "10.1.2.77"]
+		}
+	}
+}`, tmpDir)
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       nspath,
+			IfName:      ifname,
+			StdinData:   []byte(conf),
+		}
+
+		// Allocate the IP
+		_, _, err = testutils.CmdAddWithResult(nspath, ifname, []byte(conf), func() error {
+			return cmdAdd(args)
+		})
+		Expect(err).To(HaveOccurred())
+		// Need to match prefix, because ordering is not guaranteed
+		Expect(err.Error()).To(HavePrefix("failed to allocate all requested IPs: 10.1.2."))
+	})
 })
+
+func mustCIDR(s string) net.IPNet {
+	_, n, err := net.ParseCIDR(s)
+	n.IP = n.IP.To16()
+	if err != nil {
+		Fail(err.Error())
+	}
+
+	return *n
+}


### PR DESCRIPTION
This change allows the host-local allocator to allocate multiple IPs. This is intended to enable dual-stack, but is not limited to only two subnets.

Not actually a large change; mostly improved testing.