### PR TITLE
libcni: skip GC plugin execution after config injection failure

### DIFF
--- a/libcni/api.go
+++ b/libcni/api.go
@@ -830,10 +830,11 @@ func (c *CNIConfig) GCNetworkList(ctx context.Context, list *NetworkConfigList, 
 			// build config here
 			pluginConfig, err := InjectConf(plugin, inject)
 			if err != nil {
-				errs = append(errs, fmt.Errorf("failed to generate configuration to GC plugin %s: %w", plugin.Network.Type, err))
+				errs = append(errs, fmt.Errorf("failed to generate configuration to GC plugin %s: %w", pluginDescription(plugin.Network), err))
+				continue
 			}
 			if err := c.gcNetwork(ctx, pluginConfig); err != nil {
-				errs = append(errs, fmt.Errorf("failed to GC plugin %s: %w", plugin.Network.Type, err))
+				errs = append(errs, fmt.Errorf("failed to GC plugin %s: %w", pluginDescription(plugin.Network), err))
 			}
 		}
 	}


### PR DESCRIPTION
This fixes error handling in `GCNetworkList`.

When generating a GC plugin configuration fails, `GCNetworkList` currently records the error but continues and calls `gcNetwork(ctx, pluginConfig)`. `InjectConf` returns `nil` on failure, so this can lead to a nil pointer dereference inside `gcNetwork`.

The proposed fix is to `continue` after recording the configuration generation error.

Found by Linux Verification Center (linuxtesting.org) with SVACE.