### PR TITLE
Conventions: add the "ips" arg

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -89,6 +89,7 @@ For example:
 | Area  | Purpose| Spec and Example | Runtime implementations | Plugin Implementations |
 | ----- | ------ | ------------     | ----------------------- | ---------------------- |
 | labels | Pass`key=value` labels to plugins | <pre>"labels" : [<br />  { "key" : "app", "value" : "myapp" },<br />  { "key" : "env", "value" : "prod" }<br />] </pre> | none | none |
+| ips   | Request static IPs | <pre>"ips": ["10.2.2.42", "2001:db8::5"]</pre> | none | host-local |
 
 ## CNI_ARGS
 CNI_ARGS formed part of the original CNI spec and have been present since the initial release.


### PR DESCRIPTION
The `host-local` ipam plugin now supports the `ips` field in `args`. Document that.

Fixes: #303 