### PR TITLE
Fix incorrect pointer inputs to `json.Unmarshal`

### DIFF
--- a/libcni/conf.go
+++ b/libcni/conf.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+
+	"github.com/containernetworking/cni/pkg/types"
 )
 
 type NotFoundError struct {
@@ -41,8 +43,8 @@ func (e NoConfigsFoundError) Error() string {
 }
 
 func ConfFromBytes(bytes []byte) (*NetworkConfig, error) {
-	conf := &NetworkConfig{Bytes: bytes}
-	if err := json.Unmarshal(bytes, &conf.Network); err != nil {
+	conf := &NetworkConfig{Bytes: bytes, Network: &types.NetConf{}}
+	if err := json.Unmarshal(bytes, conf.Network); err != nil {
 		return nil, fmt.Errorf("error parsing configuration: %w", err)
 	}
 	if conf.Network.Type == "" {

--- a/pkg/types/040/types_test.go
+++ b/pkg/types/040/types_test.go
@@ -348,7 +348,7 @@ var _ = Describe("040 types operations", func() {
 }`))
 
 		recovered := &types040.IPConfig{}
-		Expect(json.Unmarshal(jsonBytes, &recovered)).To(Succeed())
+		Expect(json.Unmarshal(jsonBytes, recovered)).To(Succeed())
 		Expect(recovered).To(Equal(ipc))
 	})
 
@@ -363,7 +363,7 @@ var _ = Describe("040 types operations", func() {
 	Context("when unmarshalling json fails", func() {
 		It("returns an error", func() {
 			recovered := &types040.IPConfig{}
-			err := json.Unmarshal([]byte(`{"address": 5}`), &recovered)
+			err := json.Unmarshal([]byte(`{"address": 5}`), recovered)
 			Expect(err).To(MatchError(HavePrefix("json: cannot unmarshal")))
 		})
 	})

--- a/pkg/types/100/types_test.go
+++ b/pkg/types/100/types_test.go
@@ -295,14 +295,14 @@ var _ = Describe("Current types operations", func() {
 }`))
 
 		recovered := &current.IPConfig{}
-		Expect(json.Unmarshal(jsonBytes, &recovered)).To(Succeed())
+		Expect(json.Unmarshal(jsonBytes, recovered)).To(Succeed())
 		Expect(recovered).To(Equal(ipc))
 	})
 
 	Context("when unmarshalling json fails", func() {
 		It("returns an error", func() {
 			recovered := &current.IPConfig{}
-			err := json.Unmarshal([]byte(`{"address": 5}`), &recovered)
+			err := json.Unmarshal([]byte(`{"address": 5}`), recovered)
 			Expect(err).To(MatchError(HavePrefix("json: cannot unmarshal")))
 		})
 	})


### PR DESCRIPTION
See https://github.com/howardjohn/go-unmarshal-double-pointer for more
info on why this is not safe and how this is detected.