### PR TITLE
Update deprecated link in doc

### DIFF
--- a/Documentation/spec-upgrades.md
+++ b/Documentation/spec-upgrades.md
@@ -149,7 +149,7 @@ result, err := current.NewResultFromResult(ipamResult)
 ```
 
 Other examples of spec v0.3.0-compatible plugins are the
-[main plugins in this repo](https://github.com/containernetworking/cni/tree/master/plugins/main)
+[main plugins in this repo](https://github.com/containernetworking/plugins/)
 
 
 ## For Runtime Authors


### PR DESCRIPTION
Currently, the modified **plugins/main** was removed from master branch.
It's only available in **v0.3.0** tag. So this commit aims to update the
deprecated link to the working one.

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>