### PR TITLE
libcni: remove use of Masterminds/semver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/containernetworking/cni
 go 1.21
 
 require (
-	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	github.com/vishvananda/netns v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
-github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=

--- a/pkg/version/plugin.go
+++ b/pkg/version/plugin.go
@@ -142,3 +142,27 @@ func GreaterThanOrEqualTo(version, otherVersion string) (bool, error) {
 	}
 	return false, nil
 }
+
+// GreaterThan returns true if the first version is greater than the second
+func GreaterThan(version, otherVersion string) (bool, error) {
+	firstMajor, firstMinor, firstMicro, err := ParseVersion(version)
+	if err != nil {
+		return false, err
+	}
+
+	secondMajor, secondMinor, secondMicro, err := ParseVersion(otherVersion)
+	if err != nil {
+		return false, err
+	}
+
+	if firstMajor > secondMajor {
+		return true, nil
+	} else if firstMajor == secondMajor {
+		if firstMinor > secondMinor {
+			return true, nil
+		} else if firstMinor == secondMinor && firstMicro > secondMicro {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -139,4 +139,22 @@ var _ = Describe("Version operations", func() {
 			Expect(conf.PrevResult).To(BeNil())
 		})
 	})
+
+	Context("version parsing", func() {
+		It("parses versions correctly", func() {
+			v1 := "1.1.0"
+			v2 := "1.1.1"
+
+			check := func(a, b string, want bool) {
+				GinkgoHelper()
+				gt, err := version.GreaterThan(a, b)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(gt).To(Equal(want))
+			}
+
+			check(v1, v2, false)
+			check(v2, v1, true)
+			check(v2, v2, false)
+		})
+	})
 })


### PR DESCRIPTION
We didn't really need it, and it's yet another dep to update.