### PR TITLE
skel: VERSION shouldn't block on stdin

### DIFF
--- a/pkg/skel/skel.go
+++ b/pkg/skel/skel.go
@@ -17,6 +17,7 @@
 package skel
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -121,6 +122,10 @@ func (t *dispatcher) getCmdArgsFromEnv() (string, *CmdArgs, error) {
 
 	if argsMissing {
 		return "", nil, fmt.Errorf("required env variables missing")
+	}
+
+	if cmd == "VERSION" {
+		t.Stdin = bytes.NewReader(nil)
 	}
 
 	stdinData, err := ioutil.ReadAll(t.Stdin)


### PR DESCRIPTION
Right now, I have to do the following
  $ echo | CNI_COMMAND=VERSION bridge
or
  CNI_COMMAND=VERSION bridge
  ^D
to be able to get the result back.

But VERSION doesn't need to read from stdin.