### PR TITLE
Remove Gabe Rosenhouse as maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,7 +1,6 @@
 Bruce Ma <brucema19901024@gmail.com> (@mars1024)
 Casey Callendrello <cdc@redhat.com> (@squeed)
 Dan Williams <dcbw@redhat.com> (@dcbw)
-Gabe Rosenhouse <grosenhouse@pivotal.io> (@rosenhouse)
 Matt Dupre <matt@tigera.io> (@matthewdupre)
 Michael Cambria <mcambria@redhat.com> (@mccv1r0)
 Piotr Skamruk <piotr.skamruk@gmail.com> (@jellonek)


### PR DESCRIPTION
I haven't been active in a long time!  But also, I'm moving teams at VMware and won't be involved with container networking going forward.