### PR TITLE
libcni: return error if Type is empty

### DIFF
--- a/libcni/conf.go
+++ b/libcni/conf.go
@@ -45,6 +45,9 @@ func ConfFromBytes(bytes []byte) (*NetworkConfig, error) {
 	if err := json.Unmarshal(bytes, &conf.Network); err != nil {
 		return nil, fmt.Errorf("error parsing configuration: %s", err)
 	}
+	if conf.Network.Type == "" {
+		return nil, fmt.Errorf("error parsing configuration: missing 'type'")
+	}
 	return conf, nil
 }
 


### PR DESCRIPTION
A network config missing Type is pretty useless since it means we can't
find the plugin to execute.  So return an error if Type isn't given.

@containernetworking/cni-maintainers @squeed 