### PR TITLE
Add Version to CNI interface

### DIFF
--- a/libcni/api.go
+++ b/libcni/api.go
@@ -114,6 +114,8 @@ type CNI interface {
 	GetStatusNetworkList(ctx context.Context, net *NetworkConfigList) error
 
 	GetCachedAttachments(containerID string) ([]*NetworkAttachment, error)
+
+	GetVersionInfo(ctx context.Context, pluginType string) (version.PluginInfo, error)
 }
 
 type CNIConfig struct {


### PR DESCRIPTION
When looking at how to integrate STATUS/GC in containerd I noticed that Version was not exposed on the CNI Interface. I am not certain if that was intended? I didn't add a test for this yet since it might be intentionally not added. This would be helpful to have in CNI 1.1. 