### PR TITLE
Fix some typos in comment

### DIFF
--- a/pkg/types/current/types_test.go
+++ b/pkg/types/current/types_test.go
@@ -237,7 +237,7 @@ var _ = Describe("Current types operations", func() {
 		Expect(recovered).To(Equal(ipc))
 	})
 
-	Context("when unmarshaling json fails", func() {
+	Context("when unmarshalling json fails", func() {
 		It("returns an error", func() {
 			recovered := &current.IPConfig{}
 			err := json.Unmarshal([]byte(`{"address": 5}`), &recovered)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -87,7 +87,7 @@ type ResultFactoryFunc func([]byte) (Result, error)
 
 // Result is an interface that provides the result of plugin execution
 type Result interface {
-	// The highest CNI specification result verison the result supports
+	// The highest CNI specification result version the result supports
 	// without having to convert
 	Version() string
 


### PR DESCRIPTION
1. "unmarshaling" to "unmarshalling" in line 240.
2. "verison" to "version" in line 90.