### PR TITLE
README plugins list: add Linen CNI plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ To avoid duplication, we think it is prudent to define a common interface betwee
 - [CNI-Genie - generic CNI network plugin](https://github.com/Huawei-PaaS/CNI-Genie)
 - [Nuage CNI - Nuage Networks SDN plugin for network policy kubernetes support ](https://github.com/nuagenetworks/nuage-cni)
 - [Silk - a CNI plugin designed for Cloud Foundry](https://github.com/cloudfoundry-incubator/silk)
+- [Linen - a CNI plugin designed for overlay networks with Open vSwitch and fit in SDN/OpenFlow network environment](https://github.com/John-Lin/linen-cni)
 
 The CNI team also maintains some [core plugins in a separate repository](https://github.com/containernetworking/plugins).
 


### PR DESCRIPTION
Hi, I built this plugin for overlay networks with Open vSwitch. It mainly focuses on 
SDN/OpenFlow network and supports for adding SDN controller such as ONOS, Ryu and 
OpenDaylight by configuring network configuration.