### PR TITLE
invoke : ensure custom envs of CNIArgs are prepended to process envs

### DIFF
--- a/pkg/invoke/args.go
+++ b/pkg/invoke/args.go
@@ -57,16 +57,16 @@ func (args *Args) AsEnv() []string {
 		pluginArgsStr = stringify(args.PluginArgs)
 	}
 
-	// Ensure that the custom values are first, so any value present in
-	// the process environment won't override them.
-	env = append([]string{
-		"CNI_COMMAND=" + args.Command,
-		"CNI_CONTAINERID=" + args.ContainerID,
-		"CNI_NETNS=" + args.NetNS,
-		"CNI_ARGS=" + pluginArgsStr,
-		"CNI_IFNAME=" + args.IfName,
-		"CNI_PATH=" + args.Path,
-	}, env...)
+	// Duplicated values which come first will be overrided, so we must put the
+	// custom values in the end to avoid being overrided by the process environments.
+	env = append(env,
+		"CNI_COMMAND="+args.Command,
+		"CNI_CONTAINERID="+args.ContainerID,
+		"CNI_NETNS="+args.NetNS,
+		"CNI_ARGS="+pluginArgsStr,
+		"CNI_IFNAME="+args.IfName,
+		"CNI_PATH="+args.Path,
+	)
 	return env
 }
 

--- a/pkg/invoke/args_test.go
+++ b/pkg/invoke/args_test.go
@@ -25,7 +25,7 @@ import (
 
 var _ = Describe("Args", func() {
 	Describe("AsEnv", func() {
-		It("places the CNI_ environment variables ahead of any ambient variables", func() {
+		It("places the CNI_ environment variables in the end to avoid being overrided", func() {
 			args := invoke.Args{
 				Command:     "ADD",
 				ContainerID: "some-container-id",
@@ -40,10 +40,11 @@ var _ = Describe("Args", func() {
 			const numCNIEnvVars = 6
 
 			latentVars := os.Environ()
+			latentVarsLen := len(latentVars)
 
 			cniEnv := args.AsEnv()
 			Expect(cniEnv).To(HaveLen(len(latentVars) + numCNIEnvVars))
-			Expect(cniEnv[0:numCNIEnvVars]).To(Equal([]string{
+			Expect(cniEnv[latentVarsLen:]).To(Equal([]string{
 				"CNI_COMMAND=ADD",
 				"CNI_CONTAINERID=some-container-id",
 				"CNI_NETNS=/some/netns/path",
@@ -53,7 +54,7 @@ var _ = Describe("Args", func() {
 			}))
 
 			for i := range latentVars {
-				Expect(cniEnv[numCNIEnvVars+i]).To(Equal(latentVars[i]))
+				Expect(cniEnv[i]).To(Equal(latentVars[i]))
 			}
 		})
 	})


### PR DESCRIPTION
From this commit [https://github.com/golang/go/commit/e73f4894949c4ced611881329ff8f37805152585#diff-2f929a7660c606fd0c5b268dad1a9bd4R61](https://github.com/golang/go/commit/e73f4894949c4ced611881329ff8f37805152585#diff-2f929a7660c606fd0c5b268dad1a9bd4R61) in golang, we can know that the RawExec will clean the duplicated envs and keep the last valid env of the same key.
So if we want to prepend custom args from CNIArgs rather than the existing process environments, we should append custom args in the end.
