### PR TITLE
Add error codes for STATUS verb to `types.go` and `SPEC.md`

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -648,6 +648,8 @@ Error Code|Error Description
  `6`|Failed to decode content. For example, failed to unmarshal network config from bytes or failed to decode version info from string.
  `7`|Invalid network config. If some validations on network configs do not pass, this error will be raised.
  `11`|Try again later. If the plugin detects some transient condition that should clear up, it can use this code to notify the runtime it should re-try the operation later.
+ `50`|The plugin is not available (i.e. cannot service `ADD` requests)
+ `51`|The plugin is not available, and existing containers in the network may have limited connectivity.
 
 In addition, stderr can be used for unstructured output such as logs.
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -229,7 +229,7 @@ func (r *Route) Copy() *Route {
 }
 
 // Well known error codes
-// see https://github.com/containernetworking/cni/blob/main/SPEC.md#well-known-error-codes
+// see https://github.com/containernetworking/cni/blob/main/SPEC.md#error
 const (
 	ErrUnknown                     uint = iota // 0
 	ErrIncompatibleCNIVersion                  // 1
@@ -241,6 +241,8 @@ const (
 	ErrInvalidNetworkConfig                    // 7
 	ErrInvalidNetNS                            // 8
 	ErrTryAgainLater               uint = 11
+	ErrPluginNotAvailable          uint = 50
+	ErrLimitedConnectivity         uint = 51
 	ErrInternal                    uint = 999
 )
 


### PR DESCRIPTION
This PR adds constants for STATUS error codes 50 and 51 so plugins can import them. It also fixes a broken link to the spec document.