### PR TITLE
libcni: remove some deprecation warnings

### DIFF
--- a/libcni/api.go
+++ b/libcni/api.go
@@ -67,7 +67,7 @@ type RuntimeConf struct {
 	CacheDir string
 }
 
-// Deprecated: Use PluginConfig instead of NetworkConfig, the NetworkConfig
+// Use PluginConfig instead of NetworkConfig, the NetworkConfig
 // backwards-compat alias will be removed in a future release.
 type NetworkConfig = PluginConfig
 

--- a/libcni/conf.go
+++ b/libcni/conf.go
@@ -285,12 +285,10 @@ func ConfFromFile(filename string) (*NetworkConfig, error) {
 	return ConfFromBytes(bytes)
 }
 
-// Deprecated: Use NetworkConfXXX and NetworkPluginXXX functions
 func ConfListFromBytes(bytes []byte) (*NetworkConfigList, error) {
 	return NetworkConfFromBytes(bytes)
 }
 
-// Deprecated: Use NetworkConfXXX and NetworkPluginXXX functions
 func ConfListFromFile(filename string) (*NetworkConfigList, error) {
 	return NetworkConfFromFile(filename)
 }
@@ -348,7 +346,6 @@ func LoadConf(dir, name string) (*NetworkConfig, error) {
 	return nil, NotFoundError{dir, name}
 }
 
-// Deprecated: Use NetworkConfXXX and NetworkPluginXXX functions
 func LoadConfList(dir, name string) (*NetworkConfigList, error) {
 	return LoadNetworkConf(dir, name)
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -56,7 +56,7 @@ func (n *IPNet) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// Deprecated: Use PluginConf instead of NetConf, the NetConf
+// Use PluginConf instead of NetConf, the NetConf
 // backwards-compat alias will be removed in a future release.
 type NetConf = PluginConf
 


### PR DESCRIPTION
We were a bit over-eager with the deprecations; these types and aliases are doing no harm :-).