### PR TITLE
README: List vhostuser CNI as a 3rd party plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ To avoid duplication, we think it is prudent to define a common interface betwee
 - [Nuage CNI - Nuage Networks SDN plugin for network policy kubernetes support ](https://github.com/nuagenetworks/nuage-cni)
 - [Silk - a CNI plugin designed for Cloud Foundry](https://github.com/cloudfoundry-incubator/silk)
 - [Linen - a CNI plugin designed for overlay networks with Open vSwitch and fit in SDN/OpenFlow network environment](https://github.com/John-Lin/linen-cni)
+- [Vhostuser - a Dataplane network plugin - Supports OVS-DPDK & VPP](https://github.com/intel/vhost-user-net-plugin)
 
 The CNI team also maintains some [core plugins in a separate repository](https://github.com/containernetworking/plugins).
 


### PR DESCRIPTION
We like to add [Vhostuser CNI](https://github.com/intel/vhost-user-net-plugin) as a 3rd party plugin in CNI. Vhostuser plugin is a Container Network Interface (CNI) plugin to run with OVS-DPDK and VPP along with [Multus CNI](https://github.com/Intel-Corp/multus-cni) plugin in Kubernetes for Bare metal container deployment model. It enhances high performance container Networking solution and Dataplane Acceleration for NFV Environment.