### PR TITLE
Fix cnitool readme

### DIFF
--- a/cnitool/README.md
+++ b/cnitool/README.md
@@ -14,7 +14,9 @@ Then, check out and build the plugins. All commands should be run from this dire
 ```
 git clone https://github.com/containernetworking/plugins.git
 cd plugins
-./build.sh
+./build_linux.sh
+# or
+./build_windows.sh
 ```
 
 Create a network configuration


### PR DESCRIPTION
build.sh script doesn't exist anymore change to build_linux.sh or
build_windows.sh