### PR TITLE
SPEC: allow delegated IPAM to return interfaces

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -598,7 +598,9 @@ Plugins provided a `prevResult` key as part of their request configuration must 
 #### Delegated plugins (IPAM)
 Delegated plugins may omit irrelevant sections.
 
-Delegated IPAM plugins must return an abbreviated _Success_ object. Specifically, it is missing the `interfaces` array, as well as the `interface` entry in `ips`.
+Delegated IPAM plugins must return an abbreviated _Success_ object. 
+- The `interfaces` field is optional. Any interfaces provided must not have the `sandbox` field defined. Entries must not refer to interfaces in the sandbox. The delegating plugin should use the returned interface for host-side connectivity. For example, it may specify the uplink for a macvlan interface.
+- The `interface` field in the `ips` list is optional. If missing, it is assumed to apply to the interface specified by CNI_IFNAME.
 
 
 ### VERSION Success


### PR DESCRIPTION
This allows IPAM plugins to specify host-level interfaces to the delegating plugin when relevant.

Use cases:
- specifying macvlan master
- indicating which interface is to be used as the uplink