### PR TITLE
types: unexport SupportedVersions

### DIFF
--- a/pkg/types/020/types.go
+++ b/pkg/types/020/types.go
@@ -27,12 +27,15 @@ import (
 
 const ImplementedSpecVersion string = "0.2.0"
 
-var SupportedVersions = []string{"", "0.1.0", ImplementedSpecVersion}
+var supportedVersions = []string{"", "0.1.0", ImplementedSpecVersion}
 
 // Register converters for all versions less than the implemented spec version
 func init() {
-	convert.Register("0.1.0", []string{ImplementedSpecVersion}, convertFrom010)
-	convert.Register(ImplementedSpecVersion, []string{"0.1.0"}, convertTo010)
+	convert.RegisterConverter("0.1.0", []string{ImplementedSpecVersion}, convertFrom010)
+	convert.RegisterConverter(ImplementedSpecVersion, []string{"0.1.0"}, convertTo010)
+
+	// Creator
+	convert.RegisterCreator(supportedVersions, NewResult)
 }
 
 // Compatibility types for CNI version 0.1.0 and 0.2.0
@@ -44,13 +47,13 @@ func NewResult(data []byte) (types.Result, error) {
 	if err := json.Unmarshal(data, result); err != nil {
 		return nil, err
 	}
-	for _, v := range SupportedVersions {
+	for _, v := range supportedVersions {
 		if result.CNIVersion == v {
 			return result, nil
 		}
 	}
 	return nil, fmt.Errorf("result type supports %v but unmarshalled CNIVersion is %q",
-		SupportedVersions, result.CNIVersion)
+		supportedVersions, result.CNIVersion)
 }
 
 // GetResult converts the given Result object to the ImplementedSpecVersion

--- a/pkg/types/040/types.go
+++ b/pkg/types/040/types.go
@@ -28,21 +28,24 @@ import (
 
 const ImplementedSpecVersion string = "0.4.0"
 
-var SupportedVersions = []string{"0.3.0", "0.3.1", ImplementedSpecVersion}
+var supportedVersions = []string{"0.3.0", "0.3.1", ImplementedSpecVersion}
 
 // Register converters for all versions less than the implemented spec version
 func init() {
 	// Up-converters
-	convert.Register("0.1.0", SupportedVersions, convertFrom02x)
-	convert.Register("0.2.0", SupportedVersions, convertFrom02x)
-	convert.Register("0.3.0", SupportedVersions, convertInternal)
-	convert.Register("0.3.1", SupportedVersions, convertInternal)
+	convert.RegisterConverter("0.1.0", supportedVersions, convertFrom02x)
+	convert.RegisterConverter("0.2.0", supportedVersions, convertFrom02x)
+	convert.RegisterConverter("0.3.0", supportedVersions, convertInternal)
+	convert.RegisterConverter("0.3.1", supportedVersions, convertInternal)
 
 	// Down-converters
-	convert.Register("0.4.0", []string{"0.3.0", "0.3.1"}, convertInternal)
-	convert.Register("0.4.0", []string{"0.1.0", "0.2.0"}, convertTo02x)
-	convert.Register("0.3.1", []string{"0.1.0", "0.2.0"}, convertTo02x)
-	convert.Register("0.3.0", []string{"0.1.0", "0.2.0"}, convertTo02x)
+	convert.RegisterConverter("0.4.0", []string{"0.3.0", "0.3.1"}, convertInternal)
+	convert.RegisterConverter("0.4.0", []string{"0.1.0", "0.2.0"}, convertTo02x)
+	convert.RegisterConverter("0.3.1", []string{"0.1.0", "0.2.0"}, convertTo02x)
+	convert.RegisterConverter("0.3.0", []string{"0.1.0", "0.2.0"}, convertTo02x)
+
+	// Creator
+	convert.RegisterCreator(supportedVersions, NewResult)
 }
 
 func NewResult(data []byte) (types.Result, error) {
@@ -50,13 +53,13 @@ func NewResult(data []byte) (types.Result, error) {
 	if err := json.Unmarshal(data, result); err != nil {
 		return nil, err
 	}
-	for _, v := range SupportedVersions {
+	for _, v := range supportedVersions {
 		if result.CNIVersion == v {
 			return result, nil
 		}
 	}
 	return nil, fmt.Errorf("result type supports %v but unmarshalled CNIVersion is %q",
-		SupportedVersions, result.CNIVersion)
+		supportedVersions, result.CNIVersion)
 }
 
 func GetResult(r types.Result) (*Result, error) {

--- a/pkg/types/100/types.go
+++ b/pkg/types/100/types.go
@@ -28,20 +28,23 @@ import (
 
 const ImplementedSpecVersion string = "1.0.0"
 
-var SupportedVersions = []string{ImplementedSpecVersion}
+var supportedVersions = []string{ImplementedSpecVersion}
 
 // Register converters for all versions less than the implemented spec version
 func init() {
 	// Up-converters
-	convert.Register("0.1.0", SupportedVersions, convertFrom02x)
-	convert.Register("0.2.0", SupportedVersions, convertFrom02x)
-	convert.Register("0.3.0", SupportedVersions, convertFrom04x)
-	convert.Register("0.3.1", SupportedVersions, convertFrom04x)
-	convert.Register("0.4.0", SupportedVersions, convertFrom04x)
+	convert.RegisterConverter("0.1.0", supportedVersions, convertFrom02x)
+	convert.RegisterConverter("0.2.0", supportedVersions, convertFrom02x)
+	convert.RegisterConverter("0.3.0", supportedVersions, convertFrom04x)
+	convert.RegisterConverter("0.3.1", supportedVersions, convertFrom04x)
+	convert.RegisterConverter("0.4.0", supportedVersions, convertFrom04x)
 
 	// Down-converters
-	convert.Register("1.0.0", []string{"0.3.0", "0.3.1", "0.4.0"}, convertTo04x)
-	convert.Register("1.0.0", []string{"0.1.0", "0.2.0"}, convertTo02x)
+	convert.RegisterConverter("1.0.0", []string{"0.3.0", "0.3.1", "0.4.0"}, convertTo04x)
+	convert.RegisterConverter("1.0.0", []string{"0.1.0", "0.2.0"}, convertTo02x)
+
+	// Creator
+	convert.RegisterCreator(supportedVersions, NewResult)
 }
 
 func NewResult(data []byte) (types.Result, error) {
@@ -49,13 +52,13 @@ func NewResult(data []byte) (types.Result, error) {
 	if err := json.Unmarshal(data, result); err != nil {
 		return nil, err
 	}
-	for _, v := range SupportedVersions {
+	for _, v := range supportedVersions {
 		if result.CNIVersion == v {
 			return result, nil
 		}
 	}
 	return nil, fmt.Errorf("result type supports %v but unmarshalled CNIVersion is %q",
-		SupportedVersions, result.CNIVersion)
+		supportedVersions, result.CNIVersion)
 }
 
 func GetResult(r types.Result) (*Result, error) {

--- a/pkg/types/create/create.go
+++ b/pkg/types/create/create.go
@@ -1,0 +1,26 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package create
+
+import (
+	"github.com/containernetworking/cni/pkg/types"
+	convert "github.com/containernetworking/cni/pkg/types/internal"
+)
+
+// Create creates a CNI Result using the given JSON, or an error if the creation
+// could not be performed
+func Create(version string, bytes []byte) (types.Result, error) {
+	return convert.Create(version, bytes)
+}

--- a/pkg/types/internal/convert.go
+++ b/pkg/types/internal/convert.go
@@ -69,9 +69,9 @@ func Convert(from types.Result, toVersion string) (types.Result, error) {
 	return c.convertFn(from, toVersion)
 }
 
-// Register registers a CNI Result converter. SHOULD NOT BE CALLED
+// RegisterConverter registers a CNI Result converter. SHOULD NOT BE CALLED
 // EXCEPT FROM CNI ITSELF.
-func Register(fromVersion string, toVersions []string, convertFn ConvertFn) {
+func RegisterConverter(fromVersion string, toVersions []string, convertFn ConvertFn) {
 	// Make sure there is no converter already registered for these
 	// from and to versions
 	for _, v := range toVersions {

--- a/pkg/types/internal/create.go
+++ b/pkg/types/internal/create.go
@@ -1,0 +1,66 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"fmt"
+
+	"github.com/containernetworking/cni/pkg/types"
+)
+
+type ResultFactoryFunc func([]byte) (types.Result, error)
+
+type creator struct {
+	// CNI Result spec versions that createFn can create a Result for
+	versions []string
+	createFn ResultFactoryFunc
+}
+
+var creators []*creator
+
+func findCreator(version string) *creator {
+	for _, c := range creators {
+		for _, v := range c.versions {
+			if v == version {
+				return c
+			}
+		}
+	}
+	return nil
+}
+
+// Create creates a CNI Result using the given JSON, or an error if the creation
+// could not be performed
+func Create(version string, bytes []byte) (types.Result, error) {
+	if c := findCreator(version); c != nil {
+		return c.createFn(bytes)
+	}
+	return nil, fmt.Errorf("unsupported CNI result version %q", version)
+}
+
+// RegisterCreator registers a CNI Result creator. SHOULD NOT BE CALLED
+// EXCEPT FROM CNI ITSELF.
+func RegisterCreator(versions []string, createFn ResultFactoryFunc) {
+	// Make sure there is no creator already registered for these versions
+	for _, v := range versions {
+		if findCreator(v) != nil {
+			panic(fmt.Sprintf("creator already registered for %s", v))
+		}
+	}
+	creators = append(creators, &creator{
+		versions: versions,
+		createFn: createFn,
+	})
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -83,8 +83,6 @@ type NetConfList struct {
 	Plugins      []*NetConf `json:"plugins,omitempty"`
 }
 
-type ResultFactoryFunc func([]byte) (Result, error)
-
 // Result is an interface that provides the result of plugin execution
 type Result interface {
 	// The highest CNI specification result version the result supports

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -19,14 +19,13 @@ import (
 	"fmt"
 
 	"github.com/containernetworking/cni/pkg/types"
-	"github.com/containernetworking/cni/pkg/types/020"
-	"github.com/containernetworking/cni/pkg/types/040"
-	current "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/cni/pkg/types/create"
 )
 
 // Current reports the version of the CNI spec implemented by this library
 func Current() string {
-	return current.ImplementedSpecVersion
+	return types100.ImplementedSpecVersion
 }
 
 // Legacy PluginInfo describes a plugin that is backwards compatible with the
@@ -39,28 +38,10 @@ func Current() string {
 var Legacy = PluginSupports("0.1.0", "0.2.0")
 var All = PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0")
 
-var resultFactories = []struct {
-	supportedVersions []string
-	newResult         types.ResultFactoryFunc
-}{
-	{current.SupportedVersions, current.NewResult},
-	{types040.SupportedVersions, types040.NewResult},
-	{types020.SupportedVersions, types020.NewResult},
-}
-
 // Finds a Result object matching the requested version (if any) and asks
 // that object to parse the plugin result, returning an error if parsing failed.
 func NewResult(version string, resultBytes []byte) (types.Result, error) {
-	reconciler := &Reconciler{}
-	for _, resultFactory := range resultFactories {
-		err := reconciler.CheckRaw(version, resultFactory.supportedVersions)
-		if err == nil {
-			// Result supports this version
-			return resultFactory.newResult(resultBytes)
-		}
-	}
-
-	return nil, fmt.Errorf("unsupported CNI result version %q", version)
+	return create.Create(version, resultBytes)
 }
 
 // ParsePrevResult parses a prevResult in a NetConf structure and sets


### PR DESCRIPTION
SupportedVersions isn't really needed outside the types themselves.

@squeed @mccv1r0 @bboreham @matthewdupre 