### PR TITLE
fix: semgrep-missing-user-entrypoint

### DIFF
--- a/.github/actions/retest-action/Dockerfile
+++ b/.github/actions/retest-action/Dockerfile
@@ -2,6 +2,10 @@ FROM alpine:3.20
 
 RUN apk add --no-cache curl jq
 
+RUN adduser -D -s /bin/sh appuser
+
 COPY entrypoint.sh /entrypoint.sh
+
+USER appuser
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Pull Request — Semgrep Rule Fix
Rule ID: missing-user-entrypoint
Rule Message: By not specifying a USER, a program in the container may run as 'root'. This is a security hazard. If an attacker can control a process running as root, they may have control over the container. Ensure that the last USER in a Dockerfile is a USER other than 'root'.
File Path: /tools/scanResult/unzipped-2630966798/.github/actions/retest-action/Dockerfile
Line: 7

## Summary
This pull request addresses the Semgrep rule violation `missing-user-entrypoint`, which flagged that the Dockerfile did not specify a non-root user before defining the entrypoint. Running containers as `root` increases security risk, especially when executing scripts at startup.

## Change Details
### Modified File
`.github/actions/retest-action/Dockerfile`

### Updates
- Added creation of a dedicated non-root user `appuser`.
- Added `USER appuser` before the `ENTRYPOINT` directive to ensure entrypoint execution under a non-root context.
- Ensures safer execution of `entrypoint.sh` by avoiding root privileges.

## Rationale
The Semgrep rule indicates that failing to set a non-root user allows the container to run as `root`, exposing the system to privilege escalation and container compromise. This PR ensures that the final active user in the Dockerfile is a non-root user, meeting secure Dockerfile best practices.

## Verification
- Semgrep warning resolved.
- Dockerfile builds successfully with the non-root user.
- Entrypoint script is still reachable and executable by `appuser`.

## Conclusion
This update ensures secure container execution by enforcing non-root user usage in the Dockerfile, resolving the `missing-user-entrypoint` Semgrep finding.
