### PR TITLE
readme: Update CNI plugins install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Next, build the plugins:
 
 ```bash
 $ cd $GOPATH/src/github.com/containernetworking/plugins
-$ ./build.sh
+$ ./build_linux.sh # or build_windows.sh
 ```
 
 Finally, execute a command (`ifconfig` in this example) in a private network namespace that has joined the `mynet` network:


### PR DESCRIPTION
Commit containernetworking/plugins@4e1f780 (Split build.sh into two OS-specific scripts) removes the `build.sh` file. Now we have `build_linux.sh` and `build_windows.sh`.

Signed-off-by: Radostin Stoyanov <rstoyanov1@gmail.com>