### PR TITLE
skel: add support for plugin version string

### DIFF
--- a/pkg/invoke/get_version_integration_test.go
+++ b/pkg/invoke/get_version_integration_test.go
@@ -97,7 +97,7 @@ import (
 
 func c(_ *skel.CmdArgs) error { fmt.Println("{}"); return nil }
 
-func main() { skel.PluginMain(c, c, c, version.PluginSupports("0.2.0", "0.4.0", "0.999.0")) }
+func main() { skel.PluginMain(c, c, c, version.PluginSupports("0.2.0", "0.4.0", "0.999.0"), "") }
 `
 
 const git_ref_v031 = "909fe7d"

--- a/plugins/test/noop/main.go
+++ b/plugins/test/noop/main.go
@@ -212,5 +212,5 @@ func main() {
 	}
 
 	supportedVersions := debugGetSupportedVersions(stdinData)
-	skel.PluginMain(cmdAdd, cmdGet, cmdDel, version.PluginSupports(supportedVersions...))
+	skel.PluginMain(cmdAdd, cmdGet, cmdDel, version.PluginSupports(supportedVersions...), "CNI nnop plugin v0.7.0")
 }


### PR DESCRIPTION
This adds an additional argument to PluginMain, the `about` field. It is emitted on stderr when CNI_COMMAND is not provided.

This is for the ease of administrators.