### PR TITLE
wrap returned errors

### DIFF
--- a/libcni/api.go
+++ b/libcni/api.go
@@ -285,7 +285,7 @@ func (c *CNIConfig) getCachedConfig(netName string, rt *RuntimeConf) ([]byte, *R
 
 	unmarshaled := cachedInfo{}
 	if err := json.Unmarshal(bytes, &unmarshaled); err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal cached network %q config: %v", netName, err)
+		return nil, nil, fmt.Errorf("failed to unmarshal cached network %q config: %w", netName, err)
 	}
 	if unmarshaled.Kind != CNICacheV1 {
 		return nil, nil, fmt.Errorf("read cached network %q config has wrong kind: %v", netName, unmarshaled.Kind)
@@ -323,7 +323,7 @@ func (c *CNIConfig) getLegacyCachedResult(netName, cniVersion string, rt *Runtim
 	// while the container was running.
 	result, err = result.GetAsVersion(cniVersion)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert cached result to config version %q: %v", cniVersion, err)
+		return nil, fmt.Errorf("failed to convert cached result to config version %q: %w", cniVersion, err)
 	}
 	return result, nil
 }
@@ -346,7 +346,7 @@ func (c *CNIConfig) getCachedResult(netName, cniVersion string, rt *RuntimeConf)
 
 	newBytes, err := json.Marshal(&cachedInfo.RawResult)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal cached network %q config: %v", netName, err)
+		return nil, fmt.Errorf("failed to marshal cached network %q config: %w", netName, err)
 	}
 
 	// Load the cached result
@@ -361,7 +361,7 @@ func (c *CNIConfig) getCachedResult(netName, cniVersion string, rt *RuntimeConf)
 	// while the container was running.
 	result, err = result.GetAsVersion(cniVersion)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert cached result to config version %q: %v", cniVersion, err)
+		return nil, fmt.Errorf("failed to convert cached result to config version %q: %w", cniVersion, err)
 	}
 	return result, nil
 }
@@ -426,7 +426,7 @@ func (c *CNIConfig) AddNetworkList(ctx context.Context, list *NetworkConfigList,
 	}
 
 	if err = c.cacheAdd(result, list.Bytes, list.Name, rt); err != nil {
-		return nil, fmt.Errorf("failed to set network %q cached result: %v", list.Name, err)
+		return nil, fmt.Errorf("failed to set network %q cached result: %w", list.Name, err)
 	}
 
 	return result, nil
