### PR TITLE
libcni: fix cache file 'result' key name

### DIFF
--- a/libcni/api.go
+++ b/libcni/api.go
@@ -186,7 +186,7 @@ type cachedInfo struct {
 	Config         []byte                 `json:"config"`
 	CniArgs        [][2]string            `json:"cniArgs,omitempty"`
 	CapabilityArgs map[string]interface{} `json:"capabilityArgs,omitempty"`
-	RawResult      map[string]interface{} `json:"results,omitempty"`
+	RawResult      map[string]interface{} `json:"result,omitempty"`
 	Result         types.Result           `json:"-"`
 }
 


### PR DESCRIPTION
The structure member name was changed from Results -> Result during
review but we missed changing the JSON key name.  Fix that and fall
back to the old name if required.

@containernetworking/cni-maintainers @bboreham @jellonek @squeed 