### PR TITLE
Network interface name matters

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -47,8 +47,8 @@ https://docs.google.com/a/coreos.com/document/d/1CTAL4gwqRofjxyp4tTkbgHtAwb2YCcP
 - Upon completion of the container lifecycle, the runtime must execute the plugins in reverse order (relative to the order in which they were executed to add the container) to disconnect the container from the networks.
 - The container runtime must not invoke parallel operations for the same container, but is allowed to invoke parallel operations for different containers.
 - The container runtime must order ADD and DEL operations for a container, such that ADD is always followed by a corresponding DEL. DEL may be followed by additional DELs, however, and plugins should handle multiple DELs permissively (i.e. plugin DEL should be idempotent).
-- A container must be uniquely identified by a ContainerID. Plugins that store state should do so using a primary key of `(network name, container id)`.
-- A runtime must not call ADD twice (without a corresponding DEL) for the same `(network name, container id)`. In other words, a given container ID must be added to a specific network exactly once.
+- A container must be uniquely identified by a ContainerID. Plugins that store state should do so using a primary key of `(network name, container id, name of the interface inside the container)`.
+- A runtime must not call ADD twice (without a corresponding DEL) for the same `(network name, container id, name of the interface inside the container)`. This implies that a given container ID may be added to a specific network more than once only if each addition is done with a different interface name.
 
 ## CNI Plugin
 

--- a/libcni/api.go
+++ b/libcni/api.go
@@ -23,6 +23,10 @@ import (
 	"github.com/containernetworking/cni/pkg/version"
 )
 
