### PR TITLE
Update roadmap for 1.0 plans

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,19 +5,14 @@ The list below is not complete, and we advise to get the current project state f
 
 ## CNI Milestones
 
-### [v0.6.0](https://github.com/containernetworking/cni/milestones/v0.6.0)
-
-- Plugin composition functionality
-- IPv6 support
-- Strategy and tooling for backwards compatibility
-- Integrate build artefact generation with CI
-
 ### [v1.0.0](https://github.com/containernetworking/cni/milestones/v1.0.0)
 
+- Targeted for April 2020
 - More precise specification language
-- CHECK action
-- Conformance test suite for CNI plugins (both reference and 3rd party)
 - Stable SPEC
 - Complete test coverage
-- Signed release binaries
 
+### Beyond v1.0.0
+
+- Conformance test suite for CNI plugins (both reference and 3rd party)
+- Signed release binaries


### PR DESCRIPTION
0.6.0 is done.
CHECK is done.
We set a goal to get 1.0 shipped for Kubecon EU, so moved some steps out beyond that.
