### PR TITLE
Spec: Bring 1.0's treatment of "args" in line with 0.4.0

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -68,7 +68,7 @@ But the runtime would fill in the mappings so the plugin itself would receive so
 | aliases | Provide a list of names that will be mapped to the IP addresses assigned to this interface. Other containers on the same network may use one of these names to access the container.| `aliases` | List of `alias` (string entry). <pre> ["my-container", "primary-db"] </pre> | none | CNI `alias` plugin |
 
 ## "args" in network config
-`args` in [network config](https://github.com/containernetworking/cni/blob/master/SPEC.md#network-configuration) were introduced as an optional field into the `0.2.0` release of the CNI spec. The first CNI code release that it appeared in was `v0.4.0`. 
+`args` in [network config](https://github.com/containernetworking/cni/blob/master/SPEC.md#network-configuration) were reserved as a  field in the `0.2.0` release of the CNI spec.
 > args (dictionary): Optional additional arguments provided by the container runtime. For example a dictionary of labels could be passed to CNI plugins by adding them to a labels field under args.
 
 `args` provide a way of providing more structured data than the flat strings that CNI_ARGS can support.
@@ -80,7 +80,7 @@ This method of passing information to a plugin is recommended when the informati
 The conventions documented here are all namespaced under `cni` so they don't conflict with any existing `args`.
 
 For example:
-```json
+```jsonc
 {  
    "cniVersion":"0.2.0",
    "name":"net",
@@ -89,9 +89,9 @@ For example:
          "labels": [{"key": "app", "value": "myapp"}]
       }
    },
-   <REST OF CNI CONFIG HERE>
+   // <REST OF CNI CONFIG HERE>
    "ipam":{  
-     <IPAM CONFIG HERE>
+   //  <IPAM CONFIG HERE>
    }
 }
 ```

--- a/SPEC.md
+++ b/SPEC.md
@@ -343,7 +343,7 @@ While a network configuration should not change between _attachments_, there are
 - **Container ID:** A unique plaintext identifier for a container, allocated by the runtime. Must not be empty.  Must start with a alphanumeric character, optionally followed by any combination of one or more alphanumeric characters, underscore (), dot (.) or hyphen (-). During execution, always set as the  `CNI_CONTAINERID` parameter.
 - **Namespace**: A reference to the container's "isolation domain". If using network namespaces, then a path to the network namespace (e.g. `/run/netns/[nsname]`). During execution, always set as the `CNI_NETNS` parameter.
 - **Container interface name**: Name of the interface to create inside the container. During execution, always set as the `CNI_IFNAME` parameter.
-- **Generic Arguments**: Extra arguments, in the form of key-value string pairs, that are relevant to a specific attachment.  During execution, always set as the `CNI_ARGS` parameter as well as provided in the generated configuration, see below.
+- **Generic Arguments**: Extra arguments, in the form of key-value string pairs, that are relevant to a specific attachment.  During execution, always set as the `CNI_ARGS` parameter.
 - **Capability Arguments**: These are also key-value pairs. The key is a string, whereas the value is any JSON-serializable type. The keys and values are defined by [convention](CONVENTIONS.md).
 
 Furthermore, the runtime must be provided a list of paths to search for CNI plugins. This must also be provided to plugins during execution via the `CNI_PATH` environment variable.
@@ -395,7 +395,6 @@ The execution configuration for a single plugin invocation is also JSON. It cons
 The following fields must be inserted into the execution configuration by the runtime:
 - `cniVersion`: taken from the `cniVersion` field of the network configuration
 - `name`: taken from the `name` field of the network configuration
-- `args`: A JSON object, consisting of the generic arguments provided as an attachment parameter
 - `runtimeConfig`: A JSON object, consisting of the union of capabilities provided by the plugin and requested by the runtime (more detail below)
 - `prevResult`: A JSON object, consisting of the result type returned by the "previous" plugin. The meaning of "previous" is defined by the specific operation (_add_, _delete_, or _check_).
 
@@ -406,7 +405,7 @@ All other fields should be passed through unaltered.
 
 #### Deriving `runtimeConfig`
 
-Whereas `args` and CNI_ARGS are provided to all plugins, with no indication if they are going to be consumed, _Capability arguments_ need to be declared explicitly in configuration. The runtime, thus, can determine if a given network configuration supports a specific _capability_. Capabilities are not defined by the specification - rather, they are documented [conventions](CONVENTIONS.md).
+Whereas CNI_ARGS are provided to all plugins, with no indication if they are going to be consumed, _Capability arguments_ need to be declared explicitly in configuration. The runtime, thus, can determine if a given network configuration supports a specific _capability_. Capabilities are not defined by the specification - rather, they are documented [conventions](CONVENTIONS.md).
 
 As defined in section 1, the plugin configuration includes an optional key, `capabilities`. This example shows a that supports the `portMapping` capability:
 
@@ -569,7 +568,6 @@ The container runtime would perform the following steps for the `add` operation.
     "type": "bridge",
     "bridge": "cni0",
     "keyA": ["some more", "plugin specific", "configuration"],
-    "args": {"argA": "foo"},
     "ipam": {
         "type": "host-local",
         "subnet": "10.1.0.0/16",
@@ -648,7 +646,6 @@ The plugin returns the following result, configuring the interface according to 
   "cniVersion": "1.0.0",
   "name": "dbnet",
   "type": "tuning",
-  "args": {"argA": "foo"},
   "sysctl": {
     "net.core.somaxconn": "500"
   },
@@ -734,7 +731,6 @@ The plugin returns the following result. Note that the **mac** has changed.
   "cniVersion": "1.0.0",
   "name": "dbnet",
   "type": "portmap",
-  "args": {"argA": "foo"},
   "runtimeConfig": {
     "portMappings" : [
       { "hostPort": 8080, "containerPort": 80, "protocol": "tcp" }
@@ -791,7 +787,6 @@ Given the previous _Add_, the container runtime would perform the following step
   "type": "bridge",
   "bridge": "cni0",
   "keyA": ["some more", "plugin specific", "configuration"],
-  "args": {"argA": "foo"},
   "ipam": {
     "type": "host-local",
     "subnet": "10.1.0.0/16",
@@ -846,7 +841,6 @@ Assuming the `bridge` plugin is satisfied, it produces no output on standard out
   "cniVersion": "1.0.0",
   "name": "dbnet",
   "type": "tuning",
-  "args": {"argA": "foo"},
   "sysctl": {
     "net.core.somaxconn": "500"
   },
@@ -897,7 +891,6 @@ Likewise, the `tuning` plugin exits indicating success.
   "cniVersion": "1.0.0",
   "name": "dbnet",
   "type": "portmap",
-  "args": {"argA": "foo"},
   "runtimeConfig": {
     "portMappings" : [
       { "hostPort": 8080, "containerPort": 80, "protocol": "tcp" }
@@ -951,7 +944,6 @@ Note that plugins are executed in reverse order from the _Add_ and _Check_ actio
   "cniVersion": "1.0.0",
   "name": "dbnet",
   "type": "portmap",
-  "args": {"argA": "foo"},
   "runtimeConfig": {
     "portMappings" : [
       { "hostPort": 8080, "containerPort": 80, "protocol": "tcp" }
@@ -1000,7 +992,6 @@ Note that plugins are executed in reverse order from the _Add_ and _Check_ actio
   "cniVersion": "1.0.0",
   "name": "dbnet",
   "type": "tuning",
-  "args": {"argA": "foo"},
   "sysctl": {
     "net.core.somaxconn": "500"
   },
@@ -1051,7 +1042,6 @@ Note that plugins are executed in reverse order from the _Add_ and _Check_ actio
   "type": "bridge",
   "bridge": "cni0",
   "keyA": ["some more", "plugin specific", "configuration"],
-  "args": {"argA": "foo"},
   "ipam": {
     "type": "host-local",
     "subnet": "10.1.0.0/16",


### PR DESCRIPTION
The spec deviated from the existing behavior, and it was never actually implemented in libcni. So this is a no-op.
    


Signed-off-by: Casey Callendrello <cdc@redhat.com>