### PR TITLE
Add definition for attachment

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -64,11 +64,12 @@ Released versions of the spec are available as Git tags.
 
 This document proposes a generic plugin-based networking solution for application containers on Linux, the _Container Networking Interface_, or _CNI_.
 
-For the purposes of this proposal, we define three terms very specifically:
+For the purposes of this proposal, we define five terms very specifically:
 - _container_ is a network isolation domain, though the actual isolation technology is not defined by the specification. This could be a [network namespace][namespaces] or a virtual machine, for example.
 - _network_ refers to a group of endpoints that are uniquely addressable that can communicate amongst each other. This could be either an individual container (as specified above), a machine, or some other network device (e.g. a router). Containers can be conceptually _added to_ or _removed from_ one or more networks.
 - _runtime_ is the program responsible for executing CNI plugins.
 - _plugin_ is a program that applies a specified network configuration.
+- _attachment is the medium that connects the container to network.
 
 This document aims to specify the interface between "runtimes" and "plugins". The key words "must", "must not", "required", "shall", "shall not", "should", "should not", "recommended", "may" and "optional" are used as specified in [RFC 2119][rfc-2119].
 


### PR DESCRIPTION
I noticed we used attachment a few times in the spec and wanted to add it terminology. At a minimum if this is not added we should correct three to four. 