@@ -462,7 +462,7 @@ func (c *CNIConfig) CheckNetworkList(ctx context.Context, list *NetworkConfigLis
 
 	cachedResult, err := c.getCachedResult(list.Name, list.CNIVersion, rt)
 	if err != nil {
-		return fmt.Errorf("failed to get network %q cached result: %v", list.Name, err)
+		return fmt.Errorf("failed to get network %q cached result: %w", list.Name, err)
 	}
 
 	for _, net := range list.Plugins {
@@ -499,7 +499,7 @@ func (c *CNIConfig) DelNetworkList(ctx context.Context, list *NetworkConfigList,
 	} else if gtet {
 		cachedResult, err = c.getCachedResult(list.Name, list.CNIVersion, rt)
 		if err != nil {
-			return fmt.Errorf("failed to get network %q cached result: %v", list.Name, err)
+			return fmt.Errorf("failed to get network %q cached result: %w", list.Name, err)
 		}
 	}
 
@@ -535,7 +535,7 @@ func (c *CNIConfig) AddNetwork(ctx context.Context, net *NetworkConfig, rt *Runt
 	}
 
 	if err = c.cacheAdd(result, net.Bytes, net.Network.Name, rt); err != nil {
-		return nil, fmt.Errorf("failed to set network %q cached result: %v", net.Network.Name, err)
+		return nil, fmt.Errorf("failed to set network %q cached result: %w", net.Network.Name, err)
 	}
 
 	return result, nil
@@ -552,7 +552,7 @@ func (c *CNIConfig) CheckNetwork(ctx context.Context, net *NetworkConfig, rt *Ru
 
 	cachedResult, err := c.getCachedResult(net.Network.Name, net.Network.CNIVersion, rt)
 	if err != nil {
-		return fmt.Errorf("failed to get network %q cached result: %v", net.Network.Name, err)
+		return fmt.Errorf("failed to get network %q cached result: %w", net.Network.Name, err)
 	}
 	return c.checkNetwork(ctx, net.Network.Name, net.Network.CNIVersion, net, cachedResult, rt)
 }
@@ -567,7 +567,7 @@ func (c *CNIConfig) DelNetwork(ctx context.Context, net *NetworkConfig, rt *Runt
 	} else if gtet {
 		cachedResult, err = c.getCachedResult(net.Network.Name, net.Network.CNIVersion, rt)
 		if err != nil {
-			return fmt.Errorf("failed to get network %q cached result: %v", net.Network.Name, err)
+			return fmt.Errorf("failed to get network %q cached result: %w", net.Network.Name, err)
 		}
 	}
 

--- a/libcni/conf.go
+++ b/libcni/conf.go
@@ -43,7 +43,7 @@ func (e NoConfigsFoundError) Error() string {
 func ConfFromBytes(bytes []byte) (*NetworkConfig, error) {
 	conf := &NetworkConfig{Bytes: bytes}
 	if err := json.Unmarshal(bytes, &conf.Network); err != nil {
-		return nil, fmt.Errorf("error parsing configuration: %s", err)
+		return nil, fmt.Errorf("error parsing configuration: %w", err)
 	}
 	if conf.Network.Type == "" {
 		return nil, fmt.Errorf("error parsing configuration: missing 'type'")
@@ -54,7 +54,7 @@ func ConfFromBytes(bytes []byte) (*NetworkConfig, error) {
 func ConfFromFile(filename string) (*NetworkConfig, error) {
 	bytes, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return nil, fmt.Errorf("error reading %s: %s", filename, err)
+		return nil, fmt.Errorf("error reading %s: %w", filename, err)
 	}
 	return ConfFromBytes(bytes)
 }
@@ -62,7 +62,7 @@ func ConfFromFile(filename string) (*NetworkConfig, error) {
 func ConfListFromBytes(bytes []byte) (*NetworkConfigList, error) {
 	rawList := make(map[string]interface{})
 	if err := json.Unmarshal(bytes, &rawList); err != nil {
-		return nil, fmt.Errorf("error parsing configuration list: %s", err)
+		return nil, fmt.Errorf("error parsing configuration list: %w", err)
 	}
 
 	rawName, ok := rawList["name"]
@@ -114,11 +114,11 @@ func ConfListFromBytes(bytes []byte) (*NetworkConfigList, error) {
 	for i, conf := range plugins {
 		newBytes, err := json.Marshal(conf)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal plugin config %d: %v", i, err)
+			return nil, fmt.Errorf("failed to marshal plugin config %d: %w", i, err)
 		}
 		netConf, err := ConfFromBytes(newBytes)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse plugin config %d: %v", i, err)
+			return nil, fmt.Errorf("failed to parse plugin config %d: %w", i, err)
 		}
 		list.Plugins = append(list.Plugins, netConf)
 	}
@@ -129,7 +129,7 @@ func ConfListFromBytes(bytes []byte) (*NetworkConfigList, error) {
 func ConfListFromFile(filename string) (*NetworkConfigList, error) {
 	bytes, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return nil, fmt.Errorf("error reading %s: %s", filename, err)
+		return nil, fmt.Errorf("error reading %s: %w", filename, err)
 	}
 	return ConfListFromBytes(bytes)
 }
@@ -218,7 +218,7 @@ func InjectConf(original *NetworkConfig, newValues map[string]interface{}) (*Net
 	config := make(map[string]interface{})
 	err := json.Unmarshal(original.Bytes, &config)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshal existing network bytes: %s", err)
+		return nil, fmt.Errorf("unmarshal existing network bytes: %w", err)
 	}
 
 	for key, value := range newValues {

--- a/pkg/types/args.go
+++ b/pkg/types/args.go
@@ -110,7 +110,7 @@ func LoadArgs(args string, container interface{}) error {
 		}
 		err := u.UnmarshalText([]byte(valueString))
 		if err != nil {
-			return fmt.Errorf("ARGS: error parsing value of pair %q: %v)", pair, err)
+			return fmt.Errorf("ARGS: error parsing value of pair %q: %w", pair, err)
 		}
 	}
 

--- a/pkg/types/create/create.go
+++ b/pkg/types/create/create.go
@@ -30,7 +30,7 @@ func DecodeVersion(jsonBytes []byte) (string, error) {
 	}
 	err := json.Unmarshal(jsonBytes, &conf)
 	if err != nil {
-		return "", fmt.Errorf("decoding version from network config: %s", err)
+		return "", fmt.Errorf("decoding version from network config: %w", err)
 	}
 	if conf.CNIVersion == "" {
 		return "0.1.0", nil

--- a/pkg/version/legacy_examples/example_runtime.go
+++ b/pkg/version/legacy_examples/example_runtime.go
@@ -110,7 +110,7 @@ func (e *ExampleRuntime) GenerateNetConf(name string) (*ExampleNetConf, error) {
 
 	debugFile, err := ioutil.TempFile("", "cni_debug")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create noop plugin debug file: %v", err)
+		return nil, fmt.Errorf("failed to create noop plugin debug file: %w", err)
 	}
 	debugFilePath := debugFile.Name()
 
@@ -119,7 +119,7 @@ func (e *ExampleRuntime) GenerateNetConf(name string) (*ExampleNetConf, error) {
 	}
 	if err := debug.WriteDebug(debugFilePath); err != nil {
 		os.Remove(debugFilePath)
-		return nil, fmt.Errorf("failed to write noop plugin debug file %q: %v", debugFilePath, err)
+		return nil, fmt.Errorf("failed to write noop plugin debug file %q: %w", debugFilePath, err)
 	}
 	conf := &ExampleNetConf{
 		Config:        fmt.Sprintf(template.conf, debugFilePath),

--- a/pkg/version/plugin.go
+++ b/pkg/version/plugin.go
@@ -68,7 +68,7 @@ func (*PluginDecoder) Decode(jsonBytes []byte) (PluginInfo, error) {
 	var info pluginInfo
 	err := json.Unmarshal(jsonBytes, &info)
 	if err != nil {
-		return nil, fmt.Errorf("decoding version info: %s", err)
+		return nil, fmt.Errorf("decoding version info: %w", err)
 	}
 	if info.CNIVersion_ == "" {
 		return nil, fmt.Errorf("decoding version info: missing field cniVersion")
@@ -97,20 +97,20 @@ func ParseVersion(version string) (int, int, int, error) {
 
 	major, err := strconv.Atoi(parts[0])
 	if err != nil {
-		return -1, -1, -1, fmt.Errorf("failed to convert major version part %q: %v", parts[0], err)
+		return -1, -1, -1, fmt.Errorf("failed to convert major version part %q: %w", parts[0], err)
 	}
 
 	if len(parts) >= 2 {
 		minor, err = strconv.Atoi(parts[1])
 		if err != nil {
-			return -1, -1, -1, fmt.Errorf("failed to convert minor version part %q: %v", parts[1], err)
+			return -1, -1, -1, fmt.Errorf("failed to convert minor version part %q: %w", parts[1], err)
 		}
 	}
 
 	if len(parts) >= 3 {
 		micro, err = strconv.Atoi(parts[2])
 		if err != nil {
-			return -1, -1, -1, fmt.Errorf("failed to convert micro version part %q: %v", parts[2], err)
+			return -1, -1, -1, fmt.Errorf("failed to convert micro version part %q: %w", parts[2], err)
 		}
 	}
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -60,13 +60,13 @@ func ParsePrevResult(conf *types.NetConf) error {
 
 	resultBytes, err := json.Marshal(conf.RawPrevResult)
 	if err != nil {
-		return fmt.Errorf("could not serialize prevResult: %v", err)
+		return fmt.Errorf("could not serialize prevResult: %w", err)
 	}
 
 	conf.RawPrevResult = nil
 	conf.PrevResult, err = create.Create(conf.CNIVersion, resultBytes)
 	if err != nil {
-		return fmt.Errorf("could not parse prevResult: %v", err)
+		return fmt.Errorf("could not parse prevResult: %w", err)
 	}
 
 	return nil

--- a/plugins/test/noop/main.go
+++ b/plugins/test/noop/main.go
@@ -44,7 +44,7 @@ type NetConf struct {
 func loadConf(bytes []byte) (*NetConf, error) {
 	n := &NetConf{}
 	if err := json.Unmarshal(bytes, n); err != nil {
-		return nil, fmt.Errorf("failed to load netconf: %v %q", err, string(bytes))
+		return nil, fmt.Errorf("failed to load netconf: %w %q", err, string(bytes))
 	}
 	if err := version.ParsePrevResult(&n.NetConf); err != nil {
 		return nil, err
@@ -139,11 +139,11 @@ func debugBehavior(args *skel.CmdArgs, command string) error {
 		// Must print the prevResult as the CNIVersion of the config
 		newResult, err := prevResult.GetAsVersion(netConf.CNIVersion)
 		if err != nil {
-			return fmt.Errorf("failed to convert result to config %q: %v", netConf.CNIVersion, err)
+			return fmt.Errorf("failed to convert result to config %q: %w", netConf.CNIVersion, err)
 		}
 		resultBytes, err := json.Marshal(newResult)
 		if err != nil {
-			return fmt.Errorf("failed to marshal new result: %v", err)
+			return fmt.Errorf("failed to marshal new result: %w", err)
 		}
 		_, err = os.Stdout.WriteString(string(resultBytes))
 		if err != nil {


### PR DESCRIPTION
`fmt.Errorf` errors should wrap the original error with `%w`.
This allows the caller to check the errors with `errors.Is()`.

see: https://blog.golang.org/go1.13-errors