### PR TITLE
fixes the title in specification

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,4 +1,4 @@
-# Container Networking Interface Specification
+# Container Network Interface Specification
 
 ## Version
 This is CNI **spec** version **0.3.1-dev**. This spec contains **unreleased** changes.


### PR DESCRIPTION
Might be an historical artefact but I believe the correct full name for CNI should be Container Network Interface 

CC: @bboreham