### PR TITLE
bumped to golang 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: go
 dist: bionic
 
 go:
-  - 1.11.x
-  - 1.12.x
   - 1.13.x
 
 env:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
     apt-get update -y || (sleep 40 && apt-get update -y)
     apt-get install -y git
 
-    wget -qO- https://storage.googleapis.com/golang/go1.12.5.linux-amd64.tar.gz | tar -C /usr/local -xz
+    wget -qO- https://dl.google.com/go/go1.13.11.linux-amd64.tar.gz | tar -C /usr/local -xz
 
     echo 'export GOPATH=/go; export PATH=/usr/local/go/bin:$GOPATH/bin:$PATH' >> /root/.bashrc
     eval `tail -n1 /root/.bashrc`

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -14,7 +14,7 @@ rm -Rf ${SRC_DIR}/${RELEASE_DIR}
 mkdir -p ${SRC_DIR}/${RELEASE_DIR}
 mkdir -p ${OUTPUT_DIR}
 
-docker run -i -v ${SRC_DIR}:/opt/src --rm golang:1.12-alpine \
+docker run -i -v ${SRC_DIR}:/opt/src --rm golang:1.13-alpine \
 /bin/sh -xe -c "\
     apk --no-cache add bash tar;
     cd /opt/src; umask 0022;


### PR DESCRIPTION
Updated to use golang 1.13. Current version is using 1.12 which went eol on 25th Feb 2020 due to the release of 1.14. 

Signed-off-by: Daniel Sutton <daniel@ducksecops.uk>