### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/libcni/api.go
+++ b/libcni/api.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -260,7 +259,7 @@ func (c *CNIConfig) cacheAdd(result types.Result, config []byte, netName string,
 		return err
 	}
 
-	return ioutil.WriteFile(fname, newBytes, 0600)
+	return os.WriteFile(fname, newBytes, 0600)
 }
 
 func (c *CNIConfig) cacheDel(netName string, rt *RuntimeConf) error {
@@ -279,7 +278,7 @@ func (c *CNIConfig) getCachedConfig(netName string, rt *RuntimeConf) ([]byte, *R
 	if err != nil {
 		return nil, nil, err
 	}
-	bytes, err = ioutil.ReadFile(fname)
+	bytes, err = os.ReadFile(fname)
 	if err != nil {
 		// Ignore read errors; the cached result may not exist on-disk
 		return nil, nil, nil
@@ -307,7 +306,7 @@ func (c *CNIConfig) getLegacyCachedResult(netName, cniVersion string, rt *Runtim
 	if err != nil {
 		return nil, err
 	}
-	data, err := ioutil.ReadFile(fname)
+	data, err := os.ReadFile(fname)
 	if err != nil {
 		// Ignore read errors; the cached result may not exist on-disk
 		return nil, nil
@@ -335,7 +334,7 @@ func (c *CNIConfig) getCachedResult(netName, cniVersion string, rt *RuntimeConf)
 	if err != nil {
 		return nil, err
 	}
-	fdata, err := ioutil.ReadFile(fname)
+	fdata, err := os.ReadFile(fname)
 	if err != nil {
 		// Ignore read errors; the cached result may not exist on-disk
 		return nil, nil

--- a/libcni/backwards_compatibility_test.go
+++ b/libcni/backwards_compatibility_test.go
@@ -17,7 +17,6 @@ package libcni_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -36,7 +35,7 @@ var _ = Describe("Backwards compatibility", func() {
 
 	BeforeEach(func() {
 		var err error
-		cacheDirPath, err = ioutil.TempDir("", "cni_cachedir")
+		cacheDirPath, err = os.MkdirTemp("", "cni_cachedir")
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/libcni/conf.go
+++ b/libcni/conf.go
@@ -17,7 +17,6 @@ package libcni
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -55,7 +54,7 @@ func ConfFromBytes(bytes []byte) (*NetworkConfig, error) {
 }
 
 func ConfFromFile(filename string) (*NetworkConfig, error) {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %w", filename, err)
 	}
@@ -140,7 +139,7 @@ func ConfListFromBytes(bytes []byte) (*NetworkConfigList, error) {
 }
 
 func ConfListFromFile(filename string) (*NetworkConfigList, error) {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %w", filename, err)
 	}
@@ -149,7 +148,7 @@ func ConfListFromFile(filename string) (*NetworkConfigList, error) {
 
 func ConfFiles(dir string, extensions []string) ([]string, error) {
 	// In part, adapted from rkt/networking/podenv.go#listFiles
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	switch {
 	case err == nil: // break
 	case os.IsNotExist(err):

--- a/libcni/conf_test.go
+++ b/libcni/conf_test.go
@@ -16,7 +16,6 @@ package libcni_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -35,11 +34,11 @@ var _ = Describe("Loading configuration from disk", func() {
 
 		BeforeEach(func() {
 			var err error
-			configDir, err = ioutil.TempDir("", "plugin-conf")
+			configDir, err = os.MkdirTemp("", "plugin-conf")
 			Expect(err).NotTo(HaveOccurred())
 
 			pluginConfig = []byte(`{ "name": "some-plugin", "type": "foobar", "some-key": "some-value" }`)
-			Expect(ioutil.WriteFile(filepath.Join(configDir, "50-whatever.conf"), pluginConfig, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(configDir, "50-whatever.conf"), pluginConfig, 0600)).To(Succeed())
 		})
 
 		AfterEach(func() {
@@ -73,7 +72,7 @@ var _ = Describe("Loading configuration from disk", func() {
 			BeforeEach(func() {
 				Expect(os.Remove(configDir + "/50-whatever.conf")).To(Succeed())
 				pluginConfig = []byte(`{ "name": "some-plugin", "some-key": "some-value", "type": "foobar" }`)
-				Expect(ioutil.WriteFile(filepath.Join(configDir, "50-whatever.json"), pluginConfig, 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(configDir, "50-whatever.json"), pluginConfig, 0600)).To(Succeed())
 			})
 			It("finds the network config file for the plugin of the given type", func() {
 				netConfig, err := libcni.LoadConf(configDir, "some-plugin")
@@ -97,7 +96,7 @@ var _ = Describe("Loading configuration from disk", func() {
 
 		Context("when a config file is malformed", func() {
 			BeforeEach(func() {
-				Expect(ioutil.WriteFile(filepath.Join(configDir, "00-bad.conf"), []byte(`{`), 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(configDir, "00-bad.conf"), []byte(`{`), 0600)).To(Succeed())
 			})
 
 			It("returns a useful error", func() {
@@ -112,7 +111,7 @@ var _ = Describe("Loading configuration from disk", func() {
 				Expect(os.MkdirAll(subdir, 0700)).To(Succeed())
 
 				pluginConfig = []byte(`{ "name": "deep", "some-key": "some-value" }`)
-				Expect(ioutil.WriteFile(filepath.Join(subdir, "90-deep.conf"), pluginConfig, 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(subdir, "90-deep.conf"), pluginConfig, 0600)).To(Succeed())
 			})
 
 			It("will not find the config", func() {
@@ -127,11 +126,11 @@ var _ = Describe("Loading configuration from disk", func() {
 
 		BeforeEach(func() {
 			var err error
-			configDir, err = ioutil.TempDir("", "plugin-conf")
+			configDir, err = os.MkdirTemp("", "plugin-conf")
 			Expect(err).NotTo(HaveOccurred())
 
 			pluginConfig := []byte(`{ "name": "some-plugin", "type": "noop", "cniVersion": "0.3.1", "capabilities": { "portMappings": true, "somethingElse": true, "noCapability": false } }`)
-			Expect(ioutil.WriteFile(filepath.Join(configDir, "50-whatever.conf"), pluginConfig, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(configDir, "50-whatever.conf"), pluginConfig, 0600)).To(Succeed())
 		})
 
 		AfterEach(func() {
@@ -161,12 +160,12 @@ var _ = Describe("Loading configuration from disk", func() {
 			var fileName, configDir string
 			BeforeEach(func() {
 				var err error
-				configDir, err = ioutil.TempDir("", "plugin-conf")
+				configDir, err = os.MkdirTemp("", "plugin-conf")
 				Expect(err).NotTo(HaveOccurred())
 
 				fileName = filepath.Join(configDir, "50-whatever.conf")
 				pluginConfig := []byte(`{ "name": "some-plugin", "some-key": "some-value" }`)
-				Expect(ioutil.WriteFile(fileName, pluginConfig, 0600)).To(Succeed())
+				Expect(os.WriteFile(fileName, pluginConfig, 0600)).To(Succeed())
 			})
 
 			AfterEach(func() {
@@ -197,7 +196,7 @@ var _ = Describe("Loading configuration from disk", func() {
 
 		BeforeEach(func() {
 			var err error
-			configDir, err = ioutil.TempDir("", "plugin-conf")
+			configDir, err = os.MkdirTemp("", "plugin-conf")
 			Expect(err).NotTo(HaveOccurred())
 
 			configList = []byte(`{
@@ -219,7 +218,7 @@ var _ = Describe("Loading configuration from disk", func() {
     }
   ]
 }`)
-			Expect(ioutil.WriteFile(filepath.Join(configDir, "50-whatever.conflist"), configList, 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(configDir, "50-whatever.conflist"), configList, 0600)).To(Succeed())
 		})
 
 		AfterEach(func() {
@@ -258,7 +257,7 @@ var _ = Describe("Loading configuration from disk", func() {
 					"cniVersion": "0.2.0",
 					"type": "bridge"
 				}`)
-				Expect(ioutil.WriteFile(filepath.Join(configDir, "49-whatever.conf"), configFile, 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(configDir, "49-whatever.conf"), configFile, 0600)).To(Succeed())
 			})
 
 			It("Loads the config list first", func() {
@@ -297,7 +296,7 @@ var _ = Describe("Loading configuration from disk", func() {
 
 		Context("when a config file is malformed", func() {
 			BeforeEach(func() {
-				Expect(ioutil.WriteFile(filepath.Join(configDir, "00-bad.conflist"), []byte(`{`), 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(configDir, "00-bad.conflist"), []byte(`{`), 0600)).To(Succeed())
 			})
 
 			It("returns a useful error", func() {
@@ -321,7 +320,7 @@ var _ = Describe("Loading configuration from disk", func() {
     },
   ]
 }`)
-				Expect(ioutil.WriteFile(filepath.Join(subdir, "90-deep.conflist"), configList, 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(subdir, "90-deep.conflist"), configList, 0600)).To(Succeed())
 			})
 
 			It("will not find the config", func() {
@@ -343,7 +342,7 @@ var _ = Describe("Loading configuration from disk", func() {
 				    }
 				  ]
 				}`)
-				Expect(ioutil.WriteFile(filepath.Join(configDir, "50-whatever.conflist"), configList, 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(configDir, "50-whatever.conflist"), configList, 0600)).To(Succeed())
 
 				netConfigList, err := libcni.LoadConfList(configDir, "some-list")
 				Expect(err).NotTo(HaveOccurred())
@@ -362,7 +361,7 @@ var _ = Describe("Loading configuration from disk", func() {
 				    }
 				  ]
 				}`)
-				Expect(ioutil.WriteFile(filepath.Join(configDir, "50-whatever.conflist"), configList, 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(configDir, "50-whatever.conflist"), configList, 0600)).To(Succeed())
 
 				netConfigList, err := libcni.LoadConfList(configDir, "some-list")
 				Expect(err).NotTo(HaveOccurred())
@@ -382,7 +381,7 @@ var _ = Describe("Loading configuration from disk", func() {
 				    }
 				  ]
 				}`, badValue))
-				Expect(ioutil.WriteFile(filepath.Join(configDir, "50-whatever.conflist"), configList, 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(configDir, "50-whatever.conflist"), configList, 0600)).To(Succeed())
 
 				_, err := libcni.LoadConfList(configDir, "some-list")
 				Expect(err).To(MatchError(fmt.Sprintf("error parsing configuration list: invalid disableCheck value \"%s\"", badValue)))

--- a/pkg/invoke/delegate_test.go
+++ b/pkg/invoke/delegate_test.go
@@ -17,7 +17,6 @@ package invoke_test
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -59,7 +58,7 @@ var _ = Describe("Delegate", func() {
 		}
 		expectedResultBytes, _ := json.Marshal(expectedResult)
 
-		debugFile, err := ioutil.TempFile("", "cni_debug")
+		debugFile, err := os.CreateTemp("", "cni_debug")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(debugFile.Close()).To(Succeed())
 		debugFileName = debugFile.Name()

--- a/pkg/invoke/find_test.go
+++ b/pkg/invoke/find_test.go
@@ -16,7 +16,6 @@ package invoke_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,17 +36,17 @@ var _ = Describe("FindInPath", func() {
 	)
 
 	BeforeEach(func() {
-		tempDir, err := ioutil.TempDir("", "cni-find")
+		tempDir, err := os.MkdirTemp("", "cni-find")
 		Expect(err).NotTo(HaveOccurred())
 
-		plugin, err := ioutil.TempFile(tempDir, "a-cni-plugin")
+		plugin, err := os.CreateTemp(tempDir, "a-cni-plugin")
 		Expect(err).NotTo(HaveOccurred())
 
 		plugin2Name := "a-plugin-with-extension" + invoke.ExecutableFileExtensions[0]
 		plugin2, err := os.Create(filepath.Join(tempDir, plugin2Name))
 		Expect(err).NotTo(HaveOccurred())
 
-		anotherTempDir, err = ioutil.TempDir("", "nothing-here")
+		anotherTempDir, err = os.MkdirTemp("", "nothing-here")
 		Expect(err).NotTo(HaveOccurred())
 
 		multiplePaths = []string{anotherTempDir, tempDir}

--- a/pkg/invoke/get_version_integration_test.go
+++ b/pkg/invoke/get_version_integration_test.go
@@ -16,7 +16,6 @@ package invoke_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -36,7 +35,7 @@ var _ = Describe("GetVersion, integration tests", func() {
 	)
 
 	BeforeEach(func() {
-		pluginDir, err := ioutil.TempDir("", "plugins")
+		pluginDir, err := os.MkdirTemp("", "plugins")
 		Expect(err).NotTo(HaveOccurred())
 		pluginPath = filepath.Join(pluginDir, "test-plugin")
 		if runtime.GOOS == "windows" {

--- a/pkg/invoke/raw_exec_test.go
+++ b/pkg/invoke/raw_exec_test.go
@@ -17,7 +17,6 @@ package invoke_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 
 	"github.com/containernetworking/cni/pkg/invoke"
@@ -41,7 +40,7 @@ var _ = Describe("RawExec", func() {
 	const reportResult = `{ "some": "result" }`
 
 	BeforeEach(func() {
-		debugFile, err := ioutil.TempFile("", "cni_debug")
+		debugFile, err := os.CreateTemp("", "cni_debug")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(debugFile.Close()).To(Succeed())
 		debugFileName = debugFile.Name()

--- a/pkg/skel/skel.go
+++ b/pkg/skel/skel.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -148,7 +147,7 @@ func (t *dispatcher) getCmdArgsFromEnv() (string, *CmdArgs, *types.Error) {
 		t.Stdin = bytes.NewReader(nil)
 	}
 
-	stdinData, err := ioutil.ReadAll(t.Stdin)
+	stdinData, err := io.ReadAll(t.Stdin)
 	if err != nil {
 		return "", nil, types.NewError(types.ErrIOFailure, fmt.Sprintf("error reading from stdin: %v", err), "")
 	}

--- a/pkg/types/040/types_test.go
+++ b/pkg/types/040/types_test.go
@@ -16,7 +16,7 @@ package types040_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 
@@ -99,7 +99,7 @@ var _ = Describe("040 types operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// parse the result
-		out, err := ioutil.ReadAll(r)
+		out, err := io.ReadAll(r)
 		os.Stdout = oldStdout
 		Expect(err).NotTo(HaveOccurred())
 
@@ -169,7 +169,7 @@ var _ = Describe("040 types operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// parse the result
-		out, err := ioutil.ReadAll(r)
+		out, err := io.ReadAll(r)
 		os.Stdout = oldStdout
 		Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/types/100/types_test.go
+++ b/pkg/types/100/types_test.go
@@ -16,7 +16,7 @@ package types100_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 
@@ -96,7 +96,7 @@ var _ = Describe("Current types operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// parse the result
-		out, err := ioutil.ReadAll(r)
+		out, err := io.ReadAll(r)
 		os.Stdout = oldStdout
 		Expect(err).NotTo(HaveOccurred())
 
@@ -164,7 +164,7 @@ var _ = Describe("Current types operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// parse the result
-		out, err := ioutil.ReadAll(r)
+		out, err := io.ReadAll(r)
 		os.Stdout = oldStdout
 		Expect(err).NotTo(HaveOccurred())
 
@@ -223,7 +223,7 @@ var _ = Describe("Current types operations", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// parse the result
-		out, err := ioutil.ReadAll(r)
+		out, err := io.ReadAll(r)
 		os.Stdout = oldStdout
 		Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/version/legacy_examples/example_runtime.go
+++ b/pkg/version/legacy_examples/example_runtime.go
@@ -16,7 +16,6 @@ package legacy_examples
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	noop_debug "github.com/containernetworking/cni/plugins/test/noop/debug"
@@ -108,7 +107,7 @@ func (e *ExampleRuntime) GenerateNetConf(name string) (*ExampleNetConf, error) {
 		return nil, fmt.Errorf("unknown example net config template %q", name)
 	}
 
-	debugFile, err := ioutil.TempFile("", "cni_debug")
+	debugFile, err := os.CreateTemp("", "cni_debug")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create noop plugin debug file: %w", err)
 	}
@@ -149,7 +148,7 @@ var V010_Runtime = ExampleRuntime{
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/containernetworking/cni/libcni"
@@ -161,7 +160,7 @@ func main(){
 }
 
 func exec() int {
-	confBytes, err := ioutil.ReadAll(os.Stdin)
+	confBytes, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		fmt.Printf("could not read netconfig from stdin: %+v", err)
 		return 1

--- a/pkg/version/legacy_examples/examples.go
+++ b/pkg/version/legacy_examples/examples.go
@@ -17,8 +17,8 @@
 package legacy_examples
 
 import (
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 	"runtime"
 	"sync"
@@ -51,7 +51,7 @@ func ensureBuildDirExists() error {
 	}
 
 	var err error
-	buildDir, err = ioutil.TempDir("", "cni-example-plugins")
+	buildDir, err = os.MkdirTemp("", "cni-example-plugins")
 	return err
 }
 

--- a/pkg/version/testhelpers/testhelpers.go
+++ b/pkg/version/testhelpers/testhelpers.go
@@ -22,7 +22,6 @@ package testhelpers
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -81,7 +80,7 @@ func modTidy(path string) error {
 // BuildAt builds the go programSource using the version of the CNI library
 // at gitRef, and saves the resulting binary file at outputFilePath
 func BuildAt(programSource []byte, gitRef string, outputFilePath string) error {
-	tempDir, err := ioutil.TempDir(os.Getenv("GOTMPDIR"), "cni-test-")
+	tempDir, err := os.MkdirTemp(os.Getenv("GOTMPDIR"), "cni-test-")
 	if err != nil {
 		return err
 	}
@@ -97,7 +96,7 @@ func BuildAt(programSource []byte, gitRef string, outputFilePath string) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(tempDir, "main.go"), programSource, 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(tempDir, "main.go"), programSource, 0600); err != nil {
 		return err
 	}
 

--- a/pkg/version/testhelpers/testhelpers_test.go
+++ b/pkg/version/testhelpers/testhelpers_test.go
@@ -14,7 +14,6 @@
 package testhelpers
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -43,7 +42,7 @@ func main() { skel.PluginMain(c, c) }
 		gitRef = "f4364185253"
 
 		var err error
-		outputDir, err = ioutil.TempDir("", "bin")
+		outputDir, err = os.MkdirTemp("", "bin")
 		Expect(err).NotTo(HaveOccurred())
 		outputFilePath = filepath.Join(outputDir, "some-binary")
 		if runtime.GOOS == "windows" {

--- a/plugins/test/noop/debug/debug.go
+++ b/plugins/test/noop/debug/debug.go
@@ -17,7 +17,7 @@ package debug
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 
 	"github.com/containernetworking/cni/pkg/skel"
 )
@@ -42,7 +42,7 @@ type Debug struct {
 
 // ReadDebug will return a debug file recorded by the noop plugin
 func ReadDebug(debugFilePath string) (*Debug, error) {
-	debugBytes, err := ioutil.ReadFile(debugFilePath)
+	debugBytes, err := os.ReadFile(debugFilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func (debug *Debug) WriteDebug(debugFilePath string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(debugFilePath, debugBytes, 0600)
+	err = os.WriteFile(debugFilePath, debugBytes, 0600)
 	if err != nil {
 		return err
 	}

--- a/plugins/test/noop/main.go
+++ b/plugins/test/noop/main.go
@@ -25,7 +25,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -198,7 +198,7 @@ func cmdDel(args *skel.CmdArgs) error {
 
 func saveStdin() ([]byte, error) {
 	// Read original stdin
-	stdinData, err := ioutil.ReadAll(os.Stdin)
+	stdinData, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/test/noop/noop_test.go
+++ b/plugins/test/noop/noop_test.go
@@ -16,7 +16,6 @@ package main_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -46,7 +45,7 @@ var _ = Describe("No-op plugin", func() {
 			ReportVersionSupport: []string{"0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0"},
 		}
 
-		debugFile, err := ioutil.TempFile("", "cni_debug")
+		debugFile, err := os.CreateTemp("", "cni_debug")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(debugFile.Close()).To(Succeed())
 		debugFileName = debugFile.Name()


### PR DESCRIPTION
Recently we have upgraded the Go version in #913. The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir`
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`