### PR TITLE
List Knitter as 3rd party plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ To avoid duplication, we think it is prudent to define a common interface betwee
 - [Bonding CNI - a Link aggregating plugin to address failover and high availability network](https://github.com/Intel-Corp/bond-cni)
 - [ovn-kubernetes - an container network plugin built on Open vSwitch (OVS) and Open Virtual Networking (OVN) with support for both Linux and Windows](https://github.com/openvswitch/ovn-kubernetes)
 - [Juniper Contrail](http://www.juniper.net/cloud) / [TungstenFabric](https://tungstenfabric.io) -  Provides overlay SDN solution, delivering multicloud networking, hybrid cloud networking, simultaneous overlay-underlay support, network policy enforcement, network isolation, service chaining and flexible load balancing
+- [Knitter - a CNI plugin supporting multiple networking for Kubernetes](https://github.com/ZTE/Knitter)
 
 The CNI team also maintains some [core plugins in a separate repository](https://github.com/containernetworking/plugins).
 


### PR DESCRIPTION
This PR adds Knitter to 3rd party plugin list in README. Knitter is a CNI plugin supporting multiple networking for Kubernetes.