### PR TITLE
libcni: handle empty version when parsing version

### DIFF
--- a/libcni/backwards_compatibility_test.go
+++ b/libcni/backwards_compatibility_test.go
@@ -66,6 +66,9 @@ var _ = Describe("Backwards compatibility", func() {
 
 		Expect(result).To(Equal(legacy_examples.ExpectedResult))
 
+		err = cniConfig.DelNetwork(context.TODO(), netConf, runtimeConf)
+		Expect(err).NotTo(HaveOccurred())
+
 		Expect(os.RemoveAll(pluginPath)).To(Succeed())
 	})
 

--- a/pkg/version/plugin.go
+++ b/pkg/version/plugin.go
@@ -86,8 +86,8 @@ func (*PluginDecoder) Decode(jsonBytes []byte) (PluginInfo, error) {
 // minor, and micro numbers or returns an error
 func ParseVersion(version string) (int, int, int, error) {
 	var major, minor, micro int
-	if version == "" {
-		return -1, -1, -1, fmt.Errorf("invalid version %q: the version is empty", version)
+	if version == "" { // special case: no version declared == v0.1.0
+		return 0, 1, 0, nil
 	}
 
 	parts := strings.Split(version, ".")

--- a/pkg/version/plugin_test.go
+++ b/pkg/version/plugin_test.go
@@ -91,8 +91,16 @@ var _ = Describe("Decoding versions reported by a plugin", func() {
 			Expect(micro).To(Equal(3))
 		})
 
+		It("parses an empty string as v0.1.0", func() {
+			major, minor, micro, err := version.ParseVersion("")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(major).To(Equal(0))
+			Expect(minor).To(Equal(1))
+			Expect(micro).To(Equal(0))
+		})
+
 		It("returns an error for malformed versions", func() {
-			badVersions := []string{"asdfasdf", "asdf.", ".asdfas", "asdf.adsf.", "0.", "..", "1.2.3.4.5", ""}
+			badVersions := []string{"asdfasdf", "asdf.", ".asdfas", "asdf.adsf.", "0.", "..", "1.2.3.4.5"}
 			for _, v := range badVersions {
 				_, _, _, err := version.ParseVersion(v)
 				Expect(err).To(HaveOccurred())


### PR DESCRIPTION
Without this Delete failed for empty-version configs.

Update the tests to catch this case.

Signed-off-by: Casey Callendrello <cdc@redhat.com>