### PR TITLE
Extend capabilities with cgroup path

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -66,6 +66,7 @@ But the runtime would fill in the mappings so the plugin itself would receive so
 | infiniband guid | Dynamically assign Infiniband GUID to network interface. Runtime can pass this to plugins which need Infiniband GUID as input. | `infinibandGUID` | `GUID` (string entry). <pre> "c2:11:22:33:44:55:66:77" </pre> | none | CNI [`ib-sriov-cni`](https://github.com/Mellanox/ib-sriov-cni) plugin |
 | device id | Provide device identifier which is associated with the network to allow the CNI plugin to perform device dependent network configurations. | `deviceID` | `deviceID` (string entry). <pre> "0000:04:00.5" </pre> | none | CNI `host-device` plugin |
 | aliases | Provide a list of names that will be mapped to the IP addresses assigned to this interface. Other containers on the same network may use one of these names to access the container.| `aliases` | List of `alias` (string entry). <pre> ["my-container", "primary-db"] </pre> | none | CNI `alias` plugin |
+| cgroup path | Provide the cgroup path for pod as requested by CNI plugins. | `cgroupPath` | `cgroupPath` (string entry). <pre>"/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-burstable.slice/kubelet-kubepods-burstable-pod28ce45bc_63f8_48a3_a99b_cfb9e63c856c.slice" </pre> | none | CNI `host-local` plugin |
 
 ## "args" in network config
 `args` in [network config](https://github.com/containernetworking/cni/blob/master/SPEC.md#network-configuration) were reserved as a  field in the `0.2.0` release of the CNI spec.


### PR DESCRIPTION
Container runtimes can pass pod cgroup paths
when requested by CNI plugins.

Details around the use cases for this field are
documented - https://github.com/kubernetes/kubernetes/issues/113342.

Signed-off-by: Aditi Ghag <aditi@cilium.io>