### PR TITLE
Golang versions: add 1.9, drop 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: required
 dist: trusty
 
 go:
-  - 1.7.x
   - 1.8.x
+  - 1.9.x
 
 env:
   global:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
     apt-get update -y || (sleep 40 && apt-get update -y)
     apt-get install -y git
 
-    wget -qO- https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz | tar -C /usr/local -xz
+    wget -qO- https://storage.googleapis.com/golang/go1.9.1.linux-amd64.tar.gz | tar -C /usr/local -xz
 
     echo 'export GOPATH=/go; export PATH=/usr/local/go/bin:$GOPATH/bin:$PATH' >> /root/.bashrc
     eval `tail -n1 /root/.bashrc`

--- a/pkg/invoke/delegate_test.go
+++ b/pkg/invoke/delegate_test.go
@@ -75,6 +75,10 @@ var _ = Describe("Delegate", func() {
 
 	AfterEach(func() {
 		os.RemoveAll(debugFileName)
+
+		for _, k := range []string{"CNI_COMMAND", "CNI_ARGS", "CNI_PATH", "CNI_NETNS", "CNI_IFNAME"} {
+			os.Unsetenv(k)
+		}
 	})
 
 	Describe("DelegateAdd", func() {


### PR DESCRIPTION
Go 1.9 is out, 1.7 is now no longer maintained.

Reference: https://golang.org/doc/devel/release.html#policy

See also: https://github.com/containernetworking/plugins/pull/65