### PR TITLE
Set cache dir to volatile dir

### DIFF
--- a/libcni/api.go
+++ b/libcni/api.go
@@ -37,7 +37,7 @@ import (
 )
 
 var (
-	CacheDir = "/var/lib/cni"
+	CacheDir = "/var/run/cni"
 	// slightly awkward wording to preserve anyone matching on error strings
 	ErrorCheckNotSupp = fmt.Errorf("does not support the CHECK command")
 )


### PR DESCRIPTION
This was meant to be a question but since it's a pretty easy change I'll just use a PR to kick off the discussion.

The question is that **should CNI cache result persist across node restart?**

My understanding is that most networking setups will not persist across node reboot, and libcni will not recover those network setups either. Pods/container recovery after reboot is expected to be driven by the runtime. Today in k8s, pods are normally rescheduled once a node is restarted, therefore any cached CNI result will immediately go stale. It could be a problem if the same node continues to get new pods scheduled on it.

Should we set the cache dir to something volatile, say `/run/cni` or `/var/run/cni`?

Likewise I had https://github.com/containerd/containerd/issues/9825 to enable the customization of this dir in runtime. Just unsure where the best place of the change should be...

xref: https://github.com/containerd/containerd/issues/9825
xref: https://github.com/containernetworking/cni/issues/1055