### PR TITLE
Fix some typos

### DIFF
--- a/libcni/api.go
+++ b/libcni/api.go
@@ -126,7 +126,7 @@ func buildOneConfig(name, cniVersion string, orig *NetworkConfig, prevResult typ
 // These capabilities arguments are filtered through the plugin's advertised
 // capabilities from its config JSON, and any keys in the CapabilityArgs
 // matching plugin capabilities are added to the "runtimeConfig" dictionary
-// sent to the plugin via JSON on stdin.  For exmaple, if the plugin's
+// sent to the plugin via JSON on stdin.  For example, if the plugin's
 // capabilities include "portMappings", and the CapabilityArgs map includes a
 // "portMappings" key, that key and its value are added to the "runtimeConfig"
 // dictionary to be passed to the plugin's stdin.

--- a/libcni/api_test.go
+++ b/libcni/api_test.go
@@ -397,7 +397,7 @@ var _ = Describe("Invoking plugins", func() {
 
 			Context("when the result cache directory cannot be accessed", func() {
 				It("returns an error", func() {
-					// Make the results directory inaccessble by making it a
+					// Make the results directory inaccessible by making it a
 					// file instead of a directory
 					tmpPath := filepath.Join(cacheDirPath, "results")
 					err := ioutil.WriteFile(tmpPath, []byte("afdsasdfasdf"), 0600)


### PR DESCRIPTION
Fix some typos:
1. "exmaple" -> "example".
2.  "inaccessble" -> "inaccessible".