### PR TITLE
Add AWS VPC CNI for 3P list

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ To avoid duplication, we think it is prudent to define a common interface betwee
 - [Azure CNI - a CNI plugin that natively extends Azure Virtual Networks to containers](https://github.com/Azure/azure-container-networking)
 - [Hybridnet - a CNI plugin designed for hybrid clouds which provides both overlay and underlay networking for containers in one or more clusters. Overlay and underlay containers can run on the same node and have cluster-wide bidirectional network connectivity.](https://github.com/alibaba/hybridnet)
 - [Spiderpool - An IP Address Management (IPAM) CNI plugin of Kubernetes for managing static ip for underlay network](https://github.com/spidernet-io/spiderpool)
+- [AWS VPC CNI - Networking plugin for pod networking in Kubernetes using Elastic Network Interfaces on AWS](https://github.com/aws/amazon-vpc-cni-k8s)
 
 The CNI team also maintains some [core plugins in a separate repository](https://github.com/containernetworking/plugins).
 


### PR DESCRIPTION
Add aws-vpc-cni-k8s CNI plugin to 3P list. aws-vpc-cni-k8s is a default CNI plugin on EKS.

About the plugin - https://github.com/aws/amazon-vpc-cni-k8s/blob/master/docs/cni-proposal.md

