### PR TITLE
[WIP] libcni: add method to return all cached info for a container

### DIFF
--- a/libcni/api.go
+++ b/libcni/api.go
@@ -293,17 +293,7 @@ func (c *CNIConfig) getCachedConfig(netName string, rt *RuntimeConf) ([]byte, *R
 	return unmarshaled.Config, &newRt, nil
 }
 
-func (c *CNIConfig) getLegacyCachedResult(netName, cniVersion string, rt *RuntimeConf) (types.Result, error) {
-	fname, err := c.getCacheFilePath(netName, rt)
-	if err != nil {
-		return nil, err
-	}
-	data, err := ioutil.ReadFile(fname)
-	if err != nil {
-		// Ignore read errors; the cached result may not exist on-disk
-		return nil, nil
-	}
-
+func (c *CNIConfig) getLegacyCachedResult(data []byte, cniVersion string) (types.Result, error) {
 	// Read the version of the cached result
 	decoder := version.ConfigDecoder{}
 	resultCniVersion, err := decoder.Decode(data)
@@ -341,7 +331,7 @@ func (c *CNIConfig) getCachedResult(netName, cniVersion string, rt *RuntimeConf)
 
 	cachedInfo := cachedInfo{}
 	if err := json.Unmarshal(fdata, &cachedInfo); err != nil || cachedInfo.Kind != CNICacheV1 {
-		return c.getLegacyCachedResult(netName, cniVersion, rt)
+		return c.getLegacyCachedResult(fdata, cniVersion)
 	}
 
 	newBytes, err := json.Marshal(&cachedInfo.RawResult)

--- a/libcni/api_test.go
+++ b/libcni/api_test.go
@@ -1729,7 +1729,7 @@ var _ = Describe("Invoking plugins", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					cachedConfig, newRt, err := cniConfig.GetNetworkCachedConfig(netConfig, runtimeConfig)
-					Expect(err).To(MatchError("failed to unmarshal cached network \"cachetest\" config: invalid character 'a' looking for beginning of value"))
+					Expect(err).To(MatchError("failed to unmarshal cached config: invalid character 'a' looking for beginning of value"))
 					Expect(cachedConfig).To(BeNil())
 					Expect(newRt).To(BeNil())
 				})


### PR DESCRIPTION
This is a "get all the things" function, which a runtime could use on container teardown to avoid having to itself cache the uniqueness tuple when tearing down all networks for the container.

@containernetworking/cni-maintainers @squeed @mars1024 