### PR TITLE
Extend IPAM route struct to support more route types

### DIFF
--- a/pkg/types/020/types_test.go
+++ b/pkg/types/020/types_test.go
@@ -46,6 +46,10 @@ var _ = Describe("Ensures compatibility with the 0.1.0/0.2.0 spec", func() {
 		Expect(routev6).NotTo(BeNil())
 		Expect(routegwv6).NotTo(BeNil())
 
+		blackholeIPv4, err := types.ParseCIDR("10.8.11.2/32")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(blackholeIPv4).NotTo(BeNil())
+
 		// Set every field of the struct to ensure source compatibility
 		res := types020.Result{
 			CNIVersion: types020.ImplementedSpecVersion,
@@ -54,6 +58,7 @@ var _ = Describe("Ensures compatibility with the 0.1.0/0.2.0 spec", func() {
 				Gateway: net.ParseIP("1.2.3.1"),
 				Routes: []types.Route{
 					{Dst: *routev4, GW: routegwv4},
+					{Dst: *blackholeIPv4, Type: "blackhole"},
 				},
 			},
 			IP6: &types020.IPConfig{
@@ -71,7 +76,7 @@ var _ = Describe("Ensures compatibility with the 0.1.0/0.2.0 spec", func() {
 			},
 		}
 
-		Expect(res.String()).To(Equal("IP4:{IP:{IP:1.2.3.30 Mask:ffffff00} Gateway:1.2.3.1 Routes:[{Dst:{IP:15.5.6.0 Mask:ffffff00} GW:15.5.6.8}]}, IP6:{IP:{IP:abcd:1234:ffff::cdde Mask:ffffffffffffffff0000000000000000} Gateway:abcd:1234:ffff::1 Routes:[{Dst:{IP:1111:dddd:: Mask:ffffffffffffffffffff000000000000} GW:1111:dddd::aaaa}]}, DNS:{Nameservers:[1.2.3.4 1::cafe] Domain:acompany.com Search:[somedomain.com otherdomain.net] Options:[foo bar]}"))
+		Expect(res.String()).To(Equal("IP4:{IP:{IP:1.2.3.30 Mask:ffffff00} Gateway:1.2.3.1 Routes:[{Type: Dst:{IP:15.5.6.0 Mask:ffffff00} GW:15.5.6.8} {Type:blackhole Dst:{IP:10.8.11.2 Mask:ffffffff} GW:<nil>}]}, IP6:{IP:{IP:abcd:1234:ffff::cdde Mask:ffffffffffffffff0000000000000000} Gateway:abcd:1234:ffff::1 Routes:[{Type: Dst:{IP:1111:dddd:: Mask:ffffffffffffffffffff000000000000} GW:1111:dddd::aaaa}]}, DNS:{Nameservers:[1.2.3.4 1::cafe] Domain:acompany.com Search:[somedomain.com otherdomain.net] Options:[foo bar]}"))
 
 		// Redirect stdout to capture JSON result
 		oldStdout := os.Stdout
@@ -97,6 +102,10 @@ var _ = Describe("Ensures compatibility with the 0.1.0/0.2.0 spec", func() {
             {
                 "dst": "15.5.6.0/24",
                 "gw": "15.5.6.8"
+            },
+            {
+                "type": "blackhole",
+                "dst": "10.8.11.2/32"
             }
         ]
     },

--- a/pkg/types/current/types.go
+++ b/pkg/types/current/types.go
@@ -172,13 +172,15 @@ func (r *Result) convertTo020() (*types020.Result, error) {
 		is4 := route.Dst.IP.To4() != nil
 		if is4 && oldResult.IP4 != nil {
 			oldResult.IP4.Routes = append(oldResult.IP4.Routes, types.Route{
-				Dst: route.Dst,
-				GW:  route.GW,
+				Dst:  route.Dst,
+				GW:   route.GW,
+				Type: route.Type,
 			})
 		} else if !is4 && oldResult.IP6 != nil {
 			oldResult.IP6.Routes = append(oldResult.IP6.Routes, types.Route{
-				Dst: route.Dst,
-				GW:  route.GW,
+				Dst:  route.Dst,
+				GW:   route.GW,
+				Type: route.Type,
 			})
 		}
 	}

--- a/pkg/types/current/types_test.go
+++ b/pkg/types/current/types_test.go
@@ -46,6 +46,10 @@ func testResult() *current.Result {
 	Expect(routev6).NotTo(BeNil())
 	Expect(routegwv6).NotTo(BeNil())
 
+	blackholeIPv4, err := types.ParseCIDR("10.8.11.2/32")
+	Expect(err).NotTo(HaveOccurred())
+	Expect(blackholeIPv4).NotTo(BeNil())
+
 	// Set every field of the struct to ensure source compatibility
 	return &current.Result{
 		CNIVersion: "0.3.1",
@@ -73,6 +77,7 @@ func testResult() *current.Result {
 		Routes: []*types.Route{
 			{Dst: *routev4, GW: routegwv4},
 			{Dst: *routev6, GW: routegwv6},
+			{Dst: *blackholeIPv4, Type: "blackhole"},
 		},
 		DNS: types.DNS{
 			Nameservers: []string{"1.2.3.4", "1::cafe"},
@@ -133,6 +138,10 @@ var _ = Describe("Current types operations", func() {
         {
             "dst": "1111:dddd::/80",
             "gw": "1111:dddd::aaaa"
+        },
+        {
+            "type": "blackhole",
+            "dst": "10.8.11.2/32"
         }
     ],
     "dns": {
@@ -157,7 +166,7 @@ var _ = Describe("Current types operations", func() {
 		res, err := testResult().GetAsVersion("0.1.0")
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(res.String()).To(Equal("IP4:{IP:{IP:1.2.3.30 Mask:ffffff00} Gateway:1.2.3.1 Routes:[{Dst:{IP:15.5.6.0 Mask:ffffff00} GW:15.5.6.8}]}, IP6:{IP:{IP:abcd:1234:ffff::cdde Mask:ffffffffffffffff0000000000000000} Gateway:abcd:1234:ffff::1 Routes:[{Dst:{IP:1111:dddd:: Mask:ffffffffffffffffffff000000000000} GW:1111:dddd::aaaa}]}, DNS:{Nameservers:[1.2.3.4 1::cafe] Domain:acompany.com Search:[somedomain.com otherdomain.net] Options:[foo bar]}"))
+		Expect(res.String()).To(Equal("IP4:{IP:{IP:1.2.3.30 Mask:ffffff00} Gateway:1.2.3.1 Routes:[{Type: Dst:{IP:15.5.6.0 Mask:ffffff00} GW:15.5.6.8} {Type:blackhole Dst:{IP:10.8.11.2 Mask:ffffffff} GW:<nil>}]}, IP6:{IP:{IP:abcd:1234:ffff::cdde Mask:ffffffffffffffff0000000000000000} Gateway:abcd:1234:ffff::1 Routes:[{Type: Dst:{IP:1111:dddd:: Mask:ffffffffffffffffffff000000000000} GW:1111:dddd::aaaa}]}, DNS:{Nameservers:[1.2.3.4 1::cafe] Domain:acompany.com Search:[somedomain.com otherdomain.net] Options:[foo bar]}"))
 
 		// Redirect stdout to capture JSON result
 		oldStdout := os.Stdout
@@ -183,6 +192,10 @@ var _ = Describe("Current types operations", func() {
             {
                 "dst": "15.5.6.0/24",
                 "gw": "15.5.6.8"
+            },
+            {
+                "type": "blackhole",
+                "dst": "10.8.11.2/32"
             }
         ]
     },


### PR DESCRIPTION
### Summary
Only unicast routes are supported today via the IPAM `route` struct. This PR extends this by supporting other route types, specifically the blocking route types.  Related to PR https://github.com/containernetworking/plugins/pull/57

### Details
The `type` field can be used to specify the following 'blocking' routes:
* unreachable
* blackhole
* prohibit

The `type` is inferred as `unicast` by default.

The following type's are not supported:
* local
* broadcast
* throw
* nat
* anycast
* multicast

Example:
```
{
  ...
  "ipam": {
    "type": "host-local",
    "subnet": "10.22.0.0/16",
    "routes": [
      { "dst": "0.0.0.0/0" },
      { "dst": "169.254.169.254/32", "type":"blackhole" }
    ]
  }
}
```

### Testing
Ran the test suite without any errors. Also tested that I can add a 'blackhole' route. 

```
$ cat /etc/cni/net.d/10-mynet.conf
{
        "cniVersion": "0.3.0",
        "name": "mynet",
        "type": "bridge",
        "bridge": "cni0",
        "isGateway": true,
        "ipMasq": true,
        "ipam": {
                "type": "host-local",
                "subnet": "10.22.0.0/16",
                "routes": [
                        { "dst": "0.0.0.0/0" },
                        { "dst": "169.254.169.254/32", "type":"blackhole" }
                ]
        }
}
$ sudo CNI_PATH=$CNI_PATH ./docker-run.sh busybox ip route show
default via 10.22.0.1 dev eth0
10.22.0.0/16 dev eth0 scope link  src 10.22.0.37
blackhole 169.254.169.254

$ ./test.sh
Building API
Building reference CLI
Building plugins
...
Running tests without coverage profile generation...
ok      github.com/containernetworking/cni/libcni       5.707s  coverage: 88.0% of statements
ok      github.com/containernetworking/cni/pkg/invoke   6.886s  coverage: 97.1% of statements
ok      github.com/containernetworking/cni/pkg/skel     0.023s  coverage: 85.7% of statements
ok      github.com/containernetworking/cni/pkg/types    0.019s  coverage: 44.3% of statements
ok      github.com/containernetworking/cni/pkg/types/current    0.012s  coverage: 26.9% of statements
ok      github.com/containernetworking/cni/pkg/types/020        0.005s  coverage: 32.4% of statements
ok      github.com/containernetworking/cni/pkg/version  0.009s  coverage: 75.7% of statements
ok      github.com/containernetworking/cni/pkg/version/testhelpers      1.348s  coverage: 76.2% of statements
ok      github.com/containernetworking/cni/plugins/test/noop    1.044s  coverage: 0.0% of statements
Checking gofmt...
Checking govet...
Checking license header...
Success
```