### PR TITLE
when type is loopback, IP4 or IP6 is always nil

### DIFF
--- a/pkg/types/current/types.go
+++ b/pkg/types/current/types.go
@@ -104,10 +104,6 @@ func convertFrom020(result types.Result) (*Result, error) {
 		}
 	}
 
-	if len(newResult.IPs) == 0 {
-		return nil, fmt.Errorf("cannot convert: no valid IP addresses")
-	}
-
 	return newResult, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Lifubang <lifubang@aliyun.com>

issue: https://github.com/containerd/containerd/issues/2540

When type is loopback, and cniVersion is 0.2.0, the NewResultFromResult will return an error:
cannot convert: no valid IP addresses

I think we should not check IPs field in method convertFrom020. Let it check by user. Because all have been successful except this check.

Please check it, thanks.