### PR TITLE
libcni: make exec handling an interface for better downstream testing

### DIFF
--- a/cnitool/cnitool.go
+++ b/cnitool/cnitool.go
@@ -95,9 +95,7 @@ func main() {
 	s := sha512.Sum512([]byte(netns))
 	containerID := fmt.Sprintf("cnitool-%x", s[:10])
 
-	cninet := &libcni.CNIConfig{
-		Path: filepath.SplitList(os.Getenv(EnvCNIPath)),
-	}
+	cninet := libcni.NewCNIConfig(filepath.SplitList(os.Getenv(EnvCNIPath)), nil)
 
 	rt := &libcni.RuntimeConf{
 		ContainerID:    containerID,

--- a/libcni/api_test.go
+++ b/libcni/api_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Invoking plugins", func() {
 			debugFilePath string
 			debug         *noop_debug.Debug
 			pluginConfig  []byte
-			cniConfig     libcni.CNIConfig
+			cniConfig     *libcni.CNIConfig
 			runtimeConfig *libcni.RuntimeConf
 			netConfig     *libcni.NetworkConfig
 		)
@@ -165,7 +165,7 @@ var _ = Describe("Invoking plugins", func() {
 			netConfig, err = libcni.ConfFromBytes(pluginConfig)
 			Expect(err).NotTo(HaveOccurred())
 
-			cniConfig = libcni.CNIConfig{Path: []string{filepath.Dir(pluginPaths["noop"])}}
+			cniConfig = libcni.NewCNIConfig([]string{filepath.Dir(pluginPaths["noop"])}, nil)
 
 			runtimeConfig = &libcni.RuntimeConf{
 				ContainerID: "some-container-id",
@@ -246,7 +246,7 @@ var _ = Describe("Invoking plugins", func() {
 			debug         *noop_debug.Debug
 			cniBinPath    string
 			pluginConfig  string
-			cniConfig     libcni.CNIConfig
+			cniConfig     *libcni.CNIConfig
 			netConfig     *libcni.NetworkConfig
 			runtimeConfig *libcni.RuntimeConf
 
@@ -280,7 +280,7 @@ var _ = Describe("Invoking plugins", func() {
 				"cniVersion": "%s",
 				"capabilities": { "portMappings": true }
 			}`, current.ImplementedSpecVersion)
-			cniConfig = libcni.CNIConfig{Path: []string{cniBinPath}}
+			cniConfig = libcni.NewCNIConfig([]string{cniBinPath}, nil)
 			netConfig, err = libcni.ConfFromBytes([]byte(pluginConfig))
 			Expect(err).NotTo(HaveOccurred())
 			runtimeConfig = &libcni.RuntimeConf{
@@ -781,7 +781,7 @@ var _ = Describe("Invoking plugins", func() {
 		var (
 			plugins       []pluginInfo
 			cniBinPath    string
-			cniConfig     libcni.CNIConfig
+			cniConfig     *libcni.CNIConfig
 			netConfigList *libcni.NetworkConfigList
 			runtimeConfig *libcni.RuntimeConf
 
@@ -799,7 +799,7 @@ var _ = Describe("Invoking plugins", func() {
 			}
 
 			cniBinPath = filepath.Dir(pluginPaths["noop"])
-			cniConfig = libcni.CNIConfig{Path: []string{cniBinPath}}
+			cniConfig = libcni.NewCNIConfig([]string{cniBinPath}, nil)
 			runtimeConfig = &libcni.RuntimeConf{
 				ContainerID:    "some-container-id",
 				NetNS:          "/some/netns/path",

--- a/libcni/backwards_compatibility_test.go
+++ b/libcni/backwards_compatibility_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Backwards compatibility", func() {
 			CacheDir:    cacheDirPath,
 		}
 
-		cniConfig := &libcni.CNIConfig{Path: []string{filepath.Dir(pluginPath)}}
+		cniConfig := libcni.NewCNIConfig([]string{filepath.Dir(pluginPath)}, nil)
 
 		result, err := cniConfig.AddNetwork(netConf, runtimeConf)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/invoke/args_test.go
+++ b/pkg/invoke/args_test.go
@@ -31,8 +31,8 @@ var _ = Describe("Args", func() {
 				ContainerID: "some-container-id",
 				NetNS:       "/some/netns/path",
 				PluginArgs: [][2]string{
-					[2]string{"KEY1", "VALUE1"},
-					[2]string{"KEY2", "VALUE2"},
+					{"KEY1", "VALUE1"},
+					{"KEY2", "VALUE2"},
 				},
 				IfName: "eth7",
 				Path:   "/some/cni/path",

--- a/pkg/invoke/delegate.go
+++ b/pkg/invoke/delegate.go
@@ -22,47 +22,54 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 )
 
-func delegateAddOrGet(command, delegatePlugin string, netconf []byte) (types.Result, error) {
+func delegateAddOrGet(command, delegatePlugin string, netconf []byte, exec Exec) (types.Result, error) {
+	if exec == nil {
+		exec = defaultExec
+	}
+
 	paths := filepath.SplitList(os.Getenv("CNI_PATH"))
-	pluginPath, err := FindInPath(delegatePlugin, paths)
+	pluginPath, err := exec.FindInPath(delegatePlugin, paths)
 	if err != nil {
 		return nil, err
 	}
 
-	return ExecPluginWithResult(pluginPath, netconf, ArgsFromEnv())
+	return ExecPluginWithResult(pluginPath, netconf, ArgsFromEnv(), exec)
 }
 
 // DelegateAdd calls the given delegate plugin with the CNI ADD action and
 // JSON configuration
-func DelegateAdd(delegatePlugin string, netconf []byte) (types.Result, error) {
+func DelegateAdd(delegatePlugin string, netconf []byte, exec Exec) (types.Result, error) {
 	if os.Getenv("CNI_COMMAND") != "ADD" {
 		return nil, fmt.Errorf("CNI_COMMAND is not ADD")
 	}
-	return delegateAddOrGet("ADD", delegatePlugin, netconf)
+	return delegateAddOrGet("ADD", delegatePlugin, netconf, exec)
 }
 
 // DelegateGet calls the given delegate plugin with the CNI GET action and
 // JSON configuration
-func DelegateGet(delegatePlugin string, netconf []byte) (types.Result, error) {
+func DelegateGet(delegatePlugin string, netconf []byte, exec Exec) (types.Result, error) {
 	if os.Getenv("CNI_COMMAND") != "GET" {
 		return nil, fmt.Errorf("CNI_COMMAND is not GET")
 	}
-	return delegateAddOrGet("GET", delegatePlugin, netconf)
+	return delegateAddOrGet("GET", delegatePlugin, netconf, exec)
 }
 
 // DelegateDel calls the given delegate plugin with the CNI DEL action and
 // JSON configuration
-func DelegateDel(delegatePlugin string, netconf []byte) error {
+func DelegateDel(delegatePlugin string, netconf []byte, exec Exec) error {
+	if exec == nil {
+		exec = defaultExec
+	}
+
 	if os.Getenv("CNI_COMMAND") != "DEL" {
 		return fmt.Errorf("CNI_COMMAND is not DEL")
 	}
 
 	paths := filepath.SplitList(os.Getenv("CNI_PATH"))
-
-	pluginPath, err := FindInPath(delegatePlugin, paths)
+	pluginPath, err := exec.FindInPath(delegatePlugin, paths)
 	if err != nil {
 		return err
 	}
 
-	return ExecPluginWithoutResult(pluginPath, netconf, ArgsFromEnv())
+	return ExecPluginWithoutResult(pluginPath, netconf, ArgsFromEnv(), exec)
 }

--- a/pkg/invoke/delegate_test.go
+++ b/pkg/invoke/delegate_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Delegate", func() {
 		})
 
 		It("finds and execs the named plugin", func() {
-			result, err := invoke.DelegateAdd(pluginName, netConf)
+			result, err := invoke.DelegateAdd(pluginName, netConf, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(expectedResult))
 
@@ -105,7 +105,7 @@ var _ = Describe("Delegate", func() {
 			})
 
 			It("aborts and returns a useful error", func() {
-				_, err := invoke.DelegateAdd(pluginName, netConf)
+				_, err := invoke.DelegateAdd(pluginName, netConf, nil)
 				Expect(err).To(MatchError("CNI_COMMAND is not ADD"))
 			})
 		})
@@ -116,7 +116,7 @@ var _ = Describe("Delegate", func() {
 			})
 
 			It("returns a useful error", func() {
-				_, err := invoke.DelegateAdd(pluginName, netConf)
+				_, err := invoke.DelegateAdd(pluginName, netConf, nil)
 				Expect(err).To(MatchError(HavePrefix("failed to find plugin")))
 			})
 		})
@@ -128,7 +128,7 @@ var _ = Describe("Delegate", func() {
 		})
 
 		It("finds and execs the named plugin", func() {
-			result, err := invoke.DelegateGet(pluginName, netConf)
+			result, err := invoke.DelegateGet(pluginName, netConf, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(expectedResult))
 
@@ -144,7 +144,7 @@ var _ = Describe("Delegate", func() {
 			})
 
 			It("aborts and returns a useful error", func() {
-				_, err := invoke.DelegateGet(pluginName, netConf)
+				_, err := invoke.DelegateGet(pluginName, netConf, nil)
 				Expect(err).To(MatchError("CNI_COMMAND is not GET"))
 			})
 		})
@@ -155,7 +155,7 @@ var _ = Describe("Delegate", func() {
 			})
 
 			It("returns a useful error", func() {
-				_, err := invoke.DelegateGet(pluginName, netConf)
+				_, err := invoke.DelegateGet(pluginName, netConf, nil)
 				Expect(err).To(MatchError(HavePrefix("failed to find plugin")))
 			})
 		})
@@ -167,7 +167,7 @@ var _ = Describe("Delegate", func() {
 		})
 
 		It("finds and execs the named plugin", func() {
-			err := invoke.DelegateDel(pluginName, netConf)
+			err := invoke.DelegateDel(pluginName, netConf, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			pluginInvocation, err := debug.ReadDebug(debugFileName)
@@ -182,7 +182,7 @@ var _ = Describe("Delegate", func() {
 			})
 
 			It("aborts and returns a useful error", func() {
-				err := invoke.DelegateDel(pluginName, netConf)
+				err := invoke.DelegateDel(pluginName, netConf, nil)
 				Expect(err).To(MatchError("CNI_COMMAND is not DEL"))
 			})
 		})
@@ -193,7 +193,7 @@ var _ = Describe("Delegate", func() {
 			})
 
 			It("returns a useful error", func() {
-				err := invoke.DelegateDel(pluginName, netConf)
+				err := invoke.DelegateDel(pluginName, netConf, nil)
 				Expect(err).To(MatchError(HavePrefix("failed to find plugin")))
 			})
 		})

--- a/pkg/invoke/exec.go
+++ b/pkg/invoke/exec.go
@@ -22,34 +22,62 @@ import (
 	"github.com/containernetworking/cni/pkg/version"
 )
 
-func ExecPluginWithResult(pluginPath string, netconf []byte, args CNIArgs) (types.Result, error) {
-	return defaultPluginExec.WithResult(pluginPath, netconf, args)
+// Exec is an interface encapsulates all operations that deal with finding
+// and executing a CNI plugin. Tests may provide a fake implementation
+// to avoid writing fake plugins to temporary directories during the test.
+type Exec interface {
+	ExecPlugin(pluginPath string, stdinData []byte, environ []string) ([]byte, error)
+	FindInPath(plugin string, paths []string) (string, error)
+	Decode(jsonBytes []byte) (version.PluginInfo, error)
 }
 
-func ExecPluginWithoutResult(pluginPath string, netconf []byte, args CNIArgs) error {
-	return defaultPluginExec.WithoutResult(pluginPath, netconf, args)
-}
+// For example, a testcase could pass an instance of the following fakeExec
+// object to ExecPluginWithResult() to verify the incoming stdin and environment
+// and provide a tailored response:
+//
+//import (
+//	"encoding/json"
+//	"path"
+//	"strings"
+//)
+//
+//type fakeExec struct {
+//	version.PluginDecoder
+//}
+//
+//func (f *fakeExec) ExecPlugin(pluginPath string, stdinData []byte, environ []string) ([]byte, error) {
+//	net := &types.NetConf{}
+//	err := json.Unmarshal(stdinData, net)
+//	if err != nil {
+//		return nil, fmt.Errorf("failed to unmarshal configuration: %v", err)
+//	}
+//	pluginName := path.Base(pluginPath)
+//	if pluginName != net.Type {
+//		return nil, fmt.Errorf("plugin name %q did not match config type %q", pluginName, net.Type)
+//	}
+//	for _, e := range environ {
+//		// Check environment for forced failure request
+//		parts := strings.Split(e, "=")
+//		if len(parts) > 0 && parts[0] == "FAIL" {
+//			return nil, fmt.Errorf("failed to execute plugin %s", pluginName)
+//		}
+//	}
+//	return []byte("{\"CNIVersion\":\"0.4.0\"}"), nil
+//}
+//
+//func (f *fakeExec) FindInPath(plugin string, paths []string) (string, error) {
+//	if len(paths) > 0 {
+//		return path.Join(paths[0], plugin), nil
+//	}
+//	return "", fmt.Errorf("failed to find plugin %s in paths %v", plugin, paths)
+//}
 
-func GetVersionInfo(pluginPath string) (version.PluginInfo, error) {
-	return defaultPluginExec.GetVersionInfo(pluginPath)
-}
-
-var defaultPluginExec = &PluginExec{
-	RawExec:        &RawExec{Stderr: os.Stderr},
-	VersionDecoder: &version.PluginDecoder{},
-}
-
-type PluginExec struct {
-	RawExec interface {
-		ExecPlugin(pluginPath string, stdinData []byte, environ []string) ([]byte, error)
+func ExecPluginWithResult(pluginPath string, netconf []byte, args CNIArgs, exec Exec) (types.Result, error) {
+	if exec == nil {
+		exec = defaultExec
 	}
-	VersionDecoder interface {
-		Decode(jsonBytes []byte) (version.PluginInfo, error)
-	}
-}
 
-func (e *PluginExec) WithResult(pluginPath string, netconf []byte, args CNIArgs) (types.Result, error) {
-	stdoutBytes, err := e.RawExec.ExecPlugin(pluginPath, netconf, args.AsEnv())
+	stdoutBytes, err := exec.ExecPlugin(pluginPath, netconf, args.AsEnv())
 	if err != nil {
 		return nil, err
 	}
@@ -64,8 +92,11 @@ func (e *PluginExec) WithResult(pluginPath string, netconf []byte, args CNIArgs)
 	return version.NewResult(confVersion, stdoutBytes)
 }
 
-func (e *PluginExec) WithoutResult(pluginPath string, netconf []byte, args CNIArgs) error {
-	_, err := e.RawExec.ExecPlugin(pluginPath, netconf, args.AsEnv())
+func ExecPluginWithoutResult(pluginPath string, netconf []byte, args CNIArgs, exec Exec) error {
+	if exec == nil {
+		exec = defaultExec
+	}
+	_, err := exec.ExecPlugin(pluginPath, netconf, args.AsEnv())
 	return err
 }
 
@@ -73,7 +104,10 @@ func (e *PluginExec) WithoutResult(pluginPath string, netconf []byte, args CNIAr
 // For recent-enough plugins, it uses the information returned by the VERSION
 // command.  For older plugins which do not recognize that command, it reports
 // version 0.1.0
-func (e *PluginExec) GetVersionInfo(pluginPath string) (version.PluginInfo, error) {
+func GetVersionInfo(pluginPath string, exec Exec) (version.PluginInfo, error) {
+	if exec == nil {
+		exec = defaultExec
+	}
 	args := &Args{
 		Command: "VERSION",
 
@@ -83,7 +117,7 @@ func (e *PluginExec) GetVersionInfo(pluginPath string) (version.PluginInfo, erro
 		Path:   "dummy",
 	}
 	stdin := []byte(fmt.Sprintf(`{"cniVersion":%q}`, version.Current()))
-	stdoutBytes, err := e.RawExec.ExecPlugin(pluginPath, stdin, args.AsEnv())
+	stdoutBytes, err := exec.ExecPlugin(pluginPath, stdin, args.AsEnv())
 	if err != nil {
 		if err.Error() == "unknown CNI_COMMAND: VERSION" {
 			return version.PluginSupports("0.1.0"), nil
@@ -91,5 +125,19 @@ func (e *PluginExec) GetVersionInfo(pluginPath string) (version.PluginInfo, erro
 		return nil, err
 	}
 
-	return e.VersionDecoder.Decode(stdoutBytes)
+	return exec.Decode(stdoutBytes)
+}
+
+// DefaultExec is an object that implements the Exec interface which looks
+// for and executes plugins from disk.
+type DefaultExec struct {
+	*RawExec
+	version.PluginDecoder
+}
+
+// DefaultExec implements the Exec interface
+var _ Exec = &DefaultExec{}
+
+var defaultExec = &DefaultExec{
+	RawExec: &RawExec{Stderr: os.Stderr},
 }

--- a/pkg/invoke/exec_test.go
+++ b/pkg/invoke/exec_test.go
@@ -29,7 +29,7 @@ import (
 
 var _ = Describe("Executing a plugin, unit tests", func() {
 	var (
-		pluginExec     *invoke.PluginExec
+		pluginExec     invoke.Exec
 		rawExec        *fakes.RawExec
 		versionDecoder *fakes.VersionDecoder
 
@@ -45,7 +45,10 @@ var _ = Describe("Executing a plugin, unit tests", func() {
 		versionDecoder = &fakes.VersionDecoder{}
 		versionDecoder.DecodeCall.Returns.PluginInfo = version.PluginSupports("0.42.0")
 
-		pluginExec = &invoke.PluginExec{
+		pluginExec = &struct {
+			*fakes.RawExec
+			*fakes.VersionDecoder
+		}{
 			RawExec:        rawExec,
 			VersionDecoder: versionDecoder,
 		}
@@ -57,7 +60,7 @@ var _ = Describe("Executing a plugin, unit tests", func() {
 
 	Describe("returning a result", func() {
 		It("unmarshals the result bytes into the Result type", func() {
-			r, err := pluginExec.WithResult(pluginPath, netconf, cniargs)
+			r, err := invoke.ExecPluginWithResult(pluginPath, netconf, cniargs, pluginExec)
 			Expect(err).NotTo(HaveOccurred())
 
 			result, err := current.GetResult(r)
@@ -67,7 +70,7 @@ var _ = Describe("Executing a plugin, unit tests", func() {
 		})
 
 		It("passes its arguments through to the rawExec", func() {
-			pluginExec.WithResult(pluginPath, netconf, cniargs)
+			invoke.ExecPluginWithResult(pluginPath, netconf, cniargs, pluginExec)
 			Expect(rawExec.ExecPluginCall.Received.PluginPath).To(Equal(pluginPath))
 			Expect(rawExec.ExecPluginCall.Received.StdinData).To(Equal(netconf))
 			Expect(rawExec.ExecPluginCall.Received.Environ).To(Equal([]string{"SOME=ENV"}))
@@ -78,15 +81,23 @@ var _ = Describe("Executing a plugin, unit tests", func() {
 				rawExec.ExecPluginCall.Returns.Error = errors.New("banana")
 			})
 			It("returns the error", func() {
-				_, err := pluginExec.WithResult(pluginPath, netconf, cniargs)
+				_, err := invoke.ExecPluginWithResult(pluginPath, netconf, cniargs, pluginExec)
 				Expect(err).To(MatchError("banana"))
 			})
+		})
+
+		It("returns an error using the default exec interface", func() {
+			// pluginPath should not exist on-disk so we expect an error.
+			// This test simply tests that the default exec handler
+			// is run when the exec interface is nil.
+			_, err := invoke.ExecPluginWithResult(pluginPath, netconf, cniargs, nil)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	Describe("without returning a result", func() {
 		It("passes its arguments through to the rawExec", func() {
-			pluginExec.WithoutResult(pluginPath, netconf, cniargs)
+			invoke.ExecPluginWithoutResult(pluginPath, netconf, cniargs, pluginExec)
 			Expect(rawExec.ExecPluginCall.Received.PluginPath).To(Equal(pluginPath))
 			Expect(rawExec.ExecPluginCall.Received.StdinData).To(Equal(netconf))
 			Expect(rawExec.ExecPluginCall.Received.Environ).To(Equal([]string{"SOME=ENV"}))
@@ -97,9 +108,17 @@ var _ = Describe("Executing a plugin, unit tests", func() {
 				rawExec.ExecPluginCall.Returns.Error = errors.New("banana")
 			})
 			It("returns the error", func() {
-				err := pluginExec.WithoutResult(pluginPath, netconf, cniargs)
+				err := invoke.ExecPluginWithoutResult(pluginPath, netconf, cniargs, pluginExec)
 				Expect(err).To(MatchError("banana"))
 			})
+		})
+
+		It("returns an error using the default exec interface", func() {
+			// pluginPath should not exist on-disk so we expect an error.
+			// This test simply tests that the default exec handler
+			// is run when the exec interface is nil.
+			err := invoke.ExecPluginWithoutResult(pluginPath, netconf, cniargs, nil)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 
@@ -109,7 +128,7 @@ var _ = Describe("Executing a plugin, unit tests", func() {
 		})
 
 		It("execs the plugin with the command VERSION", func() {
-			pluginExec.GetVersionInfo(pluginPath)
+			invoke.GetVersionInfo(pluginPath, pluginExec)
 			Expect(rawExec.ExecPluginCall.Received.PluginPath).To(Equal(pluginPath))
 			Expect(rawExec.ExecPluginCall.Received.Environ).To(ContainElement("CNI_COMMAND=VERSION"))
 			expectedStdin, _ := json.Marshal(map[string]string{"cniVersion": version.Current()})
@@ -117,7 +136,7 @@ var _ = Describe("Executing a plugin, unit tests", func() {
 		})
 
 		It("decodes and returns the version info", func() {
-			versionInfo, err := pluginExec.GetVersionInfo(pluginPath)
+			versionInfo, err := invoke.GetVersionInfo(pluginPath, pluginExec)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(versionInfo.SupportedVersions()).To(Equal([]string{"0.42.0"}))
 			Expect(versionDecoder.DecodeCall.Received.JSONBytes).To(MatchJSON(`{ "some": "version-info" }`))
@@ -128,7 +147,7 @@ var _ = Describe("Executing a plugin, unit tests", func() {
 				rawExec.ExecPluginCall.Returns.Error = errors.New("banana")
 			})
 			It("returns the error", func() {
-				_, err := pluginExec.GetVersionInfo(pluginPath)
+				_, err := invoke.GetVersionInfo(pluginPath, pluginExec)
 				Expect(err).To(MatchError("banana"))
 			})
 		})
@@ -139,13 +158,13 @@ var _ = Describe("Executing a plugin, unit tests", func() {
 			})
 
 			It("interprets the error as a 0.1.0 version", func() {
-				versionInfo, err := pluginExec.GetVersionInfo(pluginPath)
+				versionInfo, err := invoke.GetVersionInfo(pluginPath, pluginExec)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(versionInfo.SupportedVersions()).To(ConsistOf("0.1.0"))
 			})
 
 			It("sets dummy values for env vars required by very old plugins", func() {
-				pluginExec.GetVersionInfo(pluginPath)
+				invoke.GetVersionInfo(pluginPath, pluginExec)
 
 				env := rawExec.ExecPluginCall.Received.Environ
 				Expect(env).To(ContainElement("CNI_NETNS=dummy"))

--- a/pkg/invoke/fakes/raw_exec.go
+++ b/pkg/invoke/fakes/raw_exec.go
@@ -26,6 +26,16 @@ type RawExec struct {
 			Error       error
 		}
 	}
+	FindInPathCall struct {
+		Received struct {
+			Plugin string
+			Paths  []string
+		}
+		Returns struct {
+			Path  string
+			Error error
+		}
+	}
 }
 
 func (e *RawExec) ExecPlugin(pluginPath string, stdinData []byte, environ []string) ([]byte, error) {
@@ -33,4 +43,10 @@ func (e *RawExec) ExecPlugin(pluginPath string, stdinData []byte, environ []stri
 	e.ExecPluginCall.Received.StdinData = stdinData
 	e.ExecPluginCall.Received.Environ = environ
 	return e.ExecPluginCall.Returns.ResultBytes, e.ExecPluginCall.Returns.Error
+}
+
+func (e *RawExec) FindInPath(plugin string, paths []string) (string, error) {
+	e.FindInPathCall.Received.Plugin = plugin
+	e.FindInPathCall.Received.Paths = paths
+	return e.FindInPathCall.Returns.Path, e.FindInPathCall.Returns.Error
 }

--- a/pkg/invoke/get_version_integration_test.go
+++ b/pkg/invoke/get_version_integration_test.go
@@ -51,7 +51,7 @@ var _ = Describe("GetVersion, integration tests", func() {
 	DescribeTable("correctly reporting plugin versions",
 		func(gitRef string, pluginSource string, expectedVersions version.PluginInfo) {
 			Expect(testhelpers.BuildAt([]byte(pluginSource), gitRef, pluginPath)).To(Succeed())
-			versionInfo, err := invoke.GetVersionInfo(pluginPath)
+			versionInfo, err := invoke.GetVersionInfo(pluginPath, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(versionInfo.SupportedVersions()).To(ConsistOf(expectedVersions.SupportedVersions()))

--- a/pkg/invoke/raw_exec.go
+++ b/pkg/invoke/raw_exec.go
@@ -57,3 +57,7 @@ func pluginErr(err error, output []byte) error {
 
 	return err
 }
+
+func (e *RawExec) FindInPath(plugin string, paths []string) (string, error) {
+	return FindInPath(plugin, paths)
+}


### PR DESCRIPTION
When a downstream project just uses libcni, it takes a lot of harness
code to set up binaries on-disk that get called.  Instead we can handle
that by passing an execer interface to libcni APIs that gets called
instead, which the downstreams can use to avoid execing thing entirely
and instead check arguments/environment in code.

@containernetworking/cni-maintainers @squeed 