### PR TITLE
types/create: add CreateFromBytes()

### DIFF
--- a/pkg/invoke/exec.go
+++ b/pkg/invoke/exec.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/create"
 	"github.com/containernetworking/cni/pkg/version"
 )
 
@@ -83,14 +84,7 @@ func ExecPluginWithResult(ctx context.Context, pluginPath string, netconf []byte
 		return nil, err
 	}
 
-	// Plugin must return result in same version as specified in netconf
-	versionDecoder := &version.ConfigDecoder{}
-	confVersion, err := versionDecoder.Decode(netconf)
-	if err != nil {
-		return nil, err
-	}
-
-	return version.NewResult(confVersion, stdoutBytes)
+	return create.CreateFromBytes(stdoutBytes)
 }
 
 func ExecPluginWithoutResult(ctx context.Context, pluginPath string, netconf []byte, args CNIArgs, exec Exec) error {

--- a/pkg/types/create/create.go
+++ b/pkg/types/create/create.go
@@ -15,12 +15,42 @@
 package create
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/containernetworking/cni/pkg/types"
 	convert "github.com/containernetworking/cni/pkg/types/internal"
 )
 
-// Create creates a CNI Result using the given JSON, or an error if the creation
-// could not be performed
+// DecodeVersion returns the CNI version from CNI configuration or result JSON,
+// or an error if the operation could not be performed.
+func DecodeVersion(jsonBytes []byte) (string, error) {
+	var conf struct {
+		CNIVersion string `json:"cniVersion"`
+	}
+	err := json.Unmarshal(jsonBytes, &conf)
+	if err != nil {
+		return "", fmt.Errorf("decoding version from network config: %s", err)
+	}
+	if conf.CNIVersion == "" {
+		return "0.1.0", nil
+	}
+	return conf.CNIVersion, nil
+}
+
+// Create creates a CNI Result using the given JSON with the expected
+// version, or an error if the creation could not be performed
 func Create(version string, bytes []byte) (types.Result, error) {
+	return convert.Create(version, bytes)
+}
+
+// CreateFromBytes creates a CNI Result from the given JSON, automatically
+// detecting the CNI spec version of the result. An error is returned if the
+// operation could not be performed.
+func CreateFromBytes(bytes []byte) (types.Result, error) {
+	version, err := DecodeVersion(bytes)
+	if err != nil {
+		return nil, err
+	}
 	return convert.Create(version, bytes)
 }

--- a/pkg/version/conf.go
+++ b/pkg/version/conf.go
@@ -15,23 +15,12 @@
 package version
 
 import (
-	"encoding/json"
-	"fmt"
+	"github.com/containernetworking/cni/pkg/types/create"
 )
 
 // ConfigDecoder can decode the CNI version available in network config data
 type ConfigDecoder struct{}
 
 func (*ConfigDecoder) Decode(jsonBytes []byte) (string, error) {
-	var conf struct {
-		CNIVersion string `json:"cniVersion"`
-	}
-	err := json.Unmarshal(jsonBytes, &conf)
-	if err != nil {
-		return "", fmt.Errorf("decoding version from network config: %s", err)
-	}
-	if conf.CNIVersion == "" {
-		return "0.1.0", nil
-	}
-	return conf.CNIVersion, nil
+	return create.DecodeVersion(jsonBytes)
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -64,7 +64,7 @@ func ParsePrevResult(conf *types.NetConf) error {
 	}
 
 	conf.RawPrevResult = nil
-	conf.PrevResult, err = NewResult(conf.CNIVersion, resultBytes)
+	conf.PrevResult, err = create.Create(conf.CNIVersion, resultBytes)
 	if err != nil {
 		return fmt.Errorf("could not parse prevResult: %v", err)
 	}


### PR DESCRIPTION
Turns out a number of users want to read in JSON and
create a Result object from it, and CNI didn't have
a function to do that in one call. Instead you had to
create a ConfigDecoder first, then create a Result
from the given version.

That's silly, let's just make a function to do that
and let everyone do less work.

@mccv1r0 @mars1024 @squeed @jellonek @jayunit100