### PR TITLE
Plugin(manager) interfaces and functionality arround them

### DIFF
--- a/pkg/skel/adapter.go
+++ b/pkg/skel/adapter.go
@@ -1,0 +1,63 @@
+// Copyright 2014-2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skel
+
+import (
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/version"
+)
+
+// Adapter semantically is PluginManager interface, wrapped in
+// structure type in order to define useful extension methods
+
+type Adapter struct {
+	PluginManager
+}
+
+func NewAdapter(mgr PluginManager) Adapter {
+	return Adapter{PluginManager: mgr}
+}
+
+func (a Adapter) Add(pluginType string, args *Args) (types.Result, error) {
+	plugin, err := a.FindPlugin(pluginType)
+	if err != nil {
+		return nil, err
+	}
+	return plugin.Add(args)
+}
+
+func (a Adapter) Check(pluginType string, args *Args) (types.Result, error) {
+	plugin, err := a.FindPlugin(pluginType)
+	if err != nil {
+		return nil, err
+	}
+	return plugin.Check(args)
+}
+
+func (a Adapter) Del(pluginType string, args *Args) error {
+	plugin, err := a.FindPlugin(pluginType)
+	if err != nil {
+		return err
+	}
+	return plugin.Del(args)
+}
+
+func (a Adapter) Version(pluginType string) (version.PluginInfo, error) {
+	plugin, err := a.FindPlugin(pluginType)
+	if err != nil {
+		return nil, err
+	}
+	return plugin.Version()
+}

