### PR TITLE
When CNI version isn't supplied in config, use default.

### DIFF
--- a/libcni/api.go
+++ b/libcni/api.go
@@ -632,6 +632,9 @@ func (c *CNIConfig) validatePlugin(ctx context.Context, pluginName, expectedVers
 	if err != nil {
 		return err
 	}
+	if expectedVersion == "" {
+		expectedVersion = "0.1.0"
+	}
 
 	vi, err := invoke.GetVersionInfo(ctx, pluginPath, c.exec)
 	if err != nil {

--- a/libcni/api_test.go
+++ b/libcni/api_test.go
@@ -835,6 +835,11 @@ var _ = Describe("Invoking plugins", func() {
 				_, err := cniConfig.ValidateNetwork(ctx, netConfig)
 				Expect(err).To(MatchError("plugin noop does not support config version \"broken\""))
 			})
+			It("allows version to be omitted", func() {
+				netConfig.Network.CNIVersion = ""
+				_, err := cniConfig.ValidateNetwork(ctx, netConfig)
+				Expect(err).NotTo(HaveOccurred())
+			})
 		})
 	})
 


### PR DESCRIPTION
When CNI version isn't supplied in config, use default.

Fixes [720](https://github.com/containernetworking/cni/issues/720)

Signed-off-by: Michael Cambria <mccv1r0@gmail.com>