### PR TITLE
check the range of error status code after invoking cni-plugin

### DIFF
--- a/pkg/skel/skel.go
+++ b/pkg/skel/skel.go
@@ -159,7 +159,16 @@ func (t *dispatcher) checkVersionAndCall(cmdArgs *CmdArgs, pluginVersionInfo ver
 			Details: verErr.Details(),
 		}
 	}
-	return toCall(cmdArgs)
+
+	err = toCall(cmdArgs)
+	if e, ok := err.(*types.Error); ok {
+		if e.Code < 100 {
+			e.Code = 100
+		}
+		return e
+	}
+
+	return err
 }
 
 func (t *dispatcher) pluginMain(cmdAdd, cmdDel func(_ *CmdArgs) error, versionInfo version.PluginInfo) *types.Error {

--- a/pkg/skel/skel_test.go
+++ b/pkg/skel/skel_test.go
@@ -341,6 +341,24 @@ var _ = Describe("dispatching to the correct callback", func() {
 				}))
 			})
 		})
+
+		Context("when the error code is less than 100", func() {
+			BeforeEach(func() {
+				cmdAdd.Returns.Error = &types.Error{
+					Code: 50,
+					Msg:  "bad error status code",
+				}
+			})
+
+			It("convert the error status code to 100", func() {
+				err := dispatch.pluginMain(cmdAdd.Func, cmdDel.Func, versionInfo)
+
+				Expect(err).To(Equal(&types.Error{
+					Code: 100,
+					Msg:  "bad error status code",
+				}))
+			})
+		})
 	})
 })
 


### PR DESCRIPTION
According to the [SPEC](https://github.com/containernetworking/cni/blob/master/SPEC.md#result), it may be good to check the range of error status code returned by cni-plugin.