--- a/pkg/skel/adapter_test.go
+++ b/pkg/skel/adapter_test.go
@@ -1,0 +1,132 @@
+// Copyright 2014-2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skel
+
+import (
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/cni/pkg/version"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("adapter", func() {
+
+	q := make(chan string, 1)
+	plugin := NewDirectPlugin(func(plugin *DirectPlugin) {
+		plugin.AddFunc = func(args *Args) (types.Result, error) {
+			q <- "add"
+			return &current.Result{CNIVersion: version.Current()}, nil
+		}
+		plugin.DelFunc = func(args *Args) error {
+			q <- "del"
+			return nil
+		}
+		plugin.CheckFunc = func(args *Args) (types.Result, error) {
+			q <- "check"
+			return &current.Result{CNIVersion: version.Current()}, nil
+		}
+		plugin.VersionFunc = func() (version.PluginInfo, error) {
+			q <- "version"
+			return version.All, nil
+		}
+	})
+	var adapter = NewDirectAdapter(func(manager *DirectPluginManager) {
+		manager.Plugins["test"] = plugin
+	})
+	args := &Args{
+		ContainerID: "container-id",
+		Netns:       "net-ns",
+		IfName:      "if-name",
+		Args:        "args",
+	}
+	BeforeEach(func() {
+		select {
+		case <-q:
+			Fail("unexpected event")
+		default:
+		}
+	})
+	AfterEach(func() {
+		select {
+		case <-q:
+			Fail("unexpected event")
+		default:
+		}
+	})
+
+	Describe("extension method Add", func() {
+		It("dispatched right", func() {
+			res, err := adapter.Add("test", args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal(&current.Result{CNIVersion: version.Current()}))
+			Expect(<-q).To(Equal("add"))
+		})
+	})
+	Describe("extension method Check", func() {
+		It("dispatched right", func() {
+			res, err := adapter.Check("test", args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal(&current.Result{CNIVersion: version.Current()}))
+			Expect(<-q).To(Equal("check"))
+		})
+	})
+	Describe("extension method Del", func() {
+		It("dispatched right", func() {
+			err := adapter.Del("test", args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(<-q).To(Equal("del"))
+		})
+	})
+	Describe("extension method Version", func() {
+		It("dispatched right", func() {
+			res, err := adapter.Version("test")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal(version.All))
+			Expect(<-q).To(Equal("version"))
+
+		})
+	})
+
+	Context("when plugin doesn't exists", func() {
+		Describe("extension method Add", func() {
+			It("fails", func() {
+				res, err := adapter.Add("foo", args)
+				Expect(err).To(HaveOccurred())
+				Expect(res).To(BeNil())
+			})
+		})
+		Describe("extension method Check", func() {
+			It("fails", func() {
+				res, err := adapter.Check("foo", args)
+				Expect(err).To(HaveOccurred())
+				Expect(res).To(BeNil())
+			})
+		})
+		Describe("extension method Del", func() {
+			It("fails", func() {
+				err := adapter.Del("foo", args)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		Describe("extension method Version", func() {
+			It("fails", func() {
+				res, err := adapter.Version("foo")
+				Expect(err).To(HaveOccurred())
+				Expect(res).To(BeNil())
+			})
+		})
+	})
+})

--- a/pkg/skel/cli_adapter.go
+++ b/pkg/skel/cli_adapter.go
@@ -1,0 +1,219 @@
+// Copyright 2014-2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skel
+
+import (
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containernetworking/cni/pkg/version"
+
+	"github.com/containernetworking/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/types"
+)
+
+// CNI commands
+const (
+	CmdAdd     = "ADD"
+	CmdDel     = "DEL"
+	CmdCheck   = "CHECK"
+	CmdVersion = "VERSION"
+)
+
+// CliPlugin exposes Plugin interface
+// and intended to forward invocations to specified
+// cni executable plugin. ExecPath member points
+// to this executable.
+type CliPlugin struct {
+	ExecPath string
+	Exec     invoke.Exec
+	Path     string
+}
+
+// CliPlugin implements Plugin interface
+var _ Plugin = &CliPlugin{}
+
+// CliResolver exposes Resolver interface
+// and intended to lookup for available cni executable
+// plugins. Paths member specify directories where to
+// look for plugin executables.
+type CliPluginManager struct {
+	// paths used to look for plugin executables
+	Paths []string
+	// plugin executor
+	Exec invoke.Exec
+}
+
+// CliPluginManager implements PluginManager interface
+var _ PluginManager = &CliPluginManager{}
+
+func CliPluginMain(plugin Plugin, about string) {
+	if e := CliPluginMainWithError(plugin, about); e != nil {
+		if err := e.Print(); err != nil {
+			log.Print("Error writing error JSON to stdout: ", err)
+		}
+		os.Exit(1)
+	}
+}
+
+func CliPluginMainWithError(plugin Plugin, about string) *types.Error {
+	versionInfo, err := plugin.Version()
+	if err != nil {
+		return createTypedError(err.Error())
+	}
+	return PluginMainWithError(
+		printResult(plugin.Add),
+		printResult(plugin.Check),
+		noResult(plugin.Del),
+		versionInfo,
+		about,
+	)
+}
+func NewCliAdapter(opts ...func(*CliPluginManager)) Adapter {
+	return NewAdapter(NewCliPluginManager(opts...))
+}
+
+func NewCliPluginManager(opts ...func(*CliPluginManager)) *CliPluginManager {
+	mgr := &CliPluginManager{}
+	for _, opt := range opts {
+		opt(mgr)
+	}
+	if mgr.Paths == nil {
+		mgr.Paths = filepath.SplitList(os.Getenv("CNI_PATH"))
+	}
+	if mgr.Exec == nil {
+		mgr.Exec = &invoke.DefaultExec{
+			RawExec: &invoke.RawExec{Stderr: os.Stderr},
+		}
+	}
+	return mgr
+}
+
+//
+// PluginManager interface implementation for CliPluginManager
+//
+
+func (mgr *CliPluginManager) FindPlugin(pluginType string) (Plugin, error) {
+	execPath, err := mgr.Exec.FindInPath(pluginType, mgr.Paths)
+	if err != nil {
+		return nil, err
+	}
+	return &CliPlugin{
+		ExecPath: execPath,
+		Exec:     mgr.Exec,
+		Path:     strings.Join(mgr.Paths, string(filepath.ListSeparator)),
+	}, nil
+}
+
+//
+// Plugin interface implementation for CliPlugin
+//
+
+func (p *CliPlugin) Add(args *Args) (types.Result, error) {
+	return p.execWithResult(CmdAdd, toCmdArgs(args))
+}
+
+func (p *CliPlugin) Del(args *Args) error {
+	return p.execWithoutResult(CmdDel, toCmdArgs(args))
+}
+
+func (p *CliPlugin) Check(args *Args) (types.Result, error) {
+	return p.execWithResult(CmdCheck, toCmdArgs(args))
+}
+
+func (p *CliPlugin) Version() (version.PluginInfo, error) {
+	stdoutBytes, err := p.Exec.ExecPlugin(
+		context.TODO(), p.ExecPath, nil, p.invokeArgs(CmdVersion, nil).AsEnv(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return (&version.PluginDecoder{}).Decode(stdoutBytes)
+}
+
+func (p *CliPlugin) execWithResult(command string, args *CmdArgs) (types.Result, error) {
+	return invoke.ExecPluginWithResult(
+		context.TODO(), p.ExecPath, args.StdinData, p.invokeArgs(command, args), p.Exec,
+	)
+}
+
+func (p *CliPlugin) execWithoutResult(command string, args *CmdArgs) error {
+	return invoke.ExecPluginWithoutResult(
+		context.TODO(), p.ExecPath, args.StdinData, p.invokeArgs(command, args), p.Exec,
+	)
+}
+
+func (p *CliPlugin) invokeArgs(command string, args *CmdArgs) *invoke.Args {
+	res := &invoke.Args{
+		Command: command,
+		Path:    p.Path,
+	}
+	if args != nil {
+		res.ContainerID = args.ContainerID
+		res.NetNS = args.Netns
+		res.PluginArgsStr = args.Args
+		res.IfName = args.IfName
+	}
+	return res
+}
+
+//
+// auxiliary functions
+//
+
+func toCmdArgs(args *Args) *CmdArgs {
+	if args == nil {
+		return nil
+	}
+	return &CmdArgs{
+		ContainerID: args.ContainerID,
+		Netns:       args.Netns,
+		IfName:      args.IfName,
+		Args:        args.Args,
+		StdinData:   args.StdinData,
+	}
+}
+
+func fromCmdArgs(args *CmdArgs) *Args {
+	if args == nil {
+		return nil
+	}
+	return &Args{
+		ContainerID: args.ContainerID,
+		Netns:       args.Netns,
+		IfName:      args.IfName,
+		Args:        args.Args,
+		StdinData:   args.StdinData,
+	}
+}
+
+func printResult(f func(args *Args) (types.Result, error)) func(args *CmdArgs) error {
+	return func(cmdArgs *CmdArgs) error {
+		res, err := f(fromCmdArgs(cmdArgs))
+		if err != nil {
+			return err
+		}
+		return res.Print()
+	}
+}
+
+func noResult(f func(args *Args) error) func(args *CmdArgs) error {
+	return func(cmdArgs *CmdArgs) error {
+		return f(fromCmdArgs(cmdArgs))
+	}
+}

--- a/pkg/skel/cli_adapter_test.go
+++ b/pkg/skel/cli_adapter_test.go
@@ -1,0 +1,400 @@
+// Copyright 2014-2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skel
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/current"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/containernetworking/cni/pkg/version"
+)
+
+var _ = Describe("printResult", func() {
+	Context("when args is nil", func() {
+		It("writes result to stdout on success", func() {
+			out, err := captureStdout(func() error {
+				return printResult(func(args *Args) (types.Result, error) {
+					return &current.Result{CNIVersion: version.Current()}, nil
+				})(nil)
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			res, err := current.NewResult(out)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal(&current.Result{CNIVersion: version.Current()}))
+
+		})
+	})
+
+	It("doesn't write anything to stdout on failure", func() {
+		out, err := captureStdout(func() error {
+			return printResult(func(args *Args) (types.Result, error) {
+				return nil, errors.New("simulated error")
+			})(nil)
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(len(out)).To(Equal(0))
+	})
+
+	It("writes result to stdout on success", func() {
+		out, err := captureStdout(func() error {
+			return printResult(func(args *Args) (types.Result, error) {
+				return &current.Result{CNIVersion: version.Current()}, nil
+			})(&CmdArgs{
+				ContainerID: "container-id",
+				Netns:       "net-ns",
+				IfName:      "if-name",
+				Args:        "args",
+				Path:        "path",
+			})
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		res, err := current.NewResult(out)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(&current.Result{CNIVersion: version.Current()}))
+
+	})
+})
+
+var _ = Describe("noResult", func() {
+	Context("when args is nil", func() {
+		It("passes nil too", func() {
+			err := noResult(func(args *Args) error {
+				Expect(args).To(BeNil())
+				return nil
+			})(nil)
+			Expect(err).To(BeNil())
+		})
+	})
+
+	It("returns same error", func() {
+		err := noResult(func(args *Args) error {
+			return errors.New("test")
+		})(nil)
+		Expect(err).To(Equal(errors.New("test")))
+	})
+
+	It("it passes correct args values", func() {
+		err := noResult(func(args *Args) error {
+			Expect(args.ContainerID).To(Equal("ContainerID"))
+			Expect(args.Netns).To(Equal("Netns"))
+			Expect(args.IfName).To(Equal("IfName"))
+			Expect(args.Args).To(Equal("Args"))
+			return nil
+		})(&CmdArgs{
+			ContainerID: "ContainerID",
+			Netns:       "Netns",
+			IfName:      "IfName",
+			Args:        "Args",
+			Path:        "Path",
+		})
+		Expect(err).To(BeNil())
+	})
+})
+
+var _ = Describe("toCmdArgs", func() {
+	Context("when args is nil", func() {
+		It("returns nil", func() {
+			res := toCmdArgs(nil)
+			Expect(res).To(BeNil())
+		})
+	})
+
+	It("returns cmd args with same values", func() {
+		res := toCmdArgs(&Args{
+			ContainerID: "ContainerID",
+			Netns:       "Netns",
+			IfName:      "IfName",
+			Args:        "Args",
+		})
+		Expect(res.ContainerID).To(Equal("ContainerID"))
+		Expect(res.Netns).To(Equal("Netns"))
+		Expect(res.IfName).To(Equal("IfName"))
+		Expect(res.Args).To(Equal("Args"))
+		Expect(res.Path).To(Equal(""))
+	})
+})
+
+var _ = Describe("fromCmdArgs", func() {
+	Context("when args is nil", func() {
+		It("returns nil", func() {
+			res := fromCmdArgs(nil)
+			Expect(res).To(BeNil())
+		})
+	})
+
+	It("returns cmd args with same values", func() {
+		res := fromCmdArgs(&CmdArgs{
+			ContainerID: "ContainerID",
+			Netns:       "Netns",
+			IfName:      "IfName",
+			Args:        "Args",
+			Path:        "Path",
+		})
+		Expect(res.ContainerID).To(Equal("ContainerID"))
+		Expect(res.Netns).To(Equal("Netns"))
+		Expect(res.IfName).To(Equal("IfName"))
+		Expect(res.Args).To(Equal("Args"))
+	})
+})
+
+var _ = Describe("cli adapter", func() {
+
+	q := make(chan string, 1)
+	BeforeEach(func() {
+		select {
+		case <-q:
+			Fail("unexpected event")
+		default:
+		}
+	})
+	AfterEach(func() {
+		select {
+		case <-q:
+			Fail("unexpected event")
+		default:
+		}
+	})
+
+	args := &Args{
+		ContainerID: "container-id",
+		Netns:       "net-ns",
+		IfName:      "if-name",
+		Args:        "args",
+		StdinData: []byte(fmt.Sprintf(
+			`{ "name":"test", "cniVersion": "%s" }`, version.Current(),
+		)),
+	}
+
+	Context("when plugin's calls succeeds", func() {
+
+		var adapter = NewCliAdapter(func(m *CliPluginManager) {
+			plugin := NewDirectPlugin(func(plugin *DirectPlugin) {
+				plugin.AddFunc = func(args *Args) (types.Result, error) {
+					q <- CmdAdd
+					return &current.Result{CNIVersion: version.Current()}, nil
+				}
+				plugin.DelFunc = func(args *Args) error {
+					q <- CmdDel
+					return nil
+				}
+				plugin.CheckFunc = func(args *Args) (types.Result, error) {
+					q <- CmdCheck
+					return &current.Result{CNIVersion: version.Current()}, nil
+				}
+				plugin.VersionFunc = func() (version.PluginInfo, error) {
+					q <- CmdVersion
+					return version.All, nil
+				}
+			})
+			var manager = NewDirectPluginManager(func(manager *DirectPluginManager) {
+				manager.Plugins["/cni/plugins/test"] = plugin
+			})
+			m.Paths = []string{"/cni/plugins", "/ext/cni-plugins"}
+			m.Exec = NewPluginExec(manager)
+		})
+
+		Describe("extension method Add", func() {
+			It("dispatched right", func() {
+				res, err := adapter.Add("test", args)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(res).To(Equal(&current.Result{CNIVersion: version.Current()}))
+				Expect(<-q).To(Equal(CmdAdd))
+			})
+		})
+		Describe("extension method Check", func() {
+			It("dispatched right", func() {
+				res, err := adapter.Check("test", args)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(res).To(Equal(&current.Result{CNIVersion: version.Current()}))
+				Expect(<-q).To(Equal(CmdCheck))
+			})
+		})
+		Describe("extension method Del", func() {
+			It("dispatched right", func() {
+				err := adapter.Del("test", args)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(<-q).To(Equal(CmdDel))
+			})
+		})
+		Describe("extension method Version", func() {
+			It("dispatched right", func() {
+				res, err := adapter.Version("test")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(res).To(Equal(version.All))
+				Expect(<-q).To(Equal(CmdVersion))
+
+			})
+		})
+	})
+
+	Context("when plugin's calls fails", func() {
+		simulatedError := errors.New("simulated error")
+		var adapter = NewCliAdapter(func(m *CliPluginManager) {
+			plugin := NewDirectPlugin(func(plugin *DirectPlugin) {
+				plugin.AddFunc = func(args *Args) (types.Result, error) {
+					q <- CmdAdd
+					return nil, simulatedError
+				}
+				plugin.DelFunc = func(args *Args) error {
+					q <- CmdDel
+					return simulatedError
+				}
+				plugin.CheckFunc = func(args *Args) (types.Result, error) {
+					q <- CmdCheck
+					return nil, simulatedError
+				}
+				plugin.VersionFunc = func() (version.PluginInfo, error) {
+					q <- CmdVersion
+					return nil, simulatedError
+				}
+			})
+			var manager = NewDirectPluginManager(func(manager *DirectPluginManager) {
+				manager.Plugins["test"] = plugin
+			})
+			m.Paths = []string{"/cni/plugins", "/ext/cni-plugins"}
+			m.Exec = NewPluginExec(manager)
+		})
+
+		Describe("extension method Add", func() {
+			It("propagates error", func() {
+				res, err := adapter.Add("test", args)
+				Expect(err).To(MatchError(simulatedError))
+				Expect(res).To(BeNil())
+				Expect(<-q).To(Equal(CmdAdd))
+			})
+		})
+		Describe("extension method Check", func() {
+			It("propagates error", func() {
+				res, err := adapter.Check("test", args)
+				Expect(err).To(MatchError(simulatedError))
+				Expect(res).To(BeNil())
+				Expect(<-q).To(Equal(CmdCheck))
+			})
+		})
+		Describe("extension method Del", func() {
+			It("propagates error", func() {
+				err := adapter.Del("test", args)
+				Expect(err).To(MatchError(simulatedError))
+				Expect(<-q).To(Equal(CmdDel))
+			})
+		})
+		Describe("extension method Version", func() {
+			It("propagates error", func() {
+				res, err := adapter.Version("test")
+				Expect(err).To(MatchError(simulatedError))
+				Expect(res).To(BeNil())
+				Expect(<-q).To(Equal(CmdVersion))
+
+			})
+		})
+	})
+
+	Context("when plugin doesn't exists", func() {
+
+		var adapter = NewCliAdapter(func(m *CliPluginManager) {
+			m.Paths = []string{}
+			m.Exec = NewPluginExec(
+				NewDirectPluginManager(),
+			)
+		})
+
+		Describe("extension method Add", func() {
+			It("fails", func() {
+				res, err := adapter.Add("foo", args)
+				Expect(err).To(HaveOccurred())
+				Expect(res).To(BeNil())
+			})
+		})
+		Describe("extension method Check", func() {
+			It("fails", func() {
+				res, err := adapter.Check("foo", args)
+				Expect(err).To(HaveOccurred())
+				Expect(res).To(BeNil())
+			})
+		})
+		Describe("extension method Del", func() {
+			It("fails", func() {
+				err := adapter.Del("foo", args)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		Describe("extension method Version", func() {
+			It("fails", func() {
+				res, err := adapter.Version("foo")
+				Expect(err).To(HaveOccurred())
+				Expect(res).To(BeNil())
+			})
+		})
+	})
+})
+
+var _ = Describe("NewCliPluginManager", func() {
+	Context("when Paths is nil", func() {
+		paths := []string{
+			"x/y/z", "a/b/c",
+		}
+		old := os.Getenv("CNI_PATH")
+		os.Setenv("CNI_PATH", strings.Join(paths, string(os.PathListSeparator)))
+		manager := NewCliPluginManager()
+		It("set it from CNI_PATH", func() {
+			Expect(manager.Paths).To(Equal(paths))
+		})
+		os.Setenv("CNI_PATH", old)
+
+	})
+
+	Context("when Exec is nil", func() {
+		manager := NewCliPluginManager(func(m *CliPluginManager) {
+			m.Paths = []string{}
+		})
+		It("set it to default", func() {
+			Expect(manager.Paths).To(Equal([]string{}))
+			Expect(manager.Exec).NotTo(BeNil())
+		})
+	})
+
+})
+
+func captureStdout(action func() error) ([]byte, error) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	defer w.Close()
+	oldStdout := os.Stdout
+	os.Stdout = w
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+	if err = action(); err != nil {
+		return nil, err
+	}
+	os.Stdout = oldStdout
+	if err = w.Close(); err != nil {
+		return nil, err
+	}
+	return ioutil.ReadAll(r)
+}

--- a/pkg/skel/direct_adapter.go
+++ b/pkg/skel/direct_adapter.go
@@ -1,0 +1,106 @@
+// Copyright 2014-2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skel
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/version"
+)
+
+type DirectPluginManager struct {
+	Plugins map[string]Plugin
+}
+
+// DirectPluginManager implements PluginManager interface
+var _ PluginManager = &DirectPluginManager{}
+
+type DirectPlugin struct {
+	AddFunc     func(args *Args) (types.Result, error)
+	CheckFunc   func(args *Args) (types.Result, error)
+	DelFunc     func(args *Args) error
+	VersionFunc func() (version.PluginInfo, error)
+}
+
+// DirectPlugin implements PluginManager interface
+var _ Plugin = &DirectPlugin{}
+
+func NewDirectAdapter(opts ...func(*DirectPluginManager)) Adapter {
+	return NewAdapter(NewDirectPluginManager(opts...))
+}
+
+func NewDirectPluginManager(opts ...func(*DirectPluginManager)) *DirectPluginManager {
+	mgr := &DirectPluginManager{
+		Plugins: make(map[string]Plugin),
+	}
+	for _, opt := range opts {
+		opt(mgr)
+	}
+	return mgr
+}
+
+func NewDirectPlugin(opts ...func(*DirectPlugin)) *DirectPlugin {
+	plugin := &DirectPlugin{}
+	for _, opt := range opts {
+		opt(plugin)
+	}
+	return plugin
+}
+
+//
+// DirectPluginManager implementation
+//
+
+func (p *DirectPluginManager) FindPlugin(pluginType string) (Plugin, error) {
+	plugin, ok := p.Plugins[pluginType]
+	if !ok {
+		return nil, errors.New(fmt.Sprintf("plugin %q not found", pluginType))
+	}
+	return plugin, nil
+}
+
+//
+// DirectPlugin implementation
+//
+
+func (p *DirectPlugin) Add(args *Args) (types.Result, error) {
+	if p.AddFunc == nil {
+		return nil, errors.New("not implemented")
+	}
+	return p.AddFunc(args)
+}
+
+func (p *DirectPlugin) Del(args *Args) error {
+	if p.DelFunc == nil {
+		return errors.New("not implemented")
+	}
+	return p.DelFunc(args)
+}
+
+func (p *DirectPlugin) Check(args *Args) (types.Result, error) {
+	if p.CheckFunc == nil {
+		return nil, errors.New("not implemented")
+	}
+	return p.CheckFunc(args)
+}
+
+func (p *DirectPlugin) Version() (version.PluginInfo, error) {
+	if p.VersionFunc == nil {
+		return nil, errors.New("not implemented")
+	}
+	return p.VersionFunc()
+}

--- a/pkg/skel/direct_adapter_test.go
+++ b/pkg/skel/direct_adapter_test.go
@@ -1,0 +1,55 @@
+// Copyright 2014-2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skel
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("direct plugin", func() {
+
+	Context("when no func provided", func() {
+		plugin := NewDirectPlugin()
+		Describe("method Add", func() {
+			It("returns error", func() {
+				res, err := plugin.Add(nil)
+				Expect(err).To(HaveOccurred())
+				Expect(res).To(BeNil())
+			})
+		})
+		Describe("method Check", func() {
+			It("returns error", func() {
+				res, err := plugin.Check(nil)
+				Expect(err).To(HaveOccurred())
+				Expect(res).To(BeNil())
+			})
+		})
+		Describe("method Delete", func() {
+			It("returns error", func() {
+				err := plugin.Del(nil)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		Describe("method Version", func() {
+			It("returns error", func() {
+				res, err := plugin.Version()
+				Expect(err).To(HaveOccurred())
+				Expect(res).To(BeNil())
+			})
+		})
+	})
+
+})

--- a/pkg/skel/interfaces.go
+++ b/pkg/skel/interfaces.go
@@ -1,0 +1,43 @@
+// Copyright 2014-2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skel
+
+import (
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/version"
+)
+
+// Args captures all the arguments passed in to the plugin
+// via both env vars and stdin, except CNI_PATH, which should
+// be handled differently in the beginning and should be used
+// only by specific adapters like CliPlugin
+type Args struct {
+	ContainerID string
+	Netns       string
+	IfName      string
+	Args        string
+	StdinData   []byte
+}
+
+type Plugin interface {
+	Add(args *Args) (types.Result, error)
+	Check(args *Args) (types.Result, error)
+	Del(args *Args) error
+	Version() (version.PluginInfo, error)
+}
+
+type PluginManager interface {
+	FindPlugin(pluginType string) (Plugin, error)
+}

--- a/pkg/skel/plugin_exec.go
+++ b/pkg/skel/plugin_exec.go
@@ -1,0 +1,145 @@
+// Copyright 2014-2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skel
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/containernetworking/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/version"
+)
+
+// Exec interface implementation for PluginManager
+// Allows to wrap PluginManager with Exec interface
+
+type PluginExec struct {
+	manger PluginManager
+	*version.PluginDecoder
+}
+
+// PluginExec implements Exec interface
+var _ invoke.Exec = PluginExec{}
+
+func NewPluginExec(manger PluginManager) invoke.Exec {
+	return PluginExec{manger: manger}
+}
+
+//
+//  Exec interface implementation
+//
+
+func (e PluginExec) ExecPlugin(ctx context.Context, pluginPath string, stdinData []byte, environ []string) ([]byte, error) {
+	plugin, err := e.manger.FindPlugin(pluginPath)
+	if err != nil {
+		return nil, err
+	}
+	env := envMap(environ)
+
+	args := Args{
+		ContainerID: env["CNI_CONTAINERID"],
+		Netns:       env["CNI_NETNS"],
+		Args:        env["CNI_ARGS"],
+		IfName:      env["CNI_IFNAME"],
+		StdinData:   stdinData,
+	}
+
+	switch command := env["CNI_COMMAND"]; command {
+	case CmdAdd:
+		res, err := plugin.Add(&args)
+		if err != nil {
+			return nil, err
+		}
+		return marshalResult(res)
+	case CmdCheck:
+		res, err := plugin.Check(&args)
+		if err != nil {
+			return nil, err
+		}
+		return marshalResult(res)
+	case CmdDel:
+		err := plugin.Del(&args)
+		if err != nil {
+			return nil, err
+		}
+		return nil, nil
+	case CmdVersion:
+		pluginInfo, err := plugin.Version()
+		if err != nil {
+			return nil, err
+		}
+		return marshalVersion(pluginInfo)
+	default:
+		return nil, errors.New(fmt.Sprintf(
+			"unexpected command: %q", command,
+		))
+	}
+}
+
+func (e PluginExec) FindInPath(pluginType string, paths []string) (string, error) {
+
+	_, err := e.manger.FindPlugin(pluginType)
+	if err == nil {
+		return pluginType, nil
+	}
+
+	for _, p := range paths {
+		pluginPath := path.Join(p, pluginType)
+		_, err := e.manger.FindPlugin(pluginPath)
+		if err == nil {
+			return pluginPath, nil
+		}
+	}
+
+	return "", fmt.Errorf("failed to find plugin %q in path %s", pluginType, paths)
+}
+
+//
+//  auxiliary functions
+//
+
+func marshalResult(res types.Result) ([]byte, error) {
+	b := &bytes.Buffer{}
+	if err := res.PrintTo(b); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+func marshalVersion(pluginInfo version.PluginInfo) ([]byte, error) {
+	b := &bytes.Buffer{}
+	if err := pluginInfo.Encode(b); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+func envMap(env []string) map[string]string {
+	res := make(map[string]string)
+	for _, x := range env {
+		i := strings.Index(x, "=")
+		if i >= 0 {
+			res[x[:i]] = x[i+1:]
+		} else {
+			res[x] = ""
+		}
+	}
+	return res
+}

--- a/pkg/skel/plugin_exec_test.go
+++ b/pkg/skel/plugin_exec_test.go
@@ -1,0 +1,185 @@
+// Copyright 2014-2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package skel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/containernetworking/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/cni/pkg/version"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("envMap", func() {
+	It("works for common cases", func() {
+		p := []string{"X=", "Y", "Z=foo", "", "=boo"}
+		m := envMap(p)
+		Expect(len(m)).To(Equal(len(p) - 1))
+		Expect(m["X"]).To(Equal(""))
+		Expect(m["Y"]).To(Equal(""))
+		Expect(m["Z"]).To(Equal("foo"))
+		Expect(m[""]).To(Equal("boo"))
+	})
+})
+
+var _ = Describe("plugin exec", func() {
+
+	q := make(chan string, 1)
+	BeforeEach(func() {
+		select {
+		case <-q:
+			Fail("unexpected event")
+		default:
+		}
+	})
+	AfterEach(func() {
+		select {
+		case <-q:
+			Fail("unexpected event")
+		default:
+		}
+	})
+
+	stdin := []byte(fmt.Sprintf(
+		`{ "name":"test", "cniVersion": "%s" }`, version.Current(),
+	))
+
+	var manager = NewDirectPluginManager(func(manager *DirectPluginManager) {
+		manager.Plugins["/cni/plugins/test"] = NewDirectPlugin(func(plugin *DirectPlugin) {
+			plugin.AddFunc = func(args *Args) (types.Result, error) {
+				q <- CmdAdd
+				return &current.Result{CNIVersion: version.Current()}, nil
+			}
+			plugin.DelFunc = func(args *Args) error {
+				q <- CmdDel
+				return nil
+			}
+			plugin.CheckFunc = func(args *Args) (types.Result, error) {
+				q <- CmdCheck
+				return &current.Result{CNIVersion: version.Current()}, nil
+			}
+			plugin.VersionFunc = func() (version.PluginInfo, error) {
+				q <- CmdVersion
+				return version.All, nil
+			}
+		})
+	})
+
+	var exec = NewPluginExec(manager)
+
+	Context("when invoke unknown command", func() {
+		It("returns error", func() {
+			res, err := exec.ExecPlugin(
+				context.TODO(),
+				"/cni/plugins/test",
+				stdin,
+				(&invoke.Args{Command: "unknown"}).AsEnv(),
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(res).To(BeNil())
+		})
+	})
+
+	Context("when can't find plugin", func() {
+		It("all commands returns error", func() {
+			for _, c := range []string{CmdAdd, CmdVersion, CmdCheck, CmdDel} {
+				res, err := exec.ExecPlugin(
+					context.TODO(),
+					"/cni/plugins/none",
+					stdin,
+					(&invoke.Args{Command: c}).AsEnv(),
+				)
+				Expect(err).To(HaveOccurred())
+				Expect(res).To(BeNil())
+			}
+		})
+	})
+
+	Context("when can't marshal result", func() {
+		var manager = NewDirectPluginManager(func(manager *DirectPluginManager) {
+			manager.Plugins["/cni/plugins/test"] = NewDirectPlugin(func(plugin *DirectPlugin) {
+				plugin.AddFunc = func(args *Args) (types.Result, error) {
+					q <- CmdAdd
+					return notMarshallableResult{
+						Result: &current.Result{CNIVersion: version.Current()},
+					}, nil
+				}
+				plugin.DelFunc = func(args *Args) error {
+					q <- CmdDel
+					return nil
+				}
+				plugin.CheckFunc = func(args *Args) (types.Result, error) {
+					q <- CmdCheck
+					return notMarshallableResult{
+						Result: &current.Result{CNIVersion: version.Current()},
+					}, nil
+				}
+				plugin.VersionFunc = func() (version.PluginInfo, error) {
+					q <- CmdVersion
+					return notMarshallableVersion{
+						PluginInfo: version.All,
+					}, nil
+				}
+			})
+		})
+		var exec = NewPluginExec(manager)
+		It("Add, Check command returns error", func() {
+			for _, c := range []string{CmdAdd, CmdCheck, CmdVersion} {
+				res, err := exec.ExecPlugin(
+					context.TODO(),
+					"/cni/plugins/test",
+					stdin,
+					(&invoke.Args{Command: c}).AsEnv(),
+				)
+				Expect(err).To(HaveOccurred())
+				Expect(res).To(BeNil())
+				select {
+				case e := <-q:
+					Expect(e).To(Equal(c))
+				default:
+					Fail("event expected")
+				}
+			}
+		})
+	})
+
+})
+
+type notMarshallableResult struct {
+	types.Result
+}
+
+func (r notMarshallableResult) Print() error {
+	return r.PrintTo(os.Stdout)
+}
+
+func (r notMarshallableResult) PrintTo(writer io.Writer) error {
+	return errors.New("simulated error")
+}
+
+type notMarshallableVersion struct {
+	version.PluginInfo
+}
+
+func (r notMarshallableVersion) Encode(io.Writer) error {
+	return errors.New("simulated error")
+}


### PR DESCRIPTION
this PR adds `Plugin` and `PluginManager` interfaces and additional functionality in order to allow write plugins in component based way. 
`Plugin` interface represent abstraction of plugin or delegator. The example of plugin delegator is  cli-adapter (`CliPlugin`) that exposes Plugin interfaces and forwards calls to some executable. 
`PluginManager` is interface which allows to resolve other plugins. It have only one method `FindPlugin` that takes plugin-type as parameter and returns  `Plugin` interface in case of success. For example `CliPluginManager` will look for plugin executable on the `Path` and return cli-delegator on success.
Such decomposition very simplify writing unit tests and also dealing with non-trivial uses cases when for example you may need invoke plugins over RPC. 