### PR TITLE
add interface name validation

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -68,7 +68,7 @@ The operations that CNI plugins must support are:
     - **Network namespace path**. This represents the path to the network namespace to be added, i.e. /proc/[pid]/ns/net or a bind-mount/link to it.
     - **Network configuration**. This is a JSON document describing a network to which a container can be joined. The schema is described below.
     - **Extra arguments**. This provides an alternative mechanism to allow simple configuration of CNI plugins on a per-container basis.
-    - **Name of the interface inside the container**. This is the name that should be assigned to the interface created inside the container (network namespace); consequently it must comply with the standard Linux restrictions on interface names.
+    - **Name of the interface inside the container**. This is the name that should be assigned to the interface created inside the container (network namespace); consequently it must comply with the standard Linux restrictions on interface names, must not be empty, must not be "." or "..", must be less than 16 characters and must not contain / or : or any whitespace characters.
   - Result:
     - **Interfaces list**. Depending on the plugin, this can include the sandbox (eg, container or hypervisor) interface name and/or the host interface name, the hardware addresses of each interface, and details about the sandbox (if any) the interface is in.
     - **IP configuration assigned to each interface**. The IPv4 and/or IPv6 addresses, gateways, and routes assigned to sandbox and/or host interfaces.

--- a/libcni/api.go
+++ b/libcni/api.go
@@ -409,6 +409,9 @@ func (c *CNIConfig) addNetwork(ctx context.Context, name, cniVersion string, net
 	if err := utils.ValidateNetworkName(name); err != nil {
 		return nil, err
 	}
+	if err := utils.ValidateInterfaceName(rt.IfName); err != nil {
+		return nil, err
+	}
 
 	newConf, err := buildOneConfig(name, cniVersion, net, prevResult, rt)
 	if err != nil {

--- a/libcni/api_test.go
+++ b/libcni/api_test.go
@@ -1012,7 +1012,7 @@ var _ = Describe("Invoking plugins", func() {
 				It("returns the error", func() {
 					_, err := cniConfig.AddNetworkList(ctx, netConfigList, runtimeConfig)
 					Expect(err).To(Equal(&types.Error{
-						Code:    4,
+						Code:    types.ErrInvalidEnvironmentVariables,
 						Msg:     "invalid characters in containerID",
 						Details: "some-%%container-id",
 					}))
@@ -1027,9 +1027,55 @@ var _ = Describe("Invoking plugins", func() {
 				It("returns the error", func() {
 					_, err := cniConfig.AddNetworkList(ctx, netConfigList, runtimeConfig)
 					Expect(err).To(Equal(&types.Error{
-						Code:    7,
+						Code:    types.ErrInvalidNetworkConfig,
 						Msg:     "invalid characters found in network name",
 						Details: "invalid-%%-name",
+					}))
+				})
+			})
+
+			Context("return errors when interface name is invalid", func() {
+				It("interface name is empty", func() {
+					runtimeConfig.IfName = ""
+
+					_, err := cniConfig.AddNetworkList(ctx, netConfigList, runtimeConfig)
+					Expect(err).To(Equal(&types.Error{
+						Code:    types.ErrInvalidEnvironmentVariables,
+						Msg:     "interface name is empty",
+						Details: "",
+					}))
+				})
+
+				It("interface name is overflow", func() {
+					runtimeConfig.IfName = "1234567890123456"
+
+					_, err := cniConfig.AddNetworkList(ctx, netConfigList, runtimeConfig)
+					Expect(err).To(Equal(&types.Error{
+						Code:    types.ErrInvalidEnvironmentVariables,
+						Msg:     "interface name is overflow",
+						Details: "interface name length should be less than 16 characters",
+					}))
+				})
+
+				It("interface name contains invalid characters /", func() {
+					runtimeConfig.IfName = "test/test"
+
+					_, err := cniConfig.AddNetworkList(ctx, netConfigList, runtimeConfig)
+					Expect(err).To(Equal(&types.Error{
+						Code:    types.ErrInvalidEnvironmentVariables,
+						Msg:     "interface name contains / or whitespace characters",
+						Details: "",
+					}))
+				})
+
+				It("interface name contains invalid characters whitespace", func() {
+					runtimeConfig.IfName = "test test"
+
+					_, err := cniConfig.AddNetworkList(ctx, netConfigList, runtimeConfig)
+					Expect(err).To(Equal(&types.Error{
+						Code:    types.ErrInvalidEnvironmentVariables,
+						Msg:     "interface name contains / or whitespace characters",
+						Details: "",
 					}))
 				})
 			})

--- a/libcni/api_test.go
+++ b/libcni/api_test.go
@@ -1046,14 +1046,36 @@ var _ = Describe("Invoking plugins", func() {
 					}))
 				})
 
-				It("interface name is overflow", func() {
+				It("interface name is too long", func() {
 					runtimeConfig.IfName = "1234567890123456"
 
 					_, err := cniConfig.AddNetworkList(ctx, netConfigList, runtimeConfig)
 					Expect(err).To(Equal(&types.Error{
 						Code:    types.ErrInvalidEnvironmentVariables,
-						Msg:     "interface name is overflow",
-						Details: "interface name length should be less than 16 characters",
+						Msg:     "interface name is too long",
+						Details: "interface name should be less than 16 characters",
+					}))
+				})
+
+				It("interface name is .", func() {
+					runtimeConfig.IfName = "."
+
+					_, err := cniConfig.AddNetworkList(ctx, netConfigList, runtimeConfig)
+					Expect(err).To(Equal(&types.Error{
+						Code:    types.ErrInvalidEnvironmentVariables,
+						Msg:     "interface name is . or ..",
+						Details: "",
+					}))
+				})
+
+				It("interface name is ..", func() {
+					runtimeConfig.IfName = ".."
+
+					_, err := cniConfig.AddNetworkList(ctx, netConfigList, runtimeConfig)
+					Expect(err).To(Equal(&types.Error{
+						Code:    types.ErrInvalidEnvironmentVariables,
+						Msg:     "interface name is . or ..",
+						Details: "",
 					}))
 				})
 
@@ -1063,7 +1085,18 @@ var _ = Describe("Invoking plugins", func() {
 					_, err := cniConfig.AddNetworkList(ctx, netConfigList, runtimeConfig)
 					Expect(err).To(Equal(&types.Error{
 						Code:    types.ErrInvalidEnvironmentVariables,
-						Msg:     "interface name contains / or whitespace characters",
+						Msg:     "interface name contains / or : or whitespace characters",
+						Details: "",
+					}))
+				})
+
+				It("interface name contains invalid characters :", func() {
+					runtimeConfig.IfName = "test:test"
+
+					_, err := cniConfig.AddNetworkList(ctx, netConfigList, runtimeConfig)
+					Expect(err).To(Equal(&types.Error{
+						Code:    types.ErrInvalidEnvironmentVariables,
+						Msg:     "interface name contains / or : or whitespace characters",
 						Details: "",
 					}))
 				})
@@ -1074,7 +1107,7 @@ var _ = Describe("Invoking plugins", func() {
 					_, err := cniConfig.AddNetworkList(ctx, netConfigList, runtimeConfig)
 					Expect(err).To(Equal(&types.Error{
 						Code:    types.ErrInvalidEnvironmentVariables,
-						Msg:     "interface name contains / or whitespace characters",
+						Msg:     "interface name contains / or : or whitespace characters",
 						Details: "",
 					}))
 				})

--- a/pkg/skel/skel.go
+++ b/pkg/skel/skel.go
@@ -202,12 +202,13 @@ func (t *dispatcher) pluginMain(cmdAdd, cmdCheck, cmdDel func(_ *CmdArgs) error,
 	}
 
 	if cmd != "VERSION" {
-		err = validateConfig(cmdArgs.StdinData)
-		if err != nil {
+		if err = validateConfig(cmdArgs.StdinData); err != nil {
 			return err
 		}
-		err = utils.ValidateContainerID(cmdArgs.ContainerID)
-		if err != nil {
+		if err = utils.ValidateContainerID(cmdArgs.ContainerID); err != nil {
+			return err
+		}
+		if err = utils.ValidateInterfaceName(cmdArgs.IfName); err != nil {
 			return err
 		}
 	}

--- a/pkg/skel/skel_test.go
+++ b/pkg/skel/skel_test.go
@@ -126,15 +126,39 @@ var _ = Describe("dispatching to the correct callback", func() {
 		})
 
 		Context("return errors when interface name is invalid", func() {
-			It("interface name is overflow", func() {
+			It("interface name is too long", func() {
 				environment["CNI_IFNAME"] = "1234567890123456"
 
 				err := dispatch.pluginMain(cmdAdd.Func, cmdCheck.Func, cmdDel.Func, versionInfo, "")
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(Equal(&types.Error{
 					Code:    types.ErrInvalidEnvironmentVariables,
-					Msg:     "interface name is overflow",
-					Details: "interface name length should be less than 16 characters",
+					Msg:     "interface name is too long",
+					Details: "interface name should be less than 16 characters",
+				}))
+			})
+
+			It("interface name is .", func() {
+				environment["CNI_IFNAME"] = "."
+
+				err := dispatch.pluginMain(cmdAdd.Func, cmdCheck.Func, cmdDel.Func, versionInfo, "")
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(&types.Error{
+					Code:    types.ErrInvalidEnvironmentVariables,
+					Msg:     "interface name is . or ..",
+					Details: "",
+				}))
+			})
+
+			It("interface name is ..", func() {
+				environment["CNI_IFNAME"] = ".."
+
+				err := dispatch.pluginMain(cmdAdd.Func, cmdCheck.Func, cmdDel.Func, versionInfo, "")
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(&types.Error{
+					Code:    types.ErrInvalidEnvironmentVariables,
+					Msg:     "interface name is . or ..",
+					Details: "",
 				}))
 			})
 
@@ -145,7 +169,19 @@ var _ = Describe("dispatching to the correct callback", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(Equal(&types.Error{
 					Code:    types.ErrInvalidEnvironmentVariables,
-					Msg:     "interface name contains / or whitespace characters",
+					Msg:     "interface name contains / or : or whitespace characters",
+					Details: "",
+				}))
+			})
+
+			It("interface name contains invalid characters :", func() {
+				environment["CNI_IFNAME"] = "test:test"
+
+				err := dispatch.pluginMain(cmdAdd.Func, cmdCheck.Func, cmdDel.Func, versionInfo, "")
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(&types.Error{
+					Code:    types.ErrInvalidEnvironmentVariables,
+					Msg:     "interface name contains / or : or whitespace characters",
 					Details: "",
 				}))
 			})
@@ -157,7 +193,7 @@ var _ = Describe("dispatching to the correct callback", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(Equal(&types.Error{
 					Code:    types.ErrInvalidEnvironmentVariables,
-					Msg:     "interface name contains / or whitespace characters",
+					Msg:     "interface name contains / or : or whitespace characters",
 					Details: "",
 				}))
 			})


### PR DESCRIPTION
Interface name in linux is not unrestricted, so bad interface name will break CNI plugin.
This pr will add interface name validation to libcni and skel.

validation rules ref to [https://github.com/torvalds/linux/blob/master/net/core/dev.c#L1024](https://github.com/torvalds/linux/blob/master/net/core/dev.c#L1024)