### PR TITLE
Clarify first released spec with 'args' was 0.2.0

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -58,7 +58,7 @@ But the runtime would fill in the mappings so the plugin itself would receive so
 ```
 
 ## "args" in network config
-`args` in [network config](https://github.com/containernetworking/cni/blob/master/SPEC.md#network-configuration) were introduced as an optional field into the `0.1.0` CNI spec. The first CNI code release that it appeared in was `v0.4.0`. 
+`args` in [network config](https://github.com/containernetworking/cni/blob/master/SPEC.md#network-configuration) were introduced as an optional field into the `0.2.0` release of the CNI spec. The first CNI code release that it appeared in was `v0.4.0`. 
 > args (dictionary): Optional additional arguments provided by the container runtime. For example a dictionary of labels could be passed to CNI plugins by adding them to a labels field under args.
 
 `args` provide a way of providing more structured data than the flat strings that CNI_ARGS can support.


### PR DESCRIPTION
Fixes #429 

Note I'm using the phrase "release of the spec" to try to accommodate the fact that changes to the spec were made between 0.1.0 and 0.2.0, but the first spec you should consider "released" with `args` in it is the 0.4.0 tag in this repo.