### PR TITLE
libcni: Fix error handling in GCNetworkList

### DIFF
--- a/libcni/api.go
+++ b/libcni/api.go
@@ -776,7 +776,7 @@ func (c *CNIConfig) GCNetworkList(ctx context.Context, list *NetworkConfigList, 
 	// First, get the list of cached attachments
 	cachedAttachments, err := c.GetCachedAttachments("")
 	if err != nil {
-		return nil
+		return err
 	}
 
 	var validAttachments map[types.GCAttachment]interface{}


### PR DESCRIPTION
This PR fixes error handling in the GCNetworkList function where it was returning nil instead of the actual error from GetCachedAttachments, causing silent failures.

## Changes
- Modified GCNetworkList function in libcni/api.go to return the actual error from GetCachedAttachments instead of nil
- This ensures proper error propagation and prevents silent failures during garbage collection

## Context
The issue was located around lines 772-775 in libcni/api.go where the error handling incorrectly returned nil instead of the error when GetCachedAttachments failed.

## Testing
- Fixed function now properly propagates errors from GetCachedAttachments
- Error handling is consistent with other functions in the codebase