### PR TITLE
Add OpenShift to the list of container runtimes that support CNI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ To avoid duplication, we think it is prudent to define a common interface betwee
 - [rkt - container engine](https://coreos.com/blog/rkt-cni-networking.html)
 - [Kurma - container runtime](http://kurma.io/)
 - [Kubernetes - a system to simplify container operations](http://kubernetes.io/docs/admin/network-plugins/)
+- [OpenShift - Kubernetes with additional enterprise features](https://github.com/openshift/origin/blob/master/docs/openshift_networking_requirements.md)
 - [Cloud Foundry - a platform for cloud applications](https://github.com/cloudfoundry-incubator/netman-release)
 - [Mesos - a distributed systems kernel](https://github.com/apache/mesos/blob/master/docs/cni.md)
 


### PR DESCRIPTION
OpenShift uses CNI, so I thought a link to the appropriate docs made
sense in the top-level readme where it lists the other supporting
runtimes.