### PR TITLE
tolerate invalid cni caches for deletion

### DIFF
--- a/libcni/api.go
+++ b/libcni/api.go
@@ -586,9 +586,9 @@ func (c *CNIConfig) DelNetworkList(ctx context.Context, list *NetworkConfigList,
 	if gtet, err := version.GreaterThanOrEqualTo(list.CNIVersion, "0.4.0"); err != nil {
 		return err
 	} else if gtet {
-		cachedResult, err = c.getCachedResult(list.Name, list.CNIVersion, rt)
-		if err != nil {
-			return fmt.Errorf("failed to get network %q cached result: %w", list.Name, err)
+		if cachedResult, err = c.getCachedResult(list.Name, list.CNIVersion, rt); err != nil {
+			_ = c.cacheDel(list.Name, rt)
+			cachedResult = nil
 		}
 	}
 
@@ -598,7 +598,10 @@ func (c *CNIConfig) DelNetworkList(ctx context.Context, list *NetworkConfigList,
 			return fmt.Errorf("plugin %s failed (delete): %w", pluginDescription(net.Network), err)
 		}
 	}
-	_ = c.cacheDel(list.Name, rt)
+
+	if cachedResult != nil {
+		_ = c.cacheDel(list.Name, rt)
+	}
 
 	return nil
 }

--- a/libcni/api_test.go
+++ b/libcni/api_test.go
@@ -1474,7 +1474,7 @@ var _ = Describe("Invoking plugins", func() {
 			})
 
 			Context("when the cached result is invalid", func() {
-				It("returns an error", func() {
+				It("tolerates the error", func() {
 					cacheFile := resultCacheFilePath(cacheDirPath, netConfigList.Name, runtimeConfig)
 					err := os.MkdirAll(filepath.Dir(cacheFile), 0o700)
 					Expect(err).NotTo(HaveOccurred())
@@ -1482,7 +1482,7 @@ var _ = Describe("Invoking plugins", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					err = cniConfig.DelNetworkList(ctx, netConfigList, runtimeConfig)
-					Expect(err).To(MatchError("failed to get network \"some-list\" cached result: decoding version from network config: invalid character 'a' looking for beginning of value"))
+					Expect(err).NotTo(HaveOccurred())
 				})
 			})
 		})


### PR DESCRIPTION
Fixes: #1055
Closes: #1066

In `DelNetworkList` function, ignore the errors returned by `getCachedResult` and continue to invoke plugins for deletion as best effort. Also updated the test case to adapt this new behavior.

Cached results are deleted from disk in the following two cases:
1. `getCachedResult` returns an error; OR
2. `getCachedResult` succeeds and no errors are returned from plugins

Cached results are not deleted if (I think this will allow clients to retry the deletion)
1. `getCachedResult` succeeds AND 
2. Plugin fails