### PR TITLE
Add name field in 99-loopback.conf because network name is required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ EOF
 $ cat >/etc/cni/net.d/99-loopback.conf <<EOF
 {
 	"cniVersion": "0.2.0",
+	"name": "lo",
 	"type": "loopback"
 }
 EOF


### PR DESCRIPTION
If there were no name field in 99-loopback.conf, there would be an error:
```
root@iZ2ze8rkx46zyx6mojyeb5Z:~/gocode/src/github.com/containernetworking/cni/scripts# ./priv-net-run.sh ifconfig
null : error executing ADD: missing network name
```