### PR TITLE
skel,invoke,libcni: GET -> CHECK

### DIFF
--- a/cnitool/cnitool.go
+++ b/cnitool/cnitool.go
@@ -35,8 +35,9 @@ const (
 
 	DefaultNetDir = "/etc/cni/net.d"
 
-	CmdAdd = "add"
-	CmdDel = "del"
+	CmdAdd   = "add"
+	CmdCheck = "check"
+	CmdDel   = "del"
 )
 
 func parseArgs(args string) ([][2]string, error) {
@@ -119,6 +120,9 @@ func main() {
 			_ = result.Print()
 		}
 		exit(err)
+	case CmdCheck:
+		err := cninet.CheckNetworkList(context.TODO(), netconf, rt)
+		exit(err)
 	case CmdDel:
 		exit(cninet.DelNetworkList(context.TODO(), netconf, rt))
 	}
@@ -127,9 +131,10 @@ func main() {
 func usage() {
 	exe := filepath.Base(os.Args[0])
 
-	fmt.Fprintf(os.Stderr, "%s: Add or remove network interfaces from a network namespace\n", exe)
-	fmt.Fprintf(os.Stderr, "  %s %s <net> <netns>\n", exe, CmdAdd)
-	fmt.Fprintf(os.Stderr, "  %s %s <net> <netns>\n", exe, CmdDel)
+	fmt.Fprintf(os.Stderr, "%s: Add, check, or remove network interfaces from a network namespace\n", exe)
+	fmt.Fprintf(os.Stderr, "  %s add   <net> <netns>\n", exe)
+	fmt.Fprintf(os.Stderr, "  %s check <net> <netns>\n", exe)
+	fmt.Fprintf(os.Stderr, "  %s del   <net> <netns>\n", exe)
 	os.Exit(1)
 }
 

--- a/libcni/api.go
+++ b/libcni/api.go
@@ -58,10 +58,11 @@ type NetworkConfig struct {
 }
 
 type NetworkConfigList struct {
-	Name       string
-	CNIVersion string
-	Plugins    []*NetworkConfig
-	Bytes      []byte
+	Name         string
+	CNIVersion   string
+	DisableCheck bool
+	Plugins      []*NetworkConfig
+	Bytes        []byte
 }
 
 type CNI interface {
@@ -287,6 +288,10 @@ func (c *CNIConfig) CheckNetworkList(ctx context.Context, list *NetworkConfigLis
 		return err
 	} else if !gtet {
 		return fmt.Errorf("configuration version %q does not support the CHECK command", list.CNIVersion)
+	}
+
+	if list.DisableCheck {
+		return nil
 	}
 
 	cachedResult, err := getCachedResult(list.Name, list.CNIVersion, rt)

--- a/libcni/api.go
+++ b/libcni/api.go
@@ -72,6 +72,7 @@ type CNI interface {
 	AddNetwork(ctx context.Context, net *NetworkConfig, rt *RuntimeConf) (types.Result, error)
 	CheckNetwork(ctx context.Context, net *NetworkConfig, rt *RuntimeConf) error
 	DelNetwork(ctx context.Context, net *NetworkConfig, rt *RuntimeConf) error
+	GetNetworkCachedResult(net *NetworkConfig, rt *RuntimeConf) (types.Result, error)
 
 	ValidateNetworkList(ctx context.Context, net *NetworkConfigList) ([]string, error)
 	ValidateNetwork(ctx context.Context, net *NetworkConfig) ([]string, error)
@@ -217,6 +218,18 @@ func getCachedResult(netName, cniVersion string, rt *RuntimeConf) (types.Result,
 		return nil, fmt.Errorf("failed to convert cached result version %q to config version %q: %v", resultCniVersion, cniVersion, err)
 	}
 	return result, err
+}
+
+// GetNetworkListCachedResult returns the cached Result of the previous
+// previous AddNetworkList() operation for a network list, or an error.
+func (c *CNIConfig) GetNetworkListCachedResult(list *NetworkConfigList, rt *RuntimeConf) (types.Result, error) {
+	return getCachedResult(list.Name, list.CNIVersion, rt)
+}
+
+// GetNetworkCachedResult returns the cached Result of the previous
+// previous AddNetwork() operation for a network, or an error.
+func (c *CNIConfig) GetNetworkCachedResult(net *NetworkConfig, rt *RuntimeConf) (types.Result, error) {
+	return getCachedResult(net.Network.Name, net.Network.CNIVersion, rt)
 }
 
 func (c *CNIConfig) addNetwork(ctx context.Context, name, cniVersion string, net *NetworkConfig, prevResult types.Result, rt *RuntimeConf) (types.Result, error) {

--- a/libcni/api.go
+++ b/libcni/api.go
@@ -66,11 +66,11 @@ type NetworkConfigList struct {
 
 type CNI interface {
 	AddNetworkList(ctx context.Context, net *NetworkConfigList, rt *RuntimeConf) (types.Result, error)
-	GetNetworkList(ctx context.Context, net *NetworkConfigList, rt *RuntimeConf) (types.Result, error)
+	CheckNetworkList(ctx context.Context, net *NetworkConfigList, rt *RuntimeConf) error
 	DelNetworkList(ctx context.Context, net *NetworkConfigList, rt *RuntimeConf) error
 
 	AddNetwork(ctx context.Context, net *NetworkConfig, rt *RuntimeConf) (types.Result, error)
-	GetNetwork(ctx context.Context, net *NetworkConfig, rt *RuntimeConf) (types.Result, error)
+	CheckNetwork(ctx context.Context, net *NetworkConfig, rt *RuntimeConf) error
 	DelNetwork(ctx context.Context, net *NetworkConfig, rt *RuntimeConf) error
 
 	ValidateNetworkList(ctx context.Context, net *NetworkConfigList) ([]string, error)
@@ -162,34 +162,6 @@ func (c *CNIConfig) ensureExec() invoke.Exec {
 	return c.exec
 }
 
-func (c *CNIConfig) addOrGetNetwork(ctx context.Context, command, name, cniVersion string, net *NetworkConfig, prevResult types.Result, rt *RuntimeConf) (types.Result, error) {
-
-	c.ensureExec()
-	pluginPath, err := c.exec.FindInPath(net.Network.Type, c.Path)
-	if err != nil {
-		return nil, err
-	}
-
-	newConf, err := buildOneConfig(name, cniVersion, net, prevResult, rt)
-	if err != nil {
-		return nil, err
-	}
-	return invoke.ExecPluginWithResult(ctx, pluginPath, newConf.Bytes, c.args(command, rt), c.exec)
-}
-
-// Note that only GET requests should pass an initial prevResult
-func (c *CNIConfig) addOrGetNetworkList(ctx context.Context, command string, prevResult types.Result, list *NetworkConfigList, rt *RuntimeConf) (types.Result, error) {
-	var err error
-	for _, net := range list.Plugins {
-		prevResult, err = c.addOrGetNetwork(ctx, command, list.Name, list.CNIVersion, net, prevResult, rt)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return prevResult, nil
-}
-
 func getResultCacheFilePath(netName string, rt *RuntimeConf) string {
 	cacheDir := rt.CacheDir
 	if cacheDir == "" {
@@ -247,34 +219,75 @@ func getCachedResult(netName, cniVersion string, rt *RuntimeConf) (types.Result,
 	return result, err
 }
 
-// AddNetworkList executes a sequence of plugins with the ADD command
-func (c *CNIConfig) AddNetworkList(ctx context.Context, list *NetworkConfigList, rt *RuntimeConf) (types.Result, error) {
-	result, err := c.addOrGetNetworkList(ctx, "ADD", nil, list, rt)
+func (c *CNIConfig) addNetwork(ctx context.Context, name, cniVersion string, net *NetworkConfig, prevResult types.Result, rt *RuntimeConf) (types.Result, error) {
+	c.ensureExec()
+	pluginPath, err := c.exec.FindInPath(net.Network.Type, c.Path)
 	if err != nil {
 		return nil, err
 	}
 
+	newConf, err := buildOneConfig(name, cniVersion, net, prevResult, rt)
+	if err != nil {
+		return nil, err
+	}
+
+	return invoke.ExecPluginWithResult(ctx, pluginPath, newConf.Bytes, c.args("ADD", rt), c.exec)
+}
+
+// AddNetworkList executes a sequence of plugins with the ADD command
+func (c *CNIConfig) AddNetworkList(ctx context.Context, list *NetworkConfigList, rt *RuntimeConf) (types.Result, error) {
+	var err error
+	var result types.Result
+	for _, net := range list.Plugins {
+		result, err = c.addNetwork(ctx, list.Name, list.CNIVersion, net, result, rt)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if err = setCachedResult(result, list.Name, rt); err != nil {
-		return nil, fmt.Errorf("failed to set network '%s' cached result: %v", list.Name, err)
+		return nil, fmt.Errorf("failed to set network %q cached result: %v", list.Name, err)
 	}
 
 	return result, nil
 }
 
-// GetNetworkList executes a sequence of plugins with the GET command
-func (c *CNIConfig) GetNetworkList(ctx context.Context, list *NetworkConfigList, rt *RuntimeConf) (types.Result, error) {
-	// GET was added in CNI spec version 0.4.0 and higher
+func (c *CNIConfig) checkNetwork(ctx context.Context, name, cniVersion string, net *NetworkConfig, prevResult types.Result, rt *RuntimeConf) error {
+	c.ensureExec()
+	pluginPath, err := c.exec.FindInPath(net.Network.Type, c.Path)
+	if err != nil {
+		return err
+	}
+
+	newConf, err := buildOneConfig(name, cniVersion, net, prevResult, rt)
+	if err != nil {
+		return err
+	}
+
+	return invoke.ExecPluginWithoutResult(ctx, pluginPath, newConf.Bytes, c.args("CHECK", rt), c.exec)
+}
+
+// CheckNetworkList executes a sequence of plugins with the CHECK command
+func (c *CNIConfig) CheckNetworkList(ctx context.Context, list *NetworkConfigList, rt *RuntimeConf) error {
+	// CHECK was added in CNI spec version 0.4.0 and higher
 	if gtet, err := version.GreaterThanOrEqualTo(list.CNIVersion, "0.4.0"); err != nil {
-		return nil, err
+		return err
 	} else if !gtet {
-		return nil, fmt.Errorf("configuration version %q does not support the GET command", list.CNIVersion)
+		return fmt.Errorf("configuration version %q does not support the CHECK command", list.CNIVersion)
 	}
 
 	cachedResult, err := getCachedResult(list.Name, list.CNIVersion, rt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get network '%s' cached result: %v", list.Name, err)
+		return fmt.Errorf("failed to get network %q cached result: %v", list.Name, err)
 	}
-	return c.addOrGetNetworkList(ctx, "GET", cachedResult, list, rt)
+
+	for _, net := range list.Plugins {
+		if err := c.checkNetwork(ctx, list.Name, list.CNIVersion, net, cachedResult, rt); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (c *CNIConfig) delNetwork(ctx context.Context, name, cniVersion string, net *NetworkConfig, prevResult types.Result, rt *RuntimeConf) error {
@@ -302,7 +315,7 @@ func (c *CNIConfig) DelNetworkList(ctx context.Context, list *NetworkConfigList,
 	} else if gtet {
 		cachedResult, err = getCachedResult(list.Name, list.CNIVersion, rt)
 		if err != nil {
-			return fmt.Errorf("failed to get network '%s' cached result: %v", list.Name, err)
+			return fmt.Errorf("failed to get network %q cached result: %v", list.Name, err)
 		}
 	}
 
@@ -319,32 +332,32 @@ func (c *CNIConfig) DelNetworkList(ctx context.Context, list *NetworkConfigList,
 
 // AddNetwork executes the plugin with the ADD command
 func (c *CNIConfig) AddNetwork(ctx context.Context, net *NetworkConfig, rt *RuntimeConf) (types.Result, error) {
-	result, err := c.addOrGetNetwork(ctx, "ADD", net.Network.Name, net.Network.CNIVersion, net, nil, rt)
+	result, err := c.addNetwork(ctx, net.Network.Name, net.Network.CNIVersion, net, nil, rt)
 	if err != nil {
 		return nil, err
 	}
 
 	if err = setCachedResult(result, net.Network.Name, rt); err != nil {
-		return nil, fmt.Errorf("failed to set network '%s' cached result: %v", net.Network.Name, err)
+		return nil, fmt.Errorf("failed to set network %q cached result: %v", net.Network.Name, err)
 	}
 
 	return result, nil
 }
 
-// GetNetwork executes the plugin with the GET command
-func (c *CNIConfig) GetNetwork(ctx context.Context, net *NetworkConfig, rt *RuntimeConf) (types.Result, error) {
-	// GET was added in CNI spec version 0.4.0 and higher
+// CheckNetwork executes the plugin with the CHECK command
+func (c *CNIConfig) CheckNetwork(ctx context.Context, net *NetworkConfig, rt *RuntimeConf) error {
+	// CHECK was added in CNI spec version 0.4.0 and higher
 	if gtet, err := version.GreaterThanOrEqualTo(net.Network.CNIVersion, "0.4.0"); err != nil {
-		return nil, err
+		return err
 	} else if !gtet {
-		return nil, fmt.Errorf("configuration version %q does not support the GET command", net.Network.CNIVersion)
+		return fmt.Errorf("configuration version %q does not support the CHECK command", net.Network.CNIVersion)
 	}
 
 	cachedResult, err := getCachedResult(net.Network.Name, net.Network.CNIVersion, rt)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get network '%s' cached result: %v", net.Network.Name, err)
+		return fmt.Errorf("failed to get network %q cached result: %v", net.Network.Name, err)
 	}
-	return c.addOrGetNetwork(ctx, "GET", net.Network.Name, net.Network.CNIVersion, net, cachedResult, rt)
+	return c.checkNetwork(ctx, net.Network.Name, net.Network.CNIVersion, net, cachedResult, rt)
 }
 
 // DelNetwork executes the plugin with the DEL command
@@ -357,7 +370,7 @@ func (c *CNIConfig) DelNetwork(ctx context.Context, net *NetworkConfig, rt *Runt
 	} else if gtet {
 		cachedResult, err = getCachedResult(net.Network.Name, net.Network.CNIVersion, rt)
 		if err != nil {
-			return fmt.Errorf("failed to get network '%s' cached result: %v", net.Network.Name, err)
+			return fmt.Errorf("failed to get network %q cached result: %v", net.Network.Name, err)
 		}
 	}
 

--- a/libcni/api.go
+++ b/libcni/api.go
@@ -169,7 +169,7 @@ func getResultCacheFilePath(netName string, rt *RuntimeConf) string {
 	if cacheDir == "" {
 		cacheDir = CacheDir
 	}
-	return filepath.Join(cacheDir, "results", fmt.Sprintf("%s-%s", netName, rt.ContainerID))
+	return filepath.Join(cacheDir, "results", fmt.Sprintf("%s-%s-%s", netName, rt.ContainerID, rt.IfName))
 }
 
 func setCachedResult(result types.Result, netName string, rt *RuntimeConf) error {

--- a/libcni/api_test.go
+++ b/libcni/api_test.go
@@ -359,14 +359,16 @@ var _ = Describe("Invoking plugins", func() {
 				Expect(string(debug.CmdArgs.StdinData)).To(ContainSubstring("\"portMappings\":"))
 
 				// Ensure the cached result matches the returned one
-				cacheFile := resultCacheFilePath(cacheDirPath, netConfig.Network.Name, runtimeConfig.ContainerID)
-				_, err = os.Stat(cacheFile)
+				cachedResult, err := cniConfig.GetNetworkCachedResult(netConfig, runtimeConfig)
 				Expect(err).NotTo(HaveOccurred())
-				cachedData, err := ioutil.ReadFile(cacheFile)
+				result2, err := current.GetResult(cachedResult)
 				Expect(err).NotTo(HaveOccurred())
-				returnedData, err := json.Marshal(result)
+				cachedJson, err := json.Marshal(result2)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(cachedData).To(MatchJSON(returnedData))
+
+				returnedJson, err := json.Marshal(result)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cachedJson).To(MatchJSON(returnedJson))
 			})
 
 			Context("when finding the plugin fails", func() {
@@ -597,6 +599,11 @@ var _ = Describe("Invoking plugins", func() {
 				debug.CmdArgs.StdinData = nil
 				expectedCmdArgs.StdinData = nil
 				Expect(debug.CmdArgs).To(Equal(expectedCmdArgs))
+
+				// Ensure the cached result no longer exists
+				cachedResult, err := cniConfig.GetNetworkCachedResult(netConfig, runtimeConfig)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cachedResult).To(BeNil())
 			})
 
 			Context("when finding the plugin fails", func() {
@@ -916,14 +923,16 @@ var _ = Describe("Invoking plugins", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				// Ensure the cached result matches the returned one
-				cacheFile := resultCacheFilePath(cacheDirPath, netConfigList.Name, runtimeConfig.ContainerID)
-				_, err = os.Stat(cacheFile)
+				cachedResult, err := cniConfig.GetNetworkListCachedResult(netConfigList, runtimeConfig)
 				Expect(err).NotTo(HaveOccurred())
-				cachedData, err := ioutil.ReadFile(cacheFile)
+				result2, err := current.GetResult(cachedResult)
 				Expect(err).NotTo(HaveOccurred())
-				returnedData, err := json.Marshal(result)
+				cachedJson, err := json.Marshal(result2)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(cachedData).To(MatchJSON(returnedData))
+
+				returnedJson, err := json.Marshal(result)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cachedJson).To(MatchJSON(returnedJson))
 			})
 
 			Context("when finding the plugin fails", func() {
@@ -1098,6 +1107,11 @@ var _ = Describe("Invoking plugins", func() {
 					debug.CmdArgs.StdinData = nil
 					Expect(debug.CmdArgs).To(Equal(expectedCmdArgs))
 				}
+
+				// Ensure the cached result no longer exists
+				cachedResult, err := cniConfig.GetNetworkListCachedResult(netConfigList, runtimeConfig)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cachedResult).To(BeNil())
 			})
 
 			Context("when the configuration version", func() {

--- a/libcni/api_test.go
+++ b/libcni/api_test.go
@@ -1003,6 +1003,18 @@ var _ = Describe("Invoking plugins", func() {
 				}
 			})
 
+			It("does not executes plugins with command CHECK when disableCheck is true", func() {
+				netConfigList.DisableCheck = true
+				err := cniConfig.CheckNetworkList(ctx, netConfigList, runtimeConfig)
+				Expect(err).NotTo(HaveOccurred())
+
+				for i := 0; i < len(plugins); i++ {
+					debug, err := noop_debug.ReadDebug(plugins[i].debugFilePath)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(debug.Command).To(Equal(""))
+				}
+			})
+
 			Context("when the configuration version", func() {
 				var cacheFile string
 

--- a/libcni/api_test.go
+++ b/libcni/api_test.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/containernetworking/cni/libcni"
@@ -118,8 +119,8 @@ func newPluginInfo(configValue, prevResult string, injectDebugFilePath bool, res
 	}
 }
 
-func resultCacheFilePath(cacheDirPath, netName, containerID string) string {
-	return filepath.Join(cacheDirPath, "results", netName+"-"+containerID)
+func resultCacheFilePath(cacheDirPath, netName string, rt *libcni.RuntimeConf) string {
+	return filepath.Join(cacheDirPath, "results", netName+"-"+rt.ContainerID+"-"+rt.IfName)
 }
 
 var _ = Describe("Invoking plugins", func() {
@@ -411,7 +412,7 @@ var _ = Describe("Invoking plugins", func() {
 
 		Describe("CheckNetwork", func() {
 			It("executes the plugin with command CHECK", func() {
-				cacheFile := resultCacheFilePath(cacheDirPath, netConfig.Network.Name, runtimeConfig.ContainerID)
+				cacheFile := resultCacheFilePath(cacheDirPath, netConfig.Network.Name, runtimeConfig)
 				err := os.MkdirAll(filepath.Dir(cacheFile), 0700)
 				Expect(err).NotTo(HaveOccurred())
 				cachedJson := `{
@@ -473,7 +474,7 @@ var _ = Describe("Invoking plugins", func() {
 				var cacheFile string
 
 				BeforeEach(func() {
-					cacheFile = resultCacheFilePath(cacheDirPath, netConfig.Network.Name, runtimeConfig.ContainerID)
+					cacheFile = resultCacheFilePath(cacheDirPath, netConfig.Network.Name, runtimeConfig)
 					err := os.MkdirAll(filepath.Dir(cacheFile), 0700)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -520,7 +521,7 @@ var _ = Describe("Invoking plugins", func() {
 				var cacheFile string
 
 				BeforeEach(func() {
-					cacheFile = resultCacheFilePath(cacheDirPath, netConfig.Network.Name, runtimeConfig.ContainerID)
+					cacheFile = resultCacheFilePath(cacheDirPath, netConfig.Network.Name, runtimeConfig)
 					err := os.MkdirAll(filepath.Dir(cacheFile), 0700)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -565,7 +566,7 @@ var _ = Describe("Invoking plugins", func() {
 
 		Describe("DelNetwork", func() {
 			It("executes the plugin with command DEL", func() {
-				cacheFile := resultCacheFilePath(cacheDirPath, netConfig.Network.Name, runtimeConfig.ContainerID)
+				cacheFile := resultCacheFilePath(cacheDirPath, netConfig.Network.Name, runtimeConfig)
 				err := os.MkdirAll(filepath.Dir(cacheFile), 0700)
 				Expect(err).NotTo(HaveOccurred())
 				cachedJson := `{
@@ -632,7 +633,7 @@ var _ = Describe("Invoking plugins", func() {
 				var cacheFile string
 
 				BeforeEach(func() {
-					cacheFile = resultCacheFilePath(cacheDirPath, netConfig.Network.Name, runtimeConfig.ContainerID)
+					cacheFile = resultCacheFilePath(cacheDirPath, netConfig.Network.Name, runtimeConfig)
 					err := os.MkdirAll(filepath.Dir(cacheFile), 0700)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -659,7 +660,7 @@ var _ = Describe("Invoking plugins", func() {
 				var cacheFile string
 
 				BeforeEach(func() {
-					cacheFile = resultCacheFilePath(cacheDirPath, netConfig.Network.Name, runtimeConfig.ContainerID)
+					cacheFile = resultCacheFilePath(cacheDirPath, netConfig.Network.Name, runtimeConfig)
 					err := os.MkdirAll(filepath.Dir(cacheFile), 0700)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -715,7 +716,7 @@ var _ = Describe("Invoking plugins", func() {
 				var cacheFile string
 
 				BeforeEach(func() {
-					cacheFile = resultCacheFilePath(cacheDirPath, netConfig.Network.Name, runtimeConfig.ContainerID)
+					cacheFile = resultCacheFilePath(cacheDirPath, netConfig.Network.Name, runtimeConfig)
 					err := os.MkdirAll(filepath.Dir(cacheFile), 0700)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -975,7 +976,7 @@ var _ = Describe("Invoking plugins", func() {
 
 		Describe("CheckNetworkList", func() {
 			It("executes all plugins with command CHECK", func() {
-				cacheFile := resultCacheFilePath(cacheDirPath, netConfigList.Name, runtimeConfig.ContainerID)
+				cacheFile := resultCacheFilePath(cacheDirPath, netConfigList.Name, runtimeConfig)
 				err := os.MkdirAll(filepath.Dir(cacheFile), 0700)
 				Expect(err).NotTo(HaveOccurred())
 				err = ioutil.WriteFile(cacheFile, []byte(ipResult), 0600)
@@ -1019,7 +1020,7 @@ var _ = Describe("Invoking plugins", func() {
 				var cacheFile string
 
 				BeforeEach(func() {
-					cacheFile = resultCacheFilePath(cacheDirPath, netConfigList.Name, runtimeConfig.ContainerID)
+					cacheFile = resultCacheFilePath(cacheDirPath, netConfigList.Name, runtimeConfig)
 					err := os.MkdirAll(filepath.Dir(cacheFile), 0700)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -1092,7 +1093,7 @@ var _ = Describe("Invoking plugins", func() {
 
 			Context("when the cached result is invalid", func() {
 				It("returns an error", func() {
-					cacheFile := resultCacheFilePath(cacheDirPath, netConfigList.Name, runtimeConfig.ContainerID)
+					cacheFile := resultCacheFilePath(cacheDirPath, netConfigList.Name, runtimeConfig)
 					err := os.MkdirAll(filepath.Dir(cacheFile), 0700)
 					Expect(err).NotTo(HaveOccurred())
 					err = ioutil.WriteFile(cacheFile, []byte("adfadsfasdfasfdsafaf"), 0600)
@@ -1130,7 +1131,7 @@ var _ = Describe("Invoking plugins", func() {
 				var cacheFile string
 
 				BeforeEach(func() {
-					cacheFile = resultCacheFilePath(cacheDirPath, netConfigList.Name, runtimeConfig.ContainerID)
+					cacheFile = resultCacheFilePath(cacheDirPath, netConfigList.Name, runtimeConfig)
 					err := os.MkdirAll(filepath.Dir(cacheFile), 0700)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -1215,7 +1216,7 @@ var _ = Describe("Invoking plugins", func() {
 
 			Context("when the cached result is invalid", func() {
 				It("returns an error", func() {
-					cacheFile := resultCacheFilePath(cacheDirPath, netConfigList.Name, runtimeConfig.ContainerID)
+					cacheFile := resultCacheFilePath(cacheDirPath, netConfigList.Name, runtimeConfig)
 					err := os.MkdirAll(filepath.Dir(cacheFile), 0700)
 					Expect(err).NotTo(HaveOccurred())
 					err = ioutil.WriteFile(cacheFile, []byte("adfadsfasdfasfdsafaf"), 0600)
@@ -1428,5 +1429,93 @@ var _ = Describe("Invoking plugins", func() {
 			})
 		})
 
+	})
+
+	Describe("Result cache operations", func() {
+		var (
+			debugFilePath string
+			debug         *noop_debug.Debug
+			cniBinPath    string
+			pluginConfig  string
+			cniConfig     *libcni.CNIConfig
+			netConfig     *libcni.NetworkConfig
+			runtimeConfig *libcni.RuntimeConf
+
+			ctx context.Context
+		)
+		firstIP := "10.1.2.3/24"
+		firstIfname := "eth0"
+		secondIP := "10.1.2.5/24"
+		secondIfname := "eth1"
+
+		BeforeEach(func() {
+			debugFile, err := ioutil.TempFile("", "cni_debug")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(debugFile.Close()).To(Succeed())
+			debugFilePath = debugFile.Name()
+
+			debug = &noop_debug.Debug{
+				ReportResult: fmt.Sprintf(`{
+					"cniVersion": "%s",
+					"ips": [{"version": "4", "address": "%s"}]
+				}`, current.ImplementedSpecVersion, firstIP),
+			}
+			Expect(debug.WriteDebug(debugFilePath)).To(Succeed())
+
+			cniBinPath = filepath.Dir(pluginPaths["noop"])
+			pluginConfig = fmt.Sprintf(`{
+				"type": "noop",
+				"name": "cachetest",
+				"cniVersion": "%s"
+			}`, current.ImplementedSpecVersion)
+			cniConfig = libcni.NewCNIConfig([]string{cniBinPath}, nil)
+			netConfig, err = libcni.ConfFromBytes([]byte(pluginConfig))
+			Expect(err).NotTo(HaveOccurred())
+			runtimeConfig = &libcni.RuntimeConf{
+				ContainerID: "some-container-id",
+				NetNS:       "/some/netns/path",
+				IfName:      firstIfname,
+				CacheDir:    cacheDirPath,
+				Args:        [][2]string{{"DEBUG", debugFilePath}},
+			}
+			ctx = context.TODO()
+		})
+
+		AfterEach(func() {
+			Expect(os.RemoveAll(debugFilePath)).To(Succeed())
+		})
+
+		It("creates separate cache files for multiple attachments to the same network", func() {
+			_, err := cniConfig.AddNetwork(ctx, netConfig, runtimeConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			debug.ReportResult = fmt.Sprintf(`{
+				"cniVersion": "%s",
+				"ips": [{"version": "4", "address": "%s"}]
+			}`, current.ImplementedSpecVersion, secondIP)
+			Expect(debug.WriteDebug(debugFilePath)).To(Succeed())
+			runtimeConfig.IfName = secondIfname
+			_, err = cniConfig.AddNetwork(ctx, netConfig, runtimeConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			resultsDir := filepath.Join(cacheDirPath, "results")
+			files, err := ioutil.ReadDir(resultsDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(files)).To(Equal(2))
+			var foundFirst, foundSecond bool
+			for _, f := range files {
+				data, err := ioutil.ReadFile(filepath.Join(resultsDir, f.Name()))
+				Expect(err).NotTo(HaveOccurred())
+				if strings.HasSuffix(f.Name(), firstIfname) {
+					foundFirst = true
+					Expect(strings.Contains(string(data), firstIP)).To(BeTrue())
+				} else if strings.HasSuffix(f.Name(), secondIfname) {
+					foundSecond = true
+					Expect(strings.Contains(string(data), secondIP)).To(BeTrue())
+				}
+			}
+			Expect(foundFirst).To(BeTrue())
+			Expect(foundSecond).To(BeTrue())
+		})
 	})
 })

--- a/libcni/conf.go
+++ b/libcni/conf.go
@@ -83,10 +83,19 @@ func ConfListFromBytes(bytes []byte) (*NetworkConfigList, error) {
 		}
 	}
 
+	disableCheck := false
+	if rawDisableCheck, ok := rawList["disableCheck"]; ok {
+		disableCheck, ok = rawDisableCheck.(bool)
+		if !ok {
+			return nil, fmt.Errorf("error parsing configuration list: invalid disableCheck type %T", rawDisableCheck)
+		}
+	}
+
 	list := &NetworkConfigList{
-		Name:       name,
-		CNIVersion: cniVersion,
-		Bytes:      bytes,
+		Name:         name,
+		DisableCheck: disableCheck,
+		CNIVersion:   cniVersion,
+		Bytes:        bytes,
 	}
 
 	var plugins []interface{}

--- a/libcni/conf_test.go
+++ b/libcni/conf_test.go
@@ -202,6 +202,7 @@ var _ = Describe("Loading configuration from disk", func() {
 			configList = []byte(`{
   "name": "some-list",
   "cniVersion": "0.2.0",
+  "disableCheck": true,
   "plugins": [
     {
       "type": "host-local",
@@ -228,8 +229,9 @@ var _ = Describe("Loading configuration from disk", func() {
 			netConfigList, err := libcni.LoadConfList(configDir, "some-list")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(netConfigList).To(Equal(&libcni.NetworkConfigList{
-				Name:       "some-list",
-				CNIVersion: "0.2.0",
+				Name:         "some-list",
+				CNIVersion:   "0.2.0",
+				DisableCheck: true,
 				Plugins: []*libcni.NetworkConfig{
 					{
 						Network: &types.NetConf{Type: "host-local"},

--- a/pkg/invoke/delegate_test.go
+++ b/pkg/invoke/delegate_test.go
@@ -124,30 +124,29 @@ var _ = Describe("Delegate", func() {
 		})
 	})
 
-	Describe("DelegateGet", func() {
+	Describe("DelegateCheck", func() {
 		BeforeEach(func() {
-			os.Setenv("CNI_COMMAND", "GET")
+			os.Setenv("CNI_COMMAND", "CHECK")
 		})
 
 		It("finds and execs the named plugin", func() {
-			result, err := invoke.DelegateGet(ctx, pluginName, netConf, nil)
+			err := invoke.DelegateCheck(ctx, pluginName, netConf, nil)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(expectedResult))
 
 			pluginInvocation, err := debug.ReadDebug(debugFileName)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(pluginInvocation.Command).To(Equal("GET"))
+			Expect(pluginInvocation.Command).To(Equal("CHECK"))
 			Expect(pluginInvocation.CmdArgs.IfName).To(Equal("eth7"))
 		})
 
-		Context("if the delegation isn't part of an existing GET command", func() {
+		Context("if the delegation isn't part of an existing CHECK command", func() {
 			BeforeEach(func() {
 				os.Setenv("CNI_COMMAND", "NOPE")
 			})
 
 			It("aborts and returns a useful error", func() {
-				_, err := invoke.DelegateGet(ctx, pluginName, netConf, nil)
-				Expect(err).To(MatchError("CNI_COMMAND is not GET"))
+				err := invoke.DelegateCheck(ctx, pluginName, netConf, nil)
+				Expect(err).To(MatchError("CNI_COMMAND is not CHECK"))
 			})
 		})
 
@@ -157,7 +156,7 @@ var _ = Describe("Delegate", func() {
 			})
 
 			It("returns a useful error", func() {
-				_, err := invoke.DelegateGet(ctx, pluginName, netConf, nil)
+				err := invoke.DelegateCheck(ctx, pluginName, netConf, nil)
 				Expect(err).To(MatchError(HavePrefix("failed to find plugin")))
 			})
 		})

--- a/pkg/invoke/get_version_integration_test.go
+++ b/pkg/invoke/get_version_integration_test.go
@@ -73,7 +73,7 @@ var _ = Describe("GetVersion, integration tests", func() {
 			version.PluginSupports("0.2.0", "0.999.0"),
 		),
 
-		Entry("historical: before GET was introduced",
+		Entry("historical: before CHECK was introduced",
 			git_ref_v031, plugin_source_v020_custom_versions,
 			version.PluginSupports("0.2.0", "0.999.0"),
 		),
@@ -81,14 +81,14 @@ var _ = Describe("GetVersion, integration tests", func() {
 		// this entry tracks the current behavior.  Before you change it, ensure
 		// that its previous behavior is captured in the most recent "historical" entry
 		Entry("current",
-			"HEAD", plugin_source_v040_get,
+			"HEAD", plugin_source_v040_check,
 			version.PluginSupports("0.2.0", "0.4.0", "0.999.0"),
 		),
 	)
 })
 
-// A 0.4.0 plugin that supports GET
-const plugin_source_v040_get = `package main
+// A 0.4.0 plugin that supports CHECK
+const plugin_source_v040_check = `package main
 
 import (
 	"github.com/containernetworking/cni/pkg/skel"

--- a/pkg/skel/skel.go
+++ b/pkg/skel/skel.go
@@ -74,54 +74,54 @@ func (t *dispatcher) getCmdArgsFromEnv() (string, *CmdArgs, error) {
 			"CNI_COMMAND",
 			&cmd,
 			reqForCmdEntry{
-				"ADD": true,
-				"GET": true,
-				"DEL": true,
+				"ADD":   true,
+				"CHECK": true,
+				"DEL":   true,
 			},
 		},
 		{
 			"CNI_CONTAINERID",
 			&contID,
 			reqForCmdEntry{
-				"ADD": true,
-				"GET": true,
-				"DEL": true,
+				"ADD":   true,
+				"CHECK": true,
+				"DEL":   true,
 			},
 		},
 		{
 			"CNI_NETNS",
 			&netns,
 			reqForCmdEntry{
-				"ADD": true,
-				"GET": true,
-				"DEL": false,
+				"ADD":   true,
+				"CHECK": true,
+				"DEL":   false,
 			},
 		},
 		{
 			"CNI_IFNAME",
 			&ifName,
 			reqForCmdEntry{
-				"ADD": true,
-				"GET": true,
-				"DEL": true,
+				"ADD":   true,
+				"CHECK": true,
+				"DEL":   true,
 			},
 		},
 		{
 			"CNI_ARGS",
 			&args,
 			reqForCmdEntry{
-				"ADD": false,
-				"GET": false,
-				"DEL": false,
+				"ADD":   false,
+				"CHECK": false,
+				"DEL":   false,
 			},
 		},
 		{
 			"CNI_PATH",
 			&path,
 			reqForCmdEntry{
-				"ADD": true,
-				"GET": true,
-				"DEL": true,
+				"ADD":   true,
+				"CHECK": true,
+				"DEL":   true,
 			},
 		},
 	}
@@ -198,7 +198,7 @@ func validateConfig(jsonBytes []byte) error {
 	return nil
 }
 
-func (t *dispatcher) pluginMain(cmdAdd, cmdGet, cmdDel func(_ *CmdArgs) error, versionInfo version.PluginInfo, about string) *types.Error {
+func (t *dispatcher) pluginMain(cmdAdd, cmdCheck, cmdDel func(_ *CmdArgs) error, versionInfo version.PluginInfo, about string) *types.Error {
 	cmd, cmdArgs, err := t.getCmdArgsFromEnv()
 	if err != nil {
 		// Print the about string to stderr when no command is set
@@ -219,7 +219,7 @@ func (t *dispatcher) pluginMain(cmdAdd, cmdGet, cmdDel func(_ *CmdArgs) error, v
 	switch cmd {
 	case "ADD":
 		err = t.checkVersionAndCall(cmdArgs, versionInfo, cmdAdd)
-	case "GET":
+	case "CHECK":
 		configVersion, err := t.ConfVersionDecoder.Decode(cmdArgs.StdinData)
 		if err != nil {
 			return createTypedError(err.Error())
@@ -229,7 +229,7 @@ func (t *dispatcher) pluginMain(cmdAdd, cmdGet, cmdDel func(_ *CmdArgs) error, v
 		} else if !gtet {
 			return &types.Error{
 				Code: types.ErrIncompatibleCNIVersion,
-				Msg:  "config version does not allow GET",
+				Msg:  "config version does not allow CHECK",
 			}
 		}
 		for _, pluginVersion := range versionInfo.SupportedVersions() {
@@ -237,7 +237,7 @@ func (t *dispatcher) pluginMain(cmdAdd, cmdGet, cmdDel func(_ *CmdArgs) error, v
 			if err != nil {
 				return createTypedError(err.Error())
 			} else if gtet {
-				if err := t.checkVersionAndCall(cmdArgs, versionInfo, cmdGet); err != nil {
+				if err := t.checkVersionAndCall(cmdArgs, versionInfo, cmdCheck); err != nil {
 					return createTypedError(err.Error())
 				}
 				return nil
@@ -245,7 +245,7 @@ func (t *dispatcher) pluginMain(cmdAdd, cmdGet, cmdDel func(_ *CmdArgs) error, v
 		}
 		return &types.Error{
 			Code: types.ErrIncompatibleCNIVersion,
-			Msg:  "plugin version does not allow GET",
+			Msg:  "plugin version does not allow CHECK",
 		}
 	case "DEL":
 		err = t.checkVersionAndCall(cmdArgs, versionInfo, cmdDel)
@@ -266,7 +266,7 @@ func (t *dispatcher) pluginMain(cmdAdd, cmdGet, cmdDel func(_ *CmdArgs) error, v
 }
 
 // PluginMainWithError is the core "main" for a plugin. It accepts
-// callback functions for add, get, and del CNI commands and returns an error.
+// callback functions for add, check, and del CNI commands and returns an error.
 //
 // The caller must also specify what CNI spec versions the plugin supports.
 //
@@ -277,13 +277,13 @@ func (t *dispatcher) pluginMain(cmdAdd, cmdGet, cmdDel func(_ *CmdArgs) error, v
 //
 // To let this package automatically handle errors and call os.Exit(1) for you,
 // use PluginMain() instead.
-func PluginMainWithError(cmdAdd, cmdGet, cmdDel func(_ *CmdArgs) error, versionInfo version.PluginInfo, about string) *types.Error {
+func PluginMainWithError(cmdAdd, cmdCheck, cmdDel func(_ *CmdArgs) error, versionInfo version.PluginInfo, about string) *types.Error {
 	return (&dispatcher{
 		Getenv: os.Getenv,
 		Stdin:  os.Stdin,
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,
-	}).pluginMain(cmdAdd, cmdGet, cmdDel, versionInfo, about)
+	}).pluginMain(cmdAdd, cmdCheck, cmdDel, versionInfo, about)
 }
 
 // PluginMain is the core "main" for a plugin which includes automatic error handling.
@@ -293,12 +293,12 @@ func PluginMainWithError(cmdAdd, cmdGet, cmdDel func(_ *CmdArgs) error, versionI
 // The caller can specify an "about" string, which is printed on stderr
 // when no CNI_COMMAND is specified. The reccomended output is "CNI plugin <foo> v<version>"
 //
-// When an error occurs in either cmdAdd, cmdGet, or cmdDel, PluginMain will print the error
+// When an error occurs in either cmdAdd, cmdCheck, or cmdDel, PluginMain will print the error
 // as JSON to stdout and call os.Exit(1).
 //
 // To have more control over error handling, use PluginMainWithError() instead.
-func PluginMain(cmdAdd, cmdGet, cmdDel func(_ *CmdArgs) error, versionInfo version.PluginInfo, about string) {
-	if e := PluginMainWithError(cmdAdd, cmdGet, cmdDel, versionInfo, about); e != nil {
+func PluginMain(cmdAdd, cmdCheck, cmdDel func(_ *CmdArgs) error, versionInfo version.PluginInfo, about string) {
+	if e := PluginMainWithError(cmdAdd, cmdCheck, cmdDel, versionInfo, about); e != nil {
 		if err := e.Print(); err != nil {
 			log.Print("Error writing error JSON to stdout: ", err)
 		}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -78,8 +78,9 @@ type IPAM struct {
 type NetConfList struct {
 	CNIVersion string `json:"cniVersion,omitempty"`
 
-	Name    string     `json:"name,omitempty"`
-	Plugins []*NetConf `json:"plugins,omitempty"`
+	Name         string     `json:"name,omitempty"`
+	DisableCheck bool       `json:"disableCheck,omitempty"`
+	Plugins      []*NetConf `json:"plugins,omitempty"`
 }
 
 type ResultFactoryFunc func([]byte) (Result, error)

--- a/plugins/test/noop/main.go
+++ b/plugins/test/noop/main.go
@@ -173,8 +173,8 @@ func cmdAdd(args *skel.CmdArgs) error {
 	return debugBehavior(args, "ADD")
 }
 
-func cmdGet(args *skel.CmdArgs) error {
-	return debugBehavior(args, "GET")
+func cmdCheck(args *skel.CmdArgs) error {
+	return debugBehavior(args, "CHECK")
 }
 
 func cmdDel(args *skel.CmdArgs) error {
@@ -212,5 +212,5 @@ func main() {
 	}
 
 	supportedVersions := debugGetSupportedVersions(stdinData)
-	skel.PluginMain(cmdAdd, cmdGet, cmdDel, version.PluginSupports(supportedVersions...), "CNI nnop plugin v0.7.0")
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, version.PluginSupports(supportedVersions...), "CNI noop plugin v0.7.0")
 }


### PR DESCRIPTION
Major change is that CHECK no longer returns a Result, per the spec.

@squeed @containernetworking/cni-maintainers @mcctcpip @jellonek 