### PR TITLE
Return a better error when the plugin returns none

### DIFF
--- a/libcni/api_test.go
+++ b/libcni/api_test.go
@@ -1325,7 +1325,7 @@ var _ = Describe("Invoking plugins", func() {
 					result, err := cniConfig.AddNetwork(ctx, netConfig, runtimeConfig)
 					cancel()
 					Expect(result).To(BeNil())
-					Expect(err).To(MatchError(ContainSubstring("netplugin failed but error parsing its diagnostic message")))
+					Expect(err).To(MatchError(ContainSubstring("netplugin failed with no error message")))
 				})
 
 			})
@@ -1337,7 +1337,7 @@ var _ = Describe("Invoking plugins", func() {
 					ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 					err := cniConfig.DelNetwork(ctx, netConfig, runtimeConfig)
 					cancel()
-					Expect(err).To(MatchError(ContainSubstring("netplugin failed but error parsing its diagnostic message")))
+					Expect(err).To(MatchError(ContainSubstring("netplugin failed with no error message")))
 				})
 
 			})
@@ -1349,7 +1349,7 @@ var _ = Describe("Invoking plugins", func() {
 					ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 					err := cniConfig.CheckNetwork(ctx, netConfig, runtimeConfig)
 					cancel()
-					Expect(err).To(MatchError(ContainSubstring("netplugin failed but error parsing its diagnostic message")))
+					Expect(err).To(MatchError(ContainSubstring("netplugin failed with no error message")))
 				})
 
 			})
@@ -1362,7 +1362,7 @@ var _ = Describe("Invoking plugins", func() {
 					result, err := cniConfig.GetVersionInfo(ctx, "sleep")
 					cancel()
 					Expect(result).To(BeNil())
-					Expect(err).To(MatchError(ContainSubstring("netplugin failed but error parsing its diagnostic message")))
+					Expect(err).To(MatchError(ContainSubstring("netplugin failed with no error message")))
 				})
 
 			})
@@ -1374,7 +1374,7 @@ var _ = Describe("Invoking plugins", func() {
 					ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 					_, err := cniConfig.ValidateNetwork(ctx, netConfig)
 					cancel()
-					Expect(err).To(MatchError(ContainSubstring("netplugin failed but error parsing its diagnostic message")))
+					Expect(err).To(MatchError(ContainSubstring("netplugin failed with no error message")))
 				})
 
 			})
@@ -1387,7 +1387,7 @@ var _ = Describe("Invoking plugins", func() {
 					result, err := cniConfig.AddNetworkList(ctx, netConfigList, runtimeConfig)
 					cancel()
 					Expect(result).To(BeNil())
-					Expect(err).To(MatchError(ContainSubstring("netplugin failed but error parsing its diagnostic message")))
+					Expect(err).To(MatchError(ContainSubstring("netplugin failed with no error message")))
 				})
 
 			})
@@ -1399,7 +1399,7 @@ var _ = Describe("Invoking plugins", func() {
 					ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 					err := cniConfig.DelNetworkList(ctx, netConfigList, runtimeConfig)
 					cancel()
-					Expect(err).To(MatchError(ContainSubstring("netplugin failed but error parsing its diagnostic message")))
+					Expect(err).To(MatchError(ContainSubstring("netplugin failed with no error message")))
 				})
 
 			})
@@ -1411,7 +1411,7 @@ var _ = Describe("Invoking plugins", func() {
 					ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 					err := cniConfig.CheckNetworkList(ctx, netConfigList, runtimeConfig)
 					cancel()
-					Expect(err).To(MatchError(ContainSubstring("netplugin failed but error parsing its diagnostic message")))
+					Expect(err).To(MatchError(ContainSubstring("netplugin failed with no error message")))
 				})
 
 			})
@@ -1423,7 +1423,7 @@ var _ = Describe("Invoking plugins", func() {
 					ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
 					_, err := cniConfig.ValidateNetworkList(ctx, netConfigList)
 					cancel()
-					Expect(err).To(MatchError(ContainSubstring("netplugin failed but error parsing its diagnostic message")))
+					Expect(err).To(MatchError(ContainSubstring("netplugin failed with no error message")))
 				})
 
 			})

--- a/pkg/invoke/raw_exec.go
+++ b/pkg/invoke/raw_exec.go
@@ -46,7 +46,9 @@ func (e *RawExec) ExecPlugin(ctx context.Context, pluginPath string, stdinData [
 func pluginErr(err error, output []byte) error {
 	if _, ok := err.(*exec.ExitError); ok {
 		emsg := types.Error{}
-		if perr := json.Unmarshal(output, &emsg); perr != nil {
+		if len(output) == 0 {
+			emsg.Msg = "netplugin failed with no error message"
+		} else if perr := json.Unmarshal(output, &emsg); perr != nil {
 			emsg.Msg = fmt.Sprintf("netplugin failed but error parsing its diagnostic message %q: %v", string(output), perr)
 		}
 		return &emsg


### PR DESCRIPTION
was seeing some

    Failed create pod sandbox: rpc error: code = Unknown desc = failed to
    create pod network sandbox k8s_kube-controller-manager-operator-54c6d7
    69f4-2rnzn_openshift-kube-controller-manager-operator_1f508e1a-5d25-11
    e9-b0ba-024239aadba4_0(19273c65ace39e557bcf7097e457a358ca52e4cb193388e
    b3bda13d5143c955d): netplugin failed but error parsing its diagnostic
    message \"\": unexpected end of JSON input",

and thought, that's a pretty lame error message.

(Maybe also change "netplugin" to "network plugin"? Also, as suggested by the tests, this might specifically mean "the plugin timed out", but maybe we should arrange to have an error message that states that explicitly if that happens?)