### PR TITLE
pkg/types: tolerate nil entries in Result version converters

### DIFF
--- a/pkg/types/040/types.go
+++ b/pkg/types/040/types.go
@@ -150,6 +150,9 @@ func convertTo02x(from types.Result, toVersion string) (types.Result, error) {
 	}
 
 	for _, fromIP := range fromResult.IPs {
+		if fromIP == nil {
+			continue
+		}
 		// Only convert the first IP address of each version as 0.2.0
 		// and earlier cannot handle multiple IP addresses
 		if fromIP.Version == "4" && toResult.IP4 == nil {
@@ -169,6 +172,9 @@ func convertTo02x(from types.Result, toVersion string) (types.Result, error) {
 	}
 
 	for _, fromRoute := range fromResult.Routes {
+		if fromRoute == nil {
+			continue
+		}
 		is4 := fromRoute.Dst.IP.To4() != nil
 		if is4 && toResult.IP4 != nil {
 			toResult.IP4.Routes = append(toResult.IP4.Routes, types.Route{

--- a/pkg/types/040/types_test.go
+++ b/pkg/types/040/types_test.go
@@ -85,6 +85,26 @@ func testResult() *types040.Result {
 }
 
 var _ = Describe("040 types operations", func() {
+	It("skips nil IP and route entries when downconverting to 0.2.0", func() {
+		// A JSON null in ips or routes decodes to a nil element. The 0.2.0 shape
+		// cannot represent it, so it is skipped while the valid entries still
+		// convert. The nil is placed first to prove later entries are not lost.
+		res := testResult()
+		res.IPs = append([]*types040.IPConfig{nil}, res.IPs...)
+		res.Routes = append([]*types.Route{nil}, res.Routes...)
+
+		out, err := res.GetAsVersion("0.2.0")
+		Expect(err).NotTo(HaveOccurred())
+
+		got := out.(*types020.Result)
+		Expect(got.IP4).NotTo(BeNil())
+		Expect(got.IP6).NotTo(BeNil())
+		Expect(got.IP4.IP.IP.String()).To(Equal("1.2.3.30"))
+		Expect(got.IP6.IP.IP.String()).To(Equal("abcd:1234:ffff::cdde"))
+		Expect(got.IP4.Routes).To(HaveLen(1))
+		Expect(got.IP4.Routes[0].Dst.String()).To(Equal("15.5.6.0/24"))
+	})
+
 	It("correctly encodes a 0.3.x Result", func() {
 		res := testResult()
 

--- a/pkg/types/100/types.go
+++ b/pkg/types/100/types.go
@@ -145,6 +145,10 @@ func convertFrom02x(from types.Result, toVersion string) (types.Result, error) {
 }
 
 func convertIPConfigFrom040(from *types040.IPConfig) *IPConfig {
+	// A JSON null in one of the result's lists decodes to a nil element.
+	if from == nil {
+		return nil
+	}
 	to := &IPConfig{
 		Address: from.Address,
 		Gateway: from.Gateway,
@@ -157,6 +161,9 @@ func convertIPConfigFrom040(from *types040.IPConfig) *IPConfig {
 }
 
 func convertInterfaceFrom040(from *types040.Interface) *Interface {
+	if from == nil {
+		return nil
+	}
 	return &Interface{
 		Name:    from.Name,
 		Mac:     from.Mac,
@@ -171,6 +178,7 @@ func convertFrom04x(from types.Result, toVersion string) (types.Result, error) {
 		DNS:        *fromResult.DNS.Copy(),
 		Routes:     []*types.Route{},
 	}
+	// Preserve nil slots: IPConfig.Interface indexes this slice by position.
 	for _, fromIntf := range fromResult.Interfaces {
 		toResult.Interfaces = append(toResult.Interfaces, convertInterfaceFrom040(fromIntf))
 	}
@@ -184,6 +192,9 @@ func convertFrom04x(from types.Result, toVersion string) (types.Result, error) {
 }
 
 func convertIPConfigTo040(from *IPConfig) *types040.IPConfig {
+	if from == nil {
+		return nil
+	}
 	version := "6"
 	if from.Address.IP.To4() != nil {
 		version = "4"
@@ -201,6 +212,9 @@ func convertIPConfigTo040(from *IPConfig) *types040.IPConfig {
 }
 
 func convertInterfaceTo040(from *Interface) *types040.Interface {
+	if from == nil {
+		return nil
+	}
 	return &types040.Interface{
 		Name:    from.Name,
 		Mac:     from.Mac,

--- a/pkg/types/100/types_test.go
+++ b/pkg/types/100/types_test.go
@@ -24,7 +24,9 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/containernetworking/cni/pkg/types"
+	types040 "github.com/containernetworking/cni/pkg/types/040"
 	current "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/cni/pkg/types/create"
 )
 
 func testResult() *current.Result {
@@ -84,6 +86,74 @@ func testResult() *current.Result {
 }
 
 var _ = Describe("Current types operations", func() {
+	It("preserves interface positions and IP references across list-shaped conversions", func() {
+		ipv4, err := types.ParseCIDR("192.0.2.10/24")
+		Expect(err).NotTo(HaveOccurred())
+
+		// A JSON null entry decodes to a nil pointer. List-shaped conversions
+		// preserve its position so IPConfig.Interface indices remain stable.
+		from := &types040.Result{
+			CNIVersion: "0.4.0",
+			Interfaces: []*types040.Interface{
+				nil,
+				{Name: "eth0", Sandbox: "/var/run/netns/test"},
+				{Name: "net1", Sandbox: "/var/run/netns/test"},
+			},
+			IPs: []*types040.IPConfig{
+				{Version: "4", Interface: types040.Int(1), Address: *ipv4},
+			},
+		}
+
+		out, err := from.GetAsVersion("1.0.0")
+		Expect(err).NotTo(HaveOccurred())
+
+		got := out.(*current.Result)
+		Expect(got.Interfaces).To(HaveLen(3))
+		Expect(got.Interfaces[0]).To(BeNil())
+		Expect(got.Interfaces[1]).NotTo(BeNil())
+		Expect(got.Interfaces[1].Name).To(Equal("eth0"))
+
+		Expect(got.IPs).To(HaveLen(1))
+		Expect(got.IPs[0].Interface).NotTo(BeNil())
+		Expect(*got.IPs[0].Interface).To(Equal(1))
+		Expect(*got.IPs[0].Interface).To(BeNumerically("<", len(got.Interfaces)))
+
+		roundTrip, err := got.GetAsVersion("0.4.0")
+		Expect(err).NotTo(HaveOccurred())
+
+		back := roundTrip.(*types040.Result)
+		Expect(back.Interfaces).To(HaveLen(3))
+		Expect(back.Interfaces[0]).To(BeNil())
+		Expect(back.Interfaces[1].Name).To(Equal("eth0"))
+		Expect(*back.IPs[0].Interface).To(Equal(1))
+	})
+
+	It("converts a JSON result with null entries and keeps the null slots in place", func() {
+		input := []byte(`{"cniVersion":"0.4.0","interfaces":[null,{"name":"eth0"},{"name":"net1"}],"ips":[{"version":"4","interface":1,"address":"192.0.2.10/24"}],"routes":[null]}`)
+		result, err := create.CreateFromBytes(input)
+		Expect(err).NotTo(HaveOccurred())
+
+		converted, err := result.GetAsVersion("1.0.0")
+		Expect(err).NotTo(HaveOccurred())
+
+		got := converted.(*current.Result)
+		Expect(got.Interfaces).To(HaveLen(3))
+		Expect(got.Interfaces[0]).To(BeNil())
+		Expect(got.Interfaces[1].Name).To(Equal("eth0"))
+		Expect(*got.IPs[0].Interface).To(Equal(1))
+
+		// The nil slots must round-trip to JSON null in place, not be dropped.
+		blob, err := json.Marshal(got)
+		Expect(err).NotTo(HaveOccurred())
+		raw := struct {
+			Interfaces []json.RawMessage `json:"interfaces"`
+			Routes     []json.RawMessage `json:"routes"`
+		}{}
+		Expect(json.Unmarshal(blob, &raw)).To(Succeed())
+		Expect(string(raw.Interfaces[0])).To(Equal("null"))
+		Expect(string(raw.Routes[0])).To(Equal("null"))
+	})
+
 	It("correctly encodes a 1.1.0 Result", func() {
 		res := testResult()
 


### PR DESCRIPTION
## What happens

`[null]` is valid JSON, so a result like `{"ips":[null]}` unmarshals into a slice that holds a nil pointer. When that result is converted between spec versions, the 0.4.0 and 1.0.0 IP and interface converters, and the 0.2.0 downgrade loop, read the element directly and hit a nil pointer dereference. The neighbouring DNS and route paths in the 0.4.x to 1.x converters do not crash because they go through the nil-safe `Copy()`.

## Why it matters

The null does not have to be malicious. It reaches the converters on ADD through `GetAsVersion`, on a chained plugin through `NewResultFromResult(conf.PrevResult)`, and on CHECK and DEL, which read and convert a cached result directly. GC reaches the same path when libcni deletes a stale cached attachment through `DelNetworkList`; the GC call itself carries no prevResult. So a buggy or hand-written plugin result, a crafted `prevResult`, or a tampered cache file can panic the library, and on the cached-result path that panic can surface inside the runtime that called into CNI. It is not reachable from unauthenticated network input.

## The change

The four 0.4 to 1.x converter helpers now return nil for a nil input, the way `IPConfig.Copy` and `Interface.Copy` already do, so the converter loops keep the element in its slot. This matters because `IPConfig.Interface` indexes the `Interfaces` slice by position: filtering nil entries out would shift every later index and quietly repoint IPs at the wrong interface, so the nil is preserved rather than dropped. Routes in the 0.4.x to 1.x converters were already nil-safe through `Route.Copy`; only the legacy 0.2.x downgrade loop, whose shape cannot hold a nil entry, skips it.

## Tests

The suite locks in the invariant that makes this correct. A 0.4.0 result with a null interface ahead of two real ones, converted to 1.0.0 and back, must keep three interface slots with the null in place and every `IPConfig.Interface` index still valid; that case fails if the converters filter instead of preserve. A second test starts from real JSON through `CreateFromBytes` and asserts the null slots round-trip to `null` rather than disappearing, and the 0.2.0 downgrade test puts the null first and checks the valid IPs and routes still convert.

## Scope

This keeps libcni's own version converters from panicking on a nil entry and preserves interface indices. It does not make an arbitrary malformed result safe for every downstream plugin: a plugin that iterates `Interfaces` and dereferences each entry without its own nil check can still panic on a preserved null. Pushing that policy into the converters would be a much larger change and is out of scope here.
