### PR TITLE
Validate correct number of args in cnitool

### DIFF
--- a/cnitool/cnitool.go
+++ b/cnitool/cnitool.go
@@ -57,7 +57,7 @@ func parseArgs(args string) ([][2]string, error) {
 }
 
 func main() {
-	if len(os.Args) < 3 {
+	if len(os.Args) < 4 {
 		usage()
 		return
 	}


### PR DESCRIPTION
Currently, cnitool command needs 4 args (including command itself) - e.g cnitool add `<net>`
`<netns>`. This patch changes to the number of valide args to 4 from 3.

For example, currently if cnitool runs with less args, it will get gopanic instead of validation error and usage help:
~~~
$ sudo CNI_PATH=./bin/  ~/.go/bin/cnitool add dbnet
panic: runtime error: index out of range

goroutine 1 [running]:
main.main()
	/home/knakayam/.go/src/github.com/containernetworking/cni/cnitool/cnitool.go:96 +0x799
~~~