### PR TITLE
add `100` to well-known error codes

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -533,3 +533,4 @@ The `dns` field contains a dictionary consisting of common DNS information.
 ## Well-known Error Codes
 - `1` - Incompatible CNI version
 - `2` - Unsupported field in network configuration. The error message must contain the key and value of the unsupported field.
+- `100` - Error during invocation of cni plugin. Plugin didn't specify the error code.


### PR DESCRIPTION
According to [this code](https://github.com/containernetworking/cni/blob/master/pkg/skel/skel.go#L144), it may be good to specify that `100` is a well-known error code in the SPEC. 
In this way, it could make developers less puzzled when the cni-plugin doesn't return an error which type is not [types.Error](https://github.com/containernetworking/cni/blob/master/pkg/types/types.go#L132).