### PR TITLE
Allow setting promiscuous mode for bridge

### DIFF
--- a/Documentation/bridge.md
+++ b/Documentation/bridge.md
@@ -39,4 +39,6 @@ If the bridge is missing, the plugin will create one on first use and, if gatewa
 * `ipMasq` (boolean, optional): set up IP Masquerade on the host for traffic originating from this network and destined outside of it. Defaults to false.
 * `mtu` (integer, optional): explicitly set MTU to the specified value. Defaults to the value chosen by the kernel.
 * `hairpinMode` (boolean, optional): set hairpin mode for interfaces on the bridge. Defaults to false.
+* `promisc` (boolean, optional): set promiscuous mode for the bridge.
+Defaults to false.
 * `ipam` (dictionary, required): IPAM configuration to be used for this network.

--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -44,6 +44,7 @@ type NetConf struct {
 	IPMasq       bool   `json:"ipMasq"`
 	MTU          int    `json:"mtu"`
 	HairpinMode  bool   `json:"hairpinMode"`
+	Promisc      bool   `json:"promisc"`
 }
 
 func init() {
@@ -210,6 +211,15 @@ func setupBridge(n *NetConf) (*netlink.Bridge, *current.Interface, error) {
 		return nil, nil, fmt.Errorf("failed to create bridge %q: %v", n.BrName, err)
 	}
 
+	if n.Promisc {
+		if err := netlink.SetPromiscOn(br); err != nil {
+			return nil, nil, fmt.Errorf("failed to set promisc on for %q: %v", n.BrName, err)
+		}
+	} else {
+		if err := netlink.SetPromiscOff(br); err != nil {
+			return nil, nil, fmt.Errorf("failed to set promisc off for %q: %v", n.BrName, err)
+		}
+	}
 	return br, &current.Interface{
 		Name: br.Attrs().Name,
 		Mac:  br.Attrs().HardwareAddr.String(),


### PR DESCRIPTION
Currently, one must set promiscuous mode using a script or some other out-of-band means.  This adds an option to the configuration to set it.

This is to address concerns with the issue described in https://github.com/moby/moby/issues/5618#issuecomment-280105097

There is a flag on [netlink.LinkAttrs](https://godoc.org/github.com/vishvananda/netlink#LinkAttrs), but the code presented here works and required no change to the surrounding code.  