### PR TITLE
tests: sudo not actually required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: go
-sudo: required
 dist: trusty
 
 go:

--- a/pkg/version/legacy_examples/example_runtime.go
+++ b/pkg/version/legacy_examples/example_runtime.go
@@ -150,10 +150,8 @@ var V010_Runtime = ExampleRuntime{
 import (
 	"fmt"
 	"io/ioutil"
-	"net"
 	"os"
 
-	"github.com/containernetworking/cni/pkg/ns"
 	"github.com/containernetworking/cni/libcni"
 )
 
@@ -181,19 +179,10 @@ func exec() int {
 		return 1
 	}
 
-	targetNs, err := ns.NewNS()
-	if err !=  nil {
-		fmt.Printf("Could not create ns: %+v", err)
-		return 1
-	}
-	defer targetNs.Close()
-
-	ifName := "eth0"
-
 	runtimeConf := &libcni.RuntimeConf{
 		ContainerID: "some-container-id",
-		NetNS:       targetNs.Path(),
-		IfName:      ifName,
+		NetNS:       "/some/netns/path",
+		IfName:      "eth0",
 	}
 
 	cniConfig := &libcni.CNIConfig{Path: os.Args[1:]}
@@ -221,18 +210,6 @@ func exec() int {
 	if err != nil {
 		fmt.Printf("DelNetwork failed: %v", err)
 		return 5
-	}
-
-	err = targetNs.Do(func(ns.NetNS) error {
-		_, err := net.InterfaceByName(ifName)
-		if err == nil {
-			return fmt.Errorf("interface was not deleted")
-		}
-		return nil
-	})
-	if err != nil {
-		fmt.Println(err)
-		return 6
 	}
 
 	return 0

--- a/test.sh
+++ b/test.sh
@@ -6,7 +6,7 @@ cd "$(dirname $0)"
 
 echo -n "Running tests "
 function testrun {
-    sudo -E bash -c "umask 0; PATH=$PATH go test $@"
+    bash -c "umask 0; PATH=$PATH go test $@"
 }
 if [ ! -z "${COVERALLS:-""}" ]; then
     # coverage profile only works per-package


### PR DESCRIPTION
The legacy example plugin and its libcni backwards_compatibility_test.go
just use the noop plugin, which doesn't do anything with the netns path
or make any interfaces inside the netns.  So we can remove anything
netns related from the test, which means we no longer need sudo.

@containernetworking/cni-maintainers 