+// A RuntimeConf holds the arguments to one invocation of a CNI plugin
+// excepting the network configuration, with the nested exception that
+// the `runtimeConfig` from the network configuration is included
+// here.
 type RuntimeConf struct {
 	ContainerID string
 	NetNS       string

--- a/libcni/api_test.go
+++ b/libcni/api_test.go
@@ -92,7 +92,7 @@ func newPluginInfo(configValue, prevResult string, injectDebugFilePath bool, res
 	err = json.Unmarshal([]byte(config), &newConfig)
 	Expect(err).NotTo(HaveOccurred())
 	newConfig["name"] = "some-list"
-	newConfig["cniVersion"] = "0.3.1"
+	newConfig["cniVersion"] = "0.4.0"
 
 	// Only include standard runtime config and capability args that this plugin advertises
 	newRuntimeConfig := make(map[string]interface{})
@@ -139,7 +139,7 @@ var _ = Describe("Invoking plugins", func() {
 			pluginConfig = []byte(`{
 				"type": "noop",
 				"name": "apitest",
-				"cniVersion": "0.3.1",
+				"cniVersion": "0.4.0",
 				"capabilities": {
 					"portMappings": true,
 					"somethingElse": true,
@@ -256,7 +256,7 @@ var _ = Describe("Invoking plugins", func() {
 				"type": "noop",
 				"name": "apitest",
 				"some-key": "some-value",
-				"cniVersion": "0.3.1",
+				"cniVersion": "0.4.0",
 				"capabilities": { "portMappings": true }
 			}`
 			cniConfig = libcni.CNIConfig{Path: []string{cniBinPath}}
@@ -390,7 +390,7 @@ var _ = Describe("Invoking plugins", func() {
 
 				Expect(versionInfo).NotTo(BeNil())
 				Expect(versionInfo.SupportedVersions()).To(Equal([]string{
-					"0.-42.0", "0.1.0", "0.2.0", "0.3.0", "0.3.1",
+					"0.-42.0", "0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0",
 				}))
 			})
 
@@ -461,7 +461,7 @@ var _ = Describe("Invoking plugins", func() {
 
 			configList := []byte(fmt.Sprintf(`{
   "name": "some-list",
-  "cniVersion": "0.3.1",
+  "cniVersion": "0.4.0",
   "plugins": [
     %s,
     %s,

--- a/pkg/skel/skel_test.go
+++ b/pkg/skel/skel_test.go
@@ -225,7 +225,7 @@ var _ = Describe("dispatching to the correct callback", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stdout).To(MatchJSON(`{
-				"cniVersion": "0.3.1",
+				"cniVersion": "0.4.0",
 				"supportedVersions": ["9.8.7"]
 			}`))
 		})
@@ -256,7 +256,7 @@ var _ = Describe("dispatching to the correct callback", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(r.ReadCount).To(Equal(0))
 			Expect(stdout).To(MatchJSON(`{
-				"cniVersion": "0.3.1",
+				"cniVersion": "0.4.0",
 				"supportedVersions": ["9.8.7"]
 			}`))
 		})

--- a/pkg/types/current/types.go
+++ b/pkg/types/current/types.go
@@ -24,9 +24,9 @@ import (
 	"github.com/containernetworking/cni/pkg/types/020"
 )
 
-const ImplementedSpecVersion string = "0.3.1"
+const ImplementedSpecVersion string = "0.4.0"
 
-var SupportedVersions = []string{"0.3.0", ImplementedSpecVersion}
+var SupportedVersions = []string{"0.3.0", "0.3.1", ImplementedSpecVersion}
 
 func NewResult(data []byte) (types.Result, error) {
 	result := &Result{}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -24,7 +24,7 @@ import (
 
 // Current reports the version of the CNI spec implemented by this library
 func Current() string {
-	return "0.3.1"
+	return "0.4.0"
 }
 
 // Legacy PluginInfo describes a plugin that is backwards compatible with the
@@ -35,7 +35,7 @@ func Current() string {
 // Any future CNI spec versions which meet this definition should be added to
 // this list.
 var Legacy = PluginSupports("0.1.0", "0.2.0")
-var All = PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1")
+var All = PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0")
 
 var resultFactories = []struct {
 	supportedVersions []string

--- a/plugins/test/noop/main.go
+++ b/plugins/test/noop/main.go
@@ -142,7 +142,7 @@ func debugBehavior(args *skel.CmdArgs, command string) error {
 }
 
 func debugGetSupportedVersions(stdinData []byte) []string {
-	vers := []string{"0.-42.0", "0.1.0", "0.2.0", "0.3.0", "0.3.1"}
+	vers := []string{"0.-42.0", "0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0"}
 	cniArgs := os.Getenv("CNI_ARGS")
 	if cniArgs == "" {
 		return vers

--- a/plugins/test/noop/noop_test.go
+++ b/plugins/test/noop/noop_test.go
@@ -42,7 +42,7 @@ var _ = Describe("No-op plugin", func() {
 	BeforeEach(func() {
 		debug = &noop_debug.Debug{
 			ReportResult:         reportResult,
-			ReportVersionSupport: []string{"0.1.0", "0.2.0", "0.3.0", "0.3.1"},
+			ReportVersionSupport: []string{"0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0"},
 		}
 
 		debugFile, err := ioutil.TempFile("", "cni_debug")
@@ -64,7 +64,7 @@ var _ = Describe("No-op plugin", func() {
 			// Keep this last
 			"CNI_ARGS=" + args,
 		}
-		stdinData := `{"name": "noop-test", "some":"stdin-json", "cniVersion": "0.3.1"}`
+		stdinData := `{"name": "noop-test", "some":"stdin-json", "cniVersion": "0.4.0"}`
 		cmd.Stdin = strings.NewReader(stdinData)
 		expectedCmdArgs = skel.CmdArgs{
 			ContainerID: "some-container-id",
@@ -104,7 +104,7 @@ var _ = Describe("No-op plugin", func() {
 		cmd.Stdin = strings.NewReader(`{
 	"name":"noop-test",
 	"some":"stdin-json",
-	"cniVersion": "0.3.1",
+	"cniVersion": "0.4.0",
 	"prevResult": {
 		"ips": [{"version": "4", "address": "10.1.2.15/24"}]
 	}
@@ -122,7 +122,7 @@ var _ = Describe("No-op plugin", func() {
 		cmd.Stdin = strings.NewReader(`{
 	"name":"noop-test",
 	"some":"stdin-json",
-	"cniVersion": "0.3.1",
+	"cniVersion": "0.4.0",
 	"prevResult": {
 		"ips": [{"version": "4", "address": "10.1.2.3/24"}],
 		"dns": {}
@@ -133,7 +133,7 @@ var _ = Describe("No-op plugin", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(session).Should(gexec.Exit(0))
 		Expect(session.Out.Contents()).To(MatchJSON(`{
-  "cniVersion": "0.3.1",
+  "cniVersion": "0.4.0",
 	"ips": [{"version": "4", "address": "10.1.2.3/24"}],
 	"dns": {"nameservers": ["1.2.3.4"]}
 }`))
@@ -143,7 +143,7 @@ var _ = Describe("No-op plugin", func() {
 		// Remove the DEBUG option from CNI_ARGS and regular args
 		newArgs := "FOO=BAR"
 		cmd.Env[len(cmd.Env)-1] = "CNI_ARGS=" + newArgs
-		newStdin := fmt.Sprintf(`{"name":"noop-test", "some": "stdin-json", "cniVersion": "0.3.1", "debugFile": %q}`, debugFileName)
+		newStdin := fmt.Sprintf(`{"name":"noop-test", "some": "stdin-json", "cniVersion": "0.4.0", "debugFile": %q}`, debugFileName)
 		cmd.Stdin = strings.NewReader(newStdin)
 		expectedCmdArgs.Args = newArgs
 		expectedCmdArgs.StdinData = []byte(newStdin)


### PR DESCRIPTION
This PR changes the SPEC so that state is kept per `(network name, container id, name of the interface inside the container)` tuple instead of simply per `(network name, container id)`.  In other words, this change allows one container to make multiple connections to the same network.  This came up as a desired use case in the Kubernetes network plumbing proto-WG.

I picked 0.4.0 as the new SPEC version, although 0.3.2 would be OK with me too.

I started working on updating the plugins, only to discover that they are not even consistent with the 0.3.1 spec (see https://github.com/containernetworking/plugins/issues/145).