### PR TITLE
pkg/types: explicitly import all versions

### DIFF
--- a/pkg/types/create/create.go
+++ b/pkg/types/create/create.go
@@ -19,6 +19,9 @@ import (
 	"fmt"
 
 	"github.com/containernetworking/cni/pkg/types"
+	_ "github.com/containernetworking/cni/pkg/types/020"
+	_ "github.com/containernetworking/cni/pkg/types/040"
+	_ "github.com/containernetworking/cni/pkg/types/100"
 	convert "github.com/containernetworking/cni/pkg/types/internal"
 )
 


### PR DESCRIPTION
There was a bug in which some versions didn't register their creation function, thus leaving some types un-decodeable. Fix that by explicitly importing all known versions.