### PR TITLE
Define Makefile with golangci-lint

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,9 @@ jobs:
         with:
           format: auto
       - uses: golangci/golangci-lint-action@v3
+        with:
+          args: --verbose
+          version: v1.51.2
   build:
     name: Build all linux architectures
     needs: lint

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,1 @@
+include mk/lint.mk

--- a/mk/dependencies/golangci.sh
+++ b/mk/dependencies/golangci.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+GOLANGCI_LINT_VERSION="v1.51.2"
+
+go install "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"

--- a/mk/lint.mk
+++ b/mk/lint.mk
@@ -1,0 +1,14 @@
+.PHONY: lint
+lint: golangci/install golangci/lint
+
+.PHONY: golangci/install
+golangci/install:
+	./mk/dependencies/golangci.sh
+
+.PHONY: golangci/lint
+golangci/lint:
+	golangci-lint run --verbose
+
+.PHONY: golangci/fix
+golangci/fix:
+	golangci-lint run --verbose --fix

--- a/test.sh
+++ b/test.sh
@@ -20,22 +20,6 @@ else
     go test ${PKGS}
 fi
 
-GO_FILES=$(find . -name '*.go' -type f -print)
-
-echo "Checking gofmt..."
-fmtRes=$(gofmt -d -e -s ${GO_FILES})
-if [ -n "${fmtRes}" ]; then
-	echo -e "go fmt checking failed:\n${fmtRes}"
-	exit 255
-fi
-
-echo "Checking govet..."
-vetRes=$(go vet ${PKGS})
-if [ -n "${vetRes}" ]; then
-	echo -e "go vet checking failed:\n${vetRes}"
-	exit 255
-fi
-
 echo "Checking license header..."
 licRes=$(
        for file in $(find . -type f -iname '*.go'); do


### PR DESCRIPTION
As govet and gofmt are now handled by golangci-lint, there is no need to apply them here.

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>