### PR TITLE
Add vlan id

### DIFF
--- a/pkg/types/current/types.go
+++ b/pkg/types/current/types.go
@@ -261,6 +261,7 @@ type IPConfig struct {
 	Interface *int
 	Address   net.IPNet
 	Gateway   net.IP
+	VlanId    uint16
 }
 
 func (i *IPConfig) String() string {


### PR DESCRIPTION
So it's possible for IP Allocator to return vlan ids of ips