### PR TITLE
Update golangci-lint to v1.57.1

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v6
         with:
           args: --verbose
-          version: v1.54
+          version: v1.57.1
   build:
     name: Build all linux architectures
     needs: lint

--- a/mk/dependencies/golangci.sh
+++ b/mk/dependencies/golangci.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 
-GOLANGCI_LINT_VERSION="v1.54"
+GOLANGCI_LINT_VERSION="v1.57.1"
 
 go install "github.com/golangci/golangci-lint/cmd/golangci-lint@${GOLANGCI_LINT_VERSION}"


### PR DESCRIPTION
### Issue:
New golangci-lint version is available.

### Description:
This change updates golangci-lint in CI to v1.57.1.

### Testing:
Lint check passes
