### PR TITLE
Update to Go v1.22 in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ name: test
 on: ["push", "pull_request"]
 
 env:
-  GO_VERSION: "1.19"
+  GO_VERSION: "1.22"
   LINUX_ARCHES: "amd64 386 arm arm64 s390x mips64le ppc64le"
 
 jobs:


### PR DESCRIPTION
### Issue:
N/A

### Description:
This change updates the Go version in CI to Go 1.22

### Additional resources:
- https://go.dev/doc/go1.22