### PR TITLE
chore: support both value type and pointer type in LoadArgs

### DIFF
--- a/pkg/types/args.go
+++ b/pkg/types/args.go
@@ -91,12 +91,22 @@ func LoadArgs(args string, container interface{}) error {
 			unknownArgs = append(unknownArgs, pair)
 			continue
 		}
-		keyFieldIface := keyField.Addr().Interface()
-		u, ok := keyFieldIface.(encoding.TextUnmarshaler)
+
+		var keyFieldInterface interface{}
+		switch {
+		case keyField.Kind() == reflect.Ptr:
+			keyField.Set(reflect.New(keyField.Type().Elem()))
+			keyFieldInterface = keyField.Interface()
+		case keyField.CanAddr() && keyField.Addr().CanInterface():
+			keyFieldInterface = keyField.Addr().Interface()
+		default:
+			return UnmarshalableArgsError{fmt.Errorf("field '%s' has no valid interface", keyString)}
+		}
+		u, ok := keyFieldInterface.(encoding.TextUnmarshaler)
 		if !ok {
 			return UnmarshalableArgsError{fmt.Errorf(
 				"ARGS: cannot unmarshal into field '%s' - type '%s' does not implement encoding.TextUnmarshaler",
-				keyString, reflect.TypeOf(keyFieldIface))}
+				keyString, reflect.TypeOf(keyFieldInterface))}
 		}
 		err := u.UnmarshalText([]byte(valueString))
 		if err != nil {

--- a/pkg/types/args_test.go
+++ b/pkg/types/args_test.go
@@ -15,6 +15,7 @@
 package types_test
 
 import (
+	"net"
 	"reflect"
 
 	. "github.com/containernetworking/cni/pkg/types"
@@ -127,6 +128,37 @@ var _ = Describe("LoadArgs", func() {
 			err := LoadArgs("IP=10.0.0.0/24", &conf)
 			Expect(err).To(HaveOccurred())
 
+		})
+	})
+
+	Context("When loading known arguments", func() {
+		It("should succeed if argument is marshallable value type", func() {
+			conf := struct {
+				IP net.IP
+				CommonArgs
+			}{}
+			err := LoadArgs("IP=10.0.0.0", &conf)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(conf.IP.String()).To(Equal("10.0.0.0"))
+		})
+
+		It("should succeed if argument is marshallable pointer type", func() {
+			conf := struct {
+				IP *net.IP
+				CommonArgs
+			}{}
+			err := LoadArgs("IP=10.0.0.0", &conf)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(conf.IP.String()).To(Equal("10.0.0.0"))
+		})
+
+		It("should fail if argument is pointer of marshallable pointer type", func() {
+			conf := struct {
+				IP **net.IP
+				CommonArgs
+			}{}
+			err := LoadArgs("IP=10.0.0.0", &conf)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
During the implementation of [https://github.com/containernetworking/plugins/pull/630](https://github.com/containernetworking/plugins/pull/630), I found that field with pointer type `*net.IP` can not be parsed by `LoadArgs`, but this is working on `json.Unmarshal`.

This PR is trying to support both value type and pointer type which have `encoding.TextUnmarshaler` interface in `LoadArgs`.

Signed-off-by: Bruce Ma <brucema19901024@gmail.com>