### PR TITLE
pkg/types: return error instead of crashing when code supplies an incompatible type to types.LoadArgs() 

### DIFF
--- a/pkg/types/args.go
+++ b/pkg/types/args.go
@@ -85,8 +85,11 @@ func LoadArgs(args string, container interface{}) error {
 			unknownArgs = append(unknownArgs, pair)
 			continue
 		}
-
-		u := keyField.Addr().Interface().(encoding.TextUnmarshaler)
+		keyFieldIface := keyField.Addr().Interface()
+		u, ok := keyFieldIface.(encoding.TextUnmarshaler)
+		if !ok {
+			return fmt.Errorf("ARGS: '%s' cannot be unmarshalled from textual form for pair %q", keyField, pair)
+		}
 		err := u.UnmarshalText([]byte(valueString))
 		if err != nil {
 			return fmt.Errorf("ARGS: error parsing value of pair %q: %v)", pair, err)

--- a/pkg/types/args_test.go
+++ b/pkg/types/args_test.go
@@ -118,4 +118,15 @@ var _ = Describe("LoadArgs", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
+
+	Context("When known arguments are passed and cannot be unmarshalled", func() {
+		It("LoadArgs should fail", func() {
+			conf := struct {
+				IP IPNet
+			}{}
+			err := LoadArgs("IP=10.0.0.0/24", &conf)
+			Expect(err).To(HaveOccurred())
+
+		})
+	})
 })


### PR DESCRIPTION
### Summary
`types.LoadArgs()` does an unsafe typecast for env args key value pairs.
This can cause a panic if the config type fields do not implement
the `encoding.TextUnmarshaler` interface. This commit modifies it to
do a safe type cast and return an error in such scenarios.

### Testing 
* Added a new unit test that would panic without this code-change, which passes now
* `./test.sh` succeeds as well

### Reference
1. Test Panic without the code change
```bash
$ go test ./pkg/types/
Running Suite: Types Suite
==========================
Random Seed: 1495483401
Will run 12 of 12 specs

•••••
------------------------------
•! Panic [0.000 seconds]
LoadArgs
/home/ec2-user/workspace/src/github.com/containernetworking/cni/pkg/types/args_test.go:134
  When known arguments are passed and cannot be unmarshalled
  /home/ec2-user/workspace/src/github.com/containernetworking/cni/pkg/types/args_test.go:133
    LoadArgs should fail [It]
    /home/ec2-user/workspace/src/github.com/containernetworking/cni/pkg/types/args_test.go:132

    Test Panicked
    interface conversion: *types.IPNet is not encoding.TextUnmarshaler: missing method UnmarshalText
    /home/ec2-user/go16/go/src/runtime/panic.go:443

    Full Stack Trace
        /home/ec2-user/go16/go/src/runtime/panic.go:443 +0x4e9
    github.com/containernetworking/cni/pkg/types.LoadArgs(0x87cbd0, 0xe, 0x7387a0, 0xc8202522d0, 0x0, 0x0)
        /home/ec2-user/workspace/src/github.com/containernetworking/cni/pkg/types/args.go:89 +0x784
    github.com/containernetworking/cni/pkg/types_test.glob.func4.6.1()
        /home/ec2-user/workspace/src/github.com/containernetworking/cni/pkg/types/args_test.go:128 +0x81
    github.com/containernetworking/cni/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync(0xc820063860, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /home/ec2-user/workspace/src/github.com/containernetworking/cni/pkg/types/types_suite_test.go:26 +0x7c
    testing.tRunner(0xc8201b4ea0, 0xa8b390)
        /home/ec2-user/go16/go/src/testing/testing.go:473 +0x98
    created by testing.RunTests
        /home/ec2-user/go16/go/src/testing/testing.go:582 +0x892

------------------------------
••••••

Summarizing 1 Failure:

[Panic!] LoadArgs When known arguments are passed and cannot be unmarshalled [It] LoadArgs should fail
/home/ec2-user/go16/go/src/runtime/panic.go:443

Ran 12 of 12 Specs in 0.001 seconds
FAIL! -- 11 Passed | 1 Failed | 0 Pending | 0 Skipped --- FAIL: TestTypes (0.00s)
FAIL
FAIL    github.com/containernetworking/cni/pkg/types    0.005s
```

2. Test succeeds with the code change:
```bash
$ go test ./pkg/types/
ok      github.com/containernetworking/cni/pkg/types    0.005s
```

