### PR TITLE
Fix typo in CONVENTIONS.md

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -65,7 +65,7 @@ But the runtime would fill in the mappings so the plugin itself would receive so
 
 `args` should be used for _optional_ meta-data. Runtimes can place additional data in `args` and plugins that don't understand that data should just ignore it. Runtimes should not require that a plugin understands or consumes that data provided, and so a runtime should not expect to receive an error if the data could not be acted on.
 
-This method of passing information to a plugin is recommended when the information is optional and the plugin can choose to ignore it. It's often that case that such information is passed to all plugins by the runtime whithout regard for whether the plugin can understand it. 
+This method of passing information to a plugin is recommended when the information is optional and the plugin can choose to ignore it. It's often that case that such information is passed to all plugins by the runtime without regard for whether the plugin can understand it.
 
 The conventions documented here are all namepaced under `cni` so they don't conflict with any existing `args`.
 


### PR DESCRIPTION
Fix a typo when reading CONVENTIONS.md