### PR TITLE
SPEC,plugins/debug: fix typos in docs

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -326,7 +326,7 @@ Required environment parameters:
 
 #### `GC`: Clean up any stale resources
 
-The GC comand provides a way for runtimes to specify the expected set of attachments to a network.
+The GC command provides a way for runtimes to specify the expected set of attachments to a network.
 The network plugin may then remove any resources related to attachments that do not exist in this set.
 
 Resources may, for example, include:

--- a/plugins/debug/README.md
+++ b/plugins/debug/README.md
@@ -50,7 +50,7 @@ This plugin aims to help debugging or troubleshooting in CNI plugin development.
 * `checkHooks` (string array, optional): commands executed in container network namespace at interface check.
    (note: but just execute it and does not catch command failure)
 
-### Sample CNI Ouput
+### Sample CNI Output
 
 ```
 CmdAdd


### PR DESCRIPTION
This PR corrects spelling mistakes in the *.md files.