### PR TITLE
Remove Bryan Boreham as maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,5 +1,4 @@
 Bruce Ma <brucema19901024@gmail.com> (@mars1024)
-Bryan Boreham <bryan@weave.works> (@bboreham)
 Casey Callendrello <cdc@redhat.com> (@squeed)
 Dan Williams <dcbw@redhat.com> (@dcbw)
 Gabe Rosenhouse <grosenhouse@pivotal.io> (@rosenhouse)


### PR DESCRIPTION
I am moving on from Weaveworks, and will not be working in the container networking domain.
