### PR TITLE
libcni: add config caching

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -4,11 +4,17 @@ set -euo pipefail
 # switch into the repo root directory
 cd "$(dirname $0)"
 
+go get -t ./...
+
 echo -n "Running tests "
 function testrun {
     bash -c "umask 0; PATH=$PATH go test $@"
 }
 if [ ! -z "${COVERALLS:-""}" ]; then
+    go get golang.org/x/tools/cmd/cover
+    go get github.com/modocache/gover
+    go get github.com/mattn/goveralls
+
     # coverage profile only works per-package
     PKGS="$(go list ./... | xargs echo)"
     echo "with coverage profile generation..."
@@ -18,7 +24,6 @@ if [ ! -z "${COVERALLS:-""}" ]; then
         i=$((i+1))
     done
     gover
-    goveralls -service=travis-ci -coverprofile=gover.coverprofile
 else
     echo "without coverage profile generation..."
     testrun "./..."


### PR DESCRIPTION
Cache the config JSON, CNI_ARGs, and CapabilityArgs on ADD operations,
and remove them on DEL. This allows runtimes to retrieve the cached
information to ensure that the pod is given the same config and options
on DEL as it was given on ADD.

@containernetworking/cni-maintainers @squeed 