### PR TITLE
Add a well-known error for "try again"

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -752,3 +752,4 @@ Error codes 1-99 must not be used other than as specified here.
 - `1` - Incompatible CNI version
 - `2` - Unsupported field in network configuration. The error message must contain the key and value of the unsupported field.
 - `3` - Container unknown or does not exist. This error implies the runtime does not need to perform any container network cleanup (for example, calling the `DEL` action on the container).
+- `11` - Try again later. If the plugin detects some transient condition that should clear up, it can use this code to notify the runtime it should re-try the operation later.


### PR DESCRIPTION
This came up in the maintainers' meeting - in the (rare, unspecified) cases that a plugin wants the runtime to re-try the operation it can have a special code to say that.
