### PR TITLE
Update link freenode.org to freenode.net

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ contribution. See the [DCO](DCO) file for details.
 
 The project uses the cni-dev email list and IRC chat:
 - Email: [cni-dev](https://groups.google.com/forum/#!forum/cni-dev)
-- IRC: #[containernetworking](irc://irc.freenode.org:6667/#containernetworking) channel on freenode.org
+- IRC: #[containernetworking](irc://irc.freenode.net:6667/#containernetworking) channel on [freenode.net](https://freenode.net/)
 
 Please avoid emailing maintainers found in the MAINTAINERS file directly. They
 are very busy and read the mailing lists.


### PR DESCRIPTION
The domain `freenode.org` is no longer up-to-date,
use `freenode.net` instead

Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>