### PR TITLE
libcni: always delete the cache on conflist for CNI DEL

### DIFF
--- a/libcni/api.go
+++ b/libcni/api.go
@@ -598,9 +598,7 @@ func (c *CNIConfig) DelNetworkList(ctx context.Context, list *NetworkConfigList,
 		}
 	}
 
-	if cachedResult != nil {
-		_ = c.cacheDel(list.Name, rt)
-	}
+	_ = c.cacheDel(list.Name, rt)
 
 	return nil
 }


### PR DESCRIPTION
This aligns the call with `DelNetwork`, and allows CRIO tests to bump - [0].

[0] - https://github.com/cri-o/cri-o/pull/8207#issuecomment-2129937741