### PR TITLE
add PrintTo method to Result interface

### DIFF
--- a/pkg/types/020/types.go
+++ b/pkg/types/020/types.go
@@ -17,6 +17,7 @@ package types020
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"os"
 
@@ -73,11 +74,15 @@ func (r *Result) GetAsVersion(version string) (types.Result, error) {
 }
 
 func (r *Result) Print() error {
+	return r.PrintTo(os.Stdout)
+}
+
+func (r *Result) PrintTo(writer io.Writer) error {
 	data, err := json.MarshalIndent(r, "", "    ")
 	if err != nil {
 		return err
 	}
-	_, err = os.Stdout.Write(data)
+	_, err = writer.Write(data)
 	return err
 }
 

--- a/pkg/types/current/types.go
+++ b/pkg/types/current/types.go
@@ -17,6 +17,7 @@ package current
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"os"
 
@@ -202,11 +203,15 @@ func (r *Result) GetAsVersion(version string) (types.Result, error) {
 }
 
 func (r *Result) Print() error {
+	return r.PrintTo(os.Stdout)
+}
+
+func (r *Result) PrintTo(writer io.Writer) error {
 	data, err := json.MarshalIndent(r, "", "    ")
 	if err != nil {
 		return err
 	}
-	_, err = os.Stdout.Write(data)
+	_, err = writer.Write(data)
 	return err
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 )
@@ -97,6 +98,9 @@ type Result interface {
 
 	// Prints the result in JSON format to stdout
 	Print() error
+
+	// Prints the result in JSON format to provided writer
+	PrintTo(writer io.Writer) error
 
 	// Returns a JSON string representation of the result
 	String() string


### PR DESCRIPTION
add `PrintTo` method to `Result` interface, in order to allow to marshal result to any writer, not only stdout