### PR TITLE
Add exec error when stderr is present

### DIFF
--- a/pkg/invoke/raw_exec.go
+++ b/pkg/invoke/raw_exec.go
@@ -75,7 +75,7 @@ func (e *RawExec) pluginErr(err error, stdout, stderr []byte) error {
 		if len(stderr) == 0 {
 			emsg.Msg = fmt.Sprintf("netplugin failed with no error message: %v", err)
 		} else {
-			emsg.Msg = fmt.Sprintf("netplugin failed: %q", string(stderr))
+			emsg.Msg = fmt.Sprintf("netplugin failed: %q: %v", string(stderr), err)
 		}
 	} else if perr := json.Unmarshal(stdout, &emsg); perr != nil {
 		emsg.Msg = fmt.Sprintf("netplugin failed but error parsing its diagnostic message %q: %v", string(stdout), perr)

--- a/pkg/invoke/raw_exec_test.go
+++ b/pkg/invoke/raw_exec_test.go
@@ -122,7 +122,7 @@ var _ = Describe("RawExec", func() {
 				Expect(debug.WriteDebug(debugFileName)).To(Succeed())
 				_, err := execer.ExecPlugin(ctx, pathToPlugin, stdin, environ)
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(`netplugin failed: "some stderr message"`))
+				Expect(err).To(MatchError(`netplugin failed: "some stderr message": exit status 1`))
 			})
 		})
 	})


### PR DESCRIPTION
Add exec error when plugin exits unexpectedly and stderr is populated