### PR TITLE
Add Juniper Contrail to 3rd party plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ To avoid duplication, we think it is prudent to define a common interface betwee
 - [Amazon ECS CNI Plugins - a collection of CNI Plugins to configure containers with Amazon EC2 elastic network interfaces (ENIs)](https://github.com/aws/amazon-ecs-cni-plugins)
 - [Bonding CNI - a Link aggregating plugin to address failover and high availability network](https://github.com/Intel-Corp/bond-cni)
 - [ovn-kubernetes - an container network plugin built on Open vSwitch (OVS) and Open Virtual Networking (OVN) with support for both Linux and Windows](https://github.com/openvswitch/ovn-kubernetes)
+- [Juniper Contrail](http://www.juniper.net/cloud) / [TungstenFabric](https://tungstenfabric.io) -  Provides overlay SDN solution, delivering multicloud networking, hybrid cloud networking, simultaneous overlay-underlay support, network policy enforcement, network isolation, service chaining and flexible load balancing
 
 The CNI team also maintains some [core plugins in a separate repository](https://github.com/containernetworking/plugins).
 


### PR DESCRIPTION
This change is to update the 3rd Party plugin section of README
to include and list the K8s CNI solution from Juniper Networks, INC.