### PR TITLE
dependabot: batch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      golang:
+        patterns:
+          - "*"
   - package-ecosystem: "gomod"
     directory: "/plugins/debug"
     schedule:


### PR DESCRIPTION
This combines go pkg updates in to a weekly branch, saving bother and rebase time.