### PR TITLE
Prepare for spec version v1.1

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -18,7 +18,7 @@
       - [`CHECK`: Check container's networking is as expected](#check-check-containers-networking-is-as-expected)
       - [`VERSION`: probe plugin version support](#version-probe-plugin-version-support)
   - [Section 3: Execution of Network Configurations](#section-3-execution-of-network-configurations)
-    - [Lifecycle & Ordering](#lifecycle--ordering)
+    - [Lifecycle \& Ordering](#lifecycle--ordering)
     - [Attachment Parameters](#attachment-parameters)
     - [Adding an attachment](#adding-an-attachment)
     - [Deleting an attachment](#deleting-an-attachment)
@@ -40,7 +40,7 @@
 
 ## Version
 
-This is CNI **spec** version **1.0.0**.
+This is CNI **spec** version **1.1.0-dev**.
 
 Note that this is **independent from the version of the CNI library and plugins** in this repository (e.g. the versions of [releases](https://github.com/containernetworking/cni/releases)).
 
@@ -102,7 +102,7 @@ require this.
 
 A network configuration consists of a JSON object with the following keys:
 
-- `cniVersion` (string): [Semantic Version 2.0](https://semver.org) of CNI specification to which this configuration list and all the individual configurations conform. Currently "1.0.0"
+- `cniVersion` (string): [Semantic Version 2.0](https://semver.org) of CNI specification to which this configuration list and all the individual configurations conform. Currently "1.1.0"
 - `name` (string): Network name. This should be unique across all network configurations on a host (or other administrative domain).  Must start with an alphanumeric character, optionally followed by any combination of one or more alphanumeric characters, underscore, dot (.) or hyphen (-).
 - `disableCheck` (boolean): Either `true` or `false`.  If `disableCheck` is `true`, runtimes must not call `CHECK` for this network configuration list.  This allows an administrator to prevent `CHECK`ing where a combination of plugins is known to return spurious errors.
 - `plugins` (list): A list of CNI plugins and their configuration, which is a list of plugin configuration objects.
@@ -142,7 +142,7 @@ Plugins may define additional fields that they accept and may generate an error 
 #### Example configuration
 ```jsonc
 {
-  "cniVersion": "1.0.0",
+  "cniVersion": "1.1.0",
   "name": "dbnet",
   "plugins": [
     {
@@ -477,7 +477,7 @@ Plugins provided a `prevResult` key as part of their request configuration must 
 
 Plugins must output a JSON object with the following keys upon a successful `ADD` operation:
 
-- `cniVersion`: The same version supplied on input - the string "1.0.0"
+- `cniVersion`: The same version supplied on input - the string "1.1.0"
 - `interfaces`: An array of all interfaces created by the attachment, including any host-level interfaces:
     - `name`: The name of the interface.
     - `mac`: The hardware address of the interface (if applicable).
@@ -514,7 +514,7 @@ Example:
 
 ```json
 {
-  "cniVersion": "1.0.0",
+  "cniVersion": "1.1.0",
   "code": 7,
   "msg": "Invalid Configuration",
   "details": "Network 192.168.0.0/31 too small to allocate from."
@@ -547,8 +547,8 @@ Plugins must output a JSON object with the following keys upon a `VERSION` opera
 Example:
 ```json
 {
-    "cniVersion": "1.0.0",
-    "supportedVersions": [ "0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0" ]
+    "cniVersion": "1.1.0",
+    "supportedVersions": [ "0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0", "1.1.0" ]
 }
 ```
 
@@ -566,7 +566,7 @@ The container runtime would perform the following steps for the `add` operation.
 
 ```json
 {
-    "cniVersion": "1.0.0",
+    "cniVersion": "1.1.0",
     "name": "dbnet",
     "type": "bridge",
     "bridge": "cni0",
@@ -646,7 +646,7 @@ The bridge plugin returns the following result, configuring the interface accord
 
 ```json
 {
-  "cniVersion": "1.0.0",
+  "cniVersion": "1.1.0",
   "name": "dbnet",
   "type": "tuning",
   "sysctl": {
@@ -731,7 +731,7 @@ The plugin returns the following result. Note that the **mac** has changed.
 
 ```json
 {
-  "cniVersion": "1.0.0",
+  "cniVersion": "1.1.0",
   "name": "dbnet",
   "type": "portmap",
   "runtimeConfig": {
@@ -785,7 +785,7 @@ Given the previous _Add_, the container runtime would perform the following step
 
 ```json
 {
-  "cniVersion": "1.0.0",
+  "cniVersion": "1.1.0",
   "name": "dbnet",
   "type": "bridge",
   "bridge": "cni0",
@@ -841,7 +841,7 @@ Assuming the `bridge` plugin is satisfied, it produces no output on standard out
 
 ```json
 {
-  "cniVersion": "1.0.0",
+  "cniVersion": "1.1.0",
   "name": "dbnet",
   "type": "tuning",
   "sysctl": {
@@ -891,7 +891,7 @@ Likewise, the `tuning` plugin exits indicating success.
 
 ```json
 {
-  "cniVersion": "1.0.0",
+  "cniVersion": "1.1.0",
   "name": "dbnet",
   "type": "portmap",
   "runtimeConfig": {
@@ -944,7 +944,7 @@ Note that plugins are executed in reverse order from the _Add_ and _Check_ actio
 
 ```json
 {
-  "cniVersion": "1.0.0",
+  "cniVersion": "1.1.0",
   "name": "dbnet",
   "type": "portmap",
   "runtimeConfig": {
@@ -992,7 +992,7 @@ Note that plugins are executed in reverse order from the _Add_ and _Check_ actio
 
 ```json
 {
-  "cniVersion": "1.0.0",
+  "cniVersion": "1.1.0",
   "name": "dbnet",
   "type": "tuning",
   "sysctl": {
@@ -1040,7 +1040,7 @@ Note that plugins are executed in reverse order from the _Add_ and _Check_ actio
 
 ```json
 {
-  "cniVersion": "1.0.0",
+  "cniVersion": "1.1.0",
   "name": "dbnet",
   "type": "bridge",
   "bridge": "cni0",

--- a/libcni/api_test.go
+++ b/libcni/api_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/cni/pkg/version"
 	noop_debug "github.com/containernetworking/cni/plugins/test/noop/debug"
 )
 
@@ -179,7 +180,7 @@ var _ = Describe("Invoking plugins", func() {
 
 			debug = &noop_debug.Debug{
 				ReportResult: `{
-					"cniVersion": "1.0.0",
+					"cniVersion": "` + version.Current() + `",
 					"ips": [{"address": "10.1.2.3/24"}],
 					"dns": {}
 				}`,
@@ -195,7 +196,7 @@ var _ = Describe("Invoking plugins", func() {
 					"somethingElse": true,
 					"noCapability": false
 				}
-			}`, current.ImplementedSpecVersion))
+			}`, version.Current()))
 			netConfig, err = libcni.ConfFromBytes(pluginConfig)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -301,7 +302,7 @@ var _ = Describe("Invoking plugins", func() {
 
 			debug = &noop_debug.Debug{
 				ReportResult: `{
-					"cniVersion": "1.0.0",
+					"cniVersion": "` + version.Current() + `",
 					"ips": [{"address": "10.1.2.3/24"}],
 					"dns": {}
 				}`,
@@ -319,7 +320,7 @@ var _ = Describe("Invoking plugins", func() {
 				"some-key": "some-value",
 				"cniVersion": "%s",
 				"capabilities": { "portMappings": true }
-			}`, current.ImplementedSpecVersion)
+			}`, version.Current())
 			cniConfig = libcni.NewCNIConfigWithCacheDir([]string{cniBinPath}, cacheDirPath, nil)
 			netConfig, err = libcni.ConfFromBytes([]byte(pluginConfig))
 			Expect(err).NotTo(HaveOccurred())
@@ -476,7 +477,7 @@ var _ = Describe("Invoking plugins", func() {
 				err := os.MkdirAll(filepath.Dir(cacheFile), 0o700)
 				Expect(err).NotTo(HaveOccurred())
 				cachedJson := `{
-					"cniVersion": "1.0.0",
+					"cniVersion": "` + version.Current() + `",
 					"ips": [{"address": "10.1.2.3/24"}],
 					"dns": {}
 				}`
@@ -561,7 +562,7 @@ var _ = Describe("Invoking plugins", func() {
 				Context("containing only a cached result", func() {
 					It("only passes a prevResult to the plugin", func() {
 						err := os.WriteFile(cacheFile, []byte(`{
-							"cniVersion": "1.0.0",
+							"cniVersion": "`+version.Current()+`",
 							"ips": [{"address": "10.1.2.3/24"}],
 							"dns": {}
 						}`), 0o600)
@@ -666,7 +667,7 @@ var _ = Describe("Invoking plugins", func() {
 				err := os.MkdirAll(filepath.Dir(cacheFile), 0o700)
 				Expect(err).NotTo(HaveOccurred())
 				cachedJson := `{
-					"cniVersion": "1.0.0",
+					"cniVersion": "` + version.Current() + `",
 					"ips": [{"address": "10.1.2.3/24"}],
 					"dns": {}
 				}`
@@ -874,7 +875,7 @@ var _ = Describe("Invoking plugins", func() {
 
 				Expect(versionInfo).NotTo(BeNil())
 				Expect(versionInfo.SupportedVersions()).To(Equal([]string{
-					"0.-42.0", "0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0",
+					"0.-42.0", "0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0", "1.1.0",
 				}))
 			})
 
@@ -962,8 +963,8 @@ var _ = Describe("Invoking plugins", func() {
 				"otherCapability": capabilityArgs["otherCapability"],
 			}
 
-			ipResult = fmt.Sprintf(`{"cniVersion": "%s", "dns":{},"ips":[{"address": "10.1.2.3/24"}]}`, current.ImplementedSpecVersion)
-			netConfigList, plugins = makePluginList(current.ImplementedSpecVersion, ipResult, rcMap)
+			ipResult = fmt.Sprintf(`{"cniVersion": "%s", "dns":{},"ips":[{"address": "10.1.2.3/24"}]}`, version.Current())
+			netConfigList, plugins = makePluginList(version.Current(), ipResult, rcMap)
 
 			ctx = context.TODO()
 		})
@@ -1533,7 +1534,7 @@ var _ = Describe("Invoking plugins", func() {
 				"some-key": "some-value",
 				"cniVersion": "%s",
 				"capabilities": { "portMappings": true }
-			}`, current.ImplementedSpecVersion)
+			}`, version.Current())
 
 			cniBinPath = filepath.Dir(pluginPaths["sleep"])
 			cniConfig = libcni.NewCNIConfig([]string{cniBinPath}, nil)
@@ -1560,7 +1561,7 @@ var _ = Describe("Invoking plugins", func() {
   "plugins": [
     %s
   ]
-}`, current.ImplementedSpecVersion, pluginConfig))
+}`, version.Current(), pluginConfig))
 
 			netConfigList, err = libcni.ConfListFromBytes(configList)
 			Expect(err).NotTo(HaveOccurred())
@@ -1703,7 +1704,7 @@ var _ = Describe("Invoking plugins", func() {
 				ReportResult: fmt.Sprintf(`{
 					"cniVersion": "%s",
 					"ips": [{"version": "4", "address": "%s"}]
-				}`, current.ImplementedSpecVersion, firstIP),
+				}`, version.Current(), firstIP),
 			}
 			Expect(debug.WriteDebug(debugFilePath)).To(Succeed())
 
@@ -1712,7 +1713,7 @@ var _ = Describe("Invoking plugins", func() {
 				"type": "noop",
 				"name": "%s",
 				"cniVersion": "%s"
-			}`, netName, current.ImplementedSpecVersion)
+			}`, netName, version.Current())
 			cniConfig = libcni.NewCNIConfigWithCacheDir([]string{cniBinPath}, cacheDirPath, nil)
 			netConfig, err = libcni.ConfFromBytes([]byte(pluginConfig))
 			Expect(err).NotTo(HaveOccurred())
@@ -1736,7 +1737,7 @@ var _ = Describe("Invoking plugins", func() {
 			debug.ReportResult = fmt.Sprintf(`{
 				"cniVersion": "%s",
 				"ips": [{"version": "4", "address": "%s"}]
-			}`, current.ImplementedSpecVersion, secondIP)
+			}`, version.Current(), secondIP)
 			Expect(debug.WriteDebug(debugFilePath)).To(Succeed())
 			runtimeConfig.IfName = secondIfname
 			_, err = cniConfig.AddNetwork(ctx, netConfig, runtimeConfig)

--- a/pkg/invoke/delegate_test.go
+++ b/pkg/invoke/delegate_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/containernetworking/cni/pkg/invoke"
 	current "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/cni/pkg/version"
 	"github.com/containernetworking/cni/plugins/test/noop/debug"
 )
 
@@ -42,7 +43,7 @@ var _ = Describe("Delegate", func() {
 	BeforeEach(func() {
 		netConf, _ = json.Marshal(map[string]string{
 			"name":       "delegate-test",
-			"cniVersion": current.ImplementedSpecVersion,
+			"cniVersion": version.Current(),
 		})
 
 		expectedResult = &current.Result{

--- a/pkg/skel/skel_test.go
+++ b/pkg/skel/skel_test.go
@@ -24,7 +24,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/containernetworking/cni/pkg/types"
-	current "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/cni/pkg/version"
 )
 
@@ -430,7 +429,7 @@ var _ = Describe("dispatching to the correct callback", func() {
 			Expect(stdout).To(MatchJSON(fmt.Sprintf(`{
 				"cniVersion": "%s",
 				"supportedVersions": ["9.8.7", "10.0.0"]
-			}`, current.ImplementedSpecVersion)))
+			}`, version.Current())))
 		})
 
 		It("does not call cmdAdd or cmdDel", func() {
@@ -461,7 +460,7 @@ var _ = Describe("dispatching to the correct callback", func() {
 			Expect(stdout).To(MatchJSON(fmt.Sprintf(`{
 				"cniVersion": "%s",
 				"supportedVersions": ["9.8.7", "10.0.0"]
-			}`, current.ImplementedSpecVersion)))
+			}`, version.Current())))
 		})
 	})
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -19,13 +19,12 @@ import (
 	"fmt"
 
 	"github.com/containernetworking/cni/pkg/types"
-	types100 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/cni/pkg/types/create"
 )
 
 // Current reports the version of the CNI spec implemented by this library
 func Current() string {
-	return types100.ImplementedSpecVersion
+	return "1.1.0"
 }
 
 // Legacy PluginInfo describes a plugin that is backwards compatible with the
@@ -37,7 +36,7 @@ func Current() string {
 // this list.
 var (
 	Legacy = PluginSupports("0.1.0", "0.2.0")
-	All    = PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0")
+	All    = PluginSupports("0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0", "1.1.0")
 )
 
 // VersionsFrom returns a list of versions starting from min, inclusive

--- a/plugins/test/noop/main.go
+++ b/plugins/test/noop/main.go
@@ -163,7 +163,7 @@ func debugBehavior(args *skel.CmdArgs, command string) error {
 }
 
 func debugGetSupportedVersions(stdinData []byte) []string {
-	vers := []string{"0.-42.0", "0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0"}
+	vers := []string{"0.-42.0", "0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0", "1.1.0"}
 	cniArgs := os.Getenv("CNI_ARGS")
 	if cniArgs == "" {
 		return vers


### PR DESCRIPTION
This does a bit of refactoring, since types v1.0.0 also implement the result type for v1.1.0. But nothing too bad.