### PR TITLE
fix: adding required permissions to top level and jobs in the workflow

### DIFF
--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -3,6 +3,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   retest:
     if: github.repository == 'containernetworking/cni'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,8 @@ name: test
 
 on: ["push", "pull_request"]
 
+permissions: {}
+
 env:
   GO_VERSION: "1.22"
   LINUX_ARCHES: "amd64 386 arm arm64 s390x mips64le ppc64le"


### PR DESCRIPTION
Currently the score for the Token Permissions is 0 because the top level permissions and a few job level permissions are missing in the workflows. With this change, the score will move to 10, since the workflow jobs will run with the minimal permissions. The PR retains conditions like `write` only at the job level, where it is necessary.

Fixes #1181
