### PR TITLE
libcni: find plugin in exec

### DIFF
--- a/libcni/api.go
+++ b/libcni/api.go
@@ -594,7 +594,8 @@ func (c *CNIConfig) ValidateNetwork(ctx context.Context, net *NetworkConfig) ([]
 
 // validatePlugin checks that an individual plugin's configuration is sane
 func (c *CNIConfig) validatePlugin(ctx context.Context, pluginName, expectedVersion string) error {
-	pluginPath, err := invoke.FindInPath(pluginName, c.Path)
+	c.ensureExec()
+	pluginPath, err := c.exec.FindInPath(pluginName, c.Path)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Function `validatePlugin` in libcni should find plugin by `exec.FindInPath` instead of using `invoke.FindInPath` directly, just like `addNetwork` [https://github.com/containernetworking/cni/blob/df124b22e4f7a0b716d313884aee6474b319b4a3/libcni/api.go#L378](https://github.com/containernetworking/cni/blob/df124b22e4f7a0b716d313884aee6474b319b4a3/libcni/api.go#L378).

I think this breaks CI of [https://github.com/cri-o/ocicni/pull/51](https://github.com/cri-o/ocicni/pull/51).
