### PR TITLE
cni:support for mips64le architecture.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   - TARGET=arm64
   - TARGET=ppc64le
   - TARGET=s390x
-
+  - TARGET=mips64le
 matrix:
   fast_finish: true
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -18,7 +18,7 @@ docker run -i -v ${SRC_DIR}:/opt/src --rm golang:1.14-alpine \
 /bin/sh -xe -c "\
     apk --no-cache add bash tar;
     cd /opt/src; umask 0022;
-    for arch in amd64 arm arm64 ppc64le s390x; do \
+    for arch in amd64 arm arm64 ppc64le s390x mips64le; do \
         rm -f ${OUTPUT_DIR}/* ; \
         CGO_ENABLED=0 GOARCH=\$arch ./build.sh ${BUILDFLAGS}; \
         for format in tgz; do \


### PR DESCRIPTION
Increase support for mips64le architecture, because golang language supports cross-compilation and supports the construction of mips64le cpu architecture, which makes it more convenient for users to use cni.
@dcbw
@eyakubovich