### PR TITLE
Add table of contents to SPEC.md

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,11 +1,27 @@
 # Container Network Interface Specification
 
+- [Version](#version)
+- [Overview](#overview)
+- [General considerations](#general-considerations)
+- [CNI Plugin](#cni-plugin)
+  * [Overview](#overview-1)
+  * [Parameters](#parameters)
+  * [Result](#result)
+  * [Network Configuration](#network-configuration)
+  * [Example configurations](#example-configurations)
+  * [Network Configuration Lists](#network-configuration-lists)
+  * [IP Allocation](#ip-allocation)
+  * [Well-known Structures](#well-known-structures)
+- [Well-known Error Codes](#well-known-error-codes)
+
 ## Version
+
 This is CNI **spec** version **0.4.0**.
 
 Note that this is **independent from the version of the CNI library and plugins** in this repository (e.g. the versions of [releases](https://github.com/containernetworking/cni/releases)).
 
 #### Released versions
+
 Released versions of the spec are available as Git tags.
 
 | tag                                                                                  | spec permalink                                                                        | major changes                     |


### PR DESCRIPTION
The specification is good but I found it a bit hard to navigate because it's quite long. So I added a hyperlinked table of contents to the beginning of the document.

The Markdown for the table of contents has been automatically generated with [markdown-toc](https://github.com/jonschlinkert/markdown-toc):

```bash
markdown-toc --no-firsth1 --maxdepth=2 SPEC.md
```
And then pasted into the file.

See here [how it looks like](https://github.com/weibeld/cni/blob/master/SPEC.md).