### PR TITLE
[WIP] set process group ID when fork/exec so child processes terminate together

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+sudo: required
 dist: bionic
 
 go:

--- a/pkg/invoke/os_unix.go
+++ b/pkg/invoke/os_unix.go
@@ -16,5 +16,16 @@
 
 package invoke
 
+import (
+	"os"
+	"syscall"
+)
+
 // Valid file extensions for plugin executables.
 var ExecutableFileExtensions = []string{""}
+
+// SysProcAttribute holds optional, operating system-specific attributes.
+var SysProcAttribute = &syscall.SysProcAttr{
+	Setpgid: true,
+	Pgid:    os.Getpid(),
+}

--- a/pkg/invoke/os_windows.go
+++ b/pkg/invoke/os_windows.go
@@ -14,5 +14,12 @@
 
 package invoke
 
+import (
+	"syscall"
+)
+
 // Valid file extensions for plugin executables.
 var ExecutableFileExtensions = []string{".exe", ""}
+
+// SysProcAttribute holds optional, operating system-specific attributes.
+var SysProcAttribute = &syscall.SysProcAttr{}

--- a/pkg/invoke/raw_exec.go
+++ b/pkg/invoke/raw_exec.go
@@ -36,6 +36,10 @@ func (e *RawExec) ExecPlugin(ctx context.Context, pluginPath string, stdinData [
 	c.Stdin = bytes.NewBuffer(stdinData)
 	c.Stdout = stdout
 	c.Stderr = e.Stderr
+	// This attributes make sub process has group process id which is same as its parent process id,
+	// if we use this function in tree (libcni -> plugin -> plugin ... ), all sub processes generated
+	// from root process can be killed in tree recursively.
+	c.SysProcAttr = SysProcAttribute
 	if err := c.Run(); err != nil {
 		return nil, pluginErr(err, stdout.Bytes())
 	}

--- a/test.sh
+++ b/test.sh
@@ -6,7 +6,7 @@ cd "$(dirname $0)"
 
 echo -n "Running tests "
 function testrun {
-    bash -c "umask 0; PATH=$PATH go test $@"
+    sudo -E bash -c "umask 000; PATH=$PATH go test $@"
 }
 if [ ! -z "${COVERALLS:-""}" ]; then
     # coverage profile only works per-package


### PR DESCRIPTION
Provide a experimental way to fix #687 

We let sub process called by invoke.Exec has the process group id same as its parent process id, so when the parent process is killed, all the sub processes will be killed in tree recursively.

Fox example, if we use libcni in CRI to call plugin **A**, and plugin **A** call plugin **B** and **C**, and plugin **B** call another plugin **D**, then the pid/pgid maybe like,

process|pid|pgid
-|-|-
|CRI|100|120|
|A|103|100|
|B|105|103|
|C|106|103|
|D|108|105|

If CRI (pid==100) was killed, processes(A pid==103) with group id == 100 will be killed, and processes(B pid==105 C pid==106) with group id == 103 will be killed, and process D will be killed in the same way recursively.
For the same reason , if CRI try to kill process A, B&C&D will be killed recursively.

Signed-off-by: Bruce Ma <brucema19901024@gmail.com>