### PR TITLE
Skip nil elements when converting result versions

### DIFF
--- a/pkg/types/040/types.go
+++ b/pkg/types/040/types.go
@@ -149,7 +149,11 @@ func convertTo02x(from types.Result, toVersion string) (types.Result, error) {
 		DNS:        *fromResult.DNS.Copy(),
 	}
 
+	// A JSON null in the source array unmarshals to a nil element; skip it.
 	for _, fromIP := range fromResult.IPs {
+		if fromIP == nil {
+			continue
+		}
 		// Only convert the first IP address of each version as 0.2.0
 		// and earlier cannot handle multiple IP addresses
 		if fromIP.Version == "4" && toResult.IP4 == nil {
@@ -169,6 +173,9 @@ func convertTo02x(from types.Result, toVersion string) (types.Result, error) {
 	}
 
 	for _, fromRoute := range fromResult.Routes {
+		if fromRoute == nil {
+			continue
+		}
 		is4 := fromRoute.Dst.IP.To4() != nil
 		if is4 && toResult.IP4 != nil {
 			toResult.IP4.Routes = append(toResult.IP4.Routes, types.Route{

--- a/pkg/types/100/types.go
+++ b/pkg/types/100/types.go
@@ -171,10 +171,17 @@ func convertFrom04x(from types.Result, toVersion string) (types.Result, error) {
 		DNS:        *fromResult.DNS.Copy(),
 		Routes:     []*types.Route{},
 	}
+	// A JSON null in the source array unmarshals to a nil element; skip it.
 	for _, fromIntf := range fromResult.Interfaces {
+		if fromIntf == nil {
+			continue
+		}
 		toResult.Interfaces = append(toResult.Interfaces, convertInterfaceFrom040(fromIntf))
 	}
 	for _, fromIPC := range fromResult.IPs {
+		if fromIPC == nil {
+			continue
+		}
 		toResult.IPs = append(toResult.IPs, convertIPConfigFrom040(fromIPC))
 	}
 	for _, fromRoute := range fromResult.Routes {
@@ -216,9 +223,15 @@ func convertTo04x(from types.Result, toVersion string) (types.Result, error) {
 		Routes:     []*types.Route{},
 	}
 	for _, fromIntf := range fromResult.Interfaces {
+		if fromIntf == nil {
+			continue
+		}
 		toResult.Interfaces = append(toResult.Interfaces, convertInterfaceTo040(fromIntf))
 	}
 	for _, fromIPC := range fromResult.IPs {
+		if fromIPC == nil {
+			continue
+		}
 		toResult.IPs = append(toResult.IPs, convertIPConfigTo040(fromIPC))
 	}
 	for _, fromRoute := range fromResult.Routes {

--- a/pkg/types/100/types_test.go
+++ b/pkg/types/100/types_test.go
@@ -24,7 +24,9 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/containernetworking/cni/pkg/types"
+	types040 "github.com/containernetworking/cni/pkg/types/040"
 	current "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/containernetworking/cni/pkg/types/create"
 )
 
 func testResult() *current.Result {
@@ -341,5 +343,46 @@ var _ = Describe("Current types operations", func() {
 		Expect(json).To(MatchJSON(`{
     "address": "10.1.2.3/24"
 }`))
+	})
+})
+
+var _ = Describe("Result version conversion with nil elements", func() {
+	// A JSON null in a result array (such as {"ips":[null]}) unmarshals to a nil
+	// element that the version converters used to dereference and panic on.
+
+	It("skips null ips and interfaces converting 0.4.0 up to 1.0.0", func() {
+		from := &types040.Result{
+			CNIVersion: "0.4.0",
+			Interfaces: []*types040.Interface{nil},
+			IPs:        []*types040.IPConfig{nil},
+		}
+		res, err := from.GetAsVersion("1.0.0")
+		Expect(err).NotTo(HaveOccurred())
+		r, ok := res.(*current.Result)
+		Expect(ok).To(BeTrue())
+		Expect(r.Interfaces).To(BeEmpty())
+		Expect(r.IPs).To(BeEmpty())
+	})
+
+	It("skips null ips and interfaces converting 1.0.0 down to 0.4.0", func() {
+		from := &current.Result{
+			CNIVersion: "1.0.0",
+			Interfaces: []*current.Interface{nil},
+			IPs:        []*current.IPConfig{nil},
+		}
+		res, err := from.GetAsVersion("0.4.0")
+		Expect(err).NotTo(HaveOccurred())
+		r, ok := res.(*types040.Result)
+		Expect(ok).To(BeTrue())
+		Expect(r.Interfaces).To(BeEmpty())
+		Expect(r.IPs).To(BeEmpty())
+	})
+
+	It("skips a null route converting 0.4.0 down to 0.2.0", func() {
+		res, err := create.CreateFromBytes([]byte(
+			`{"cniVersion":"0.4.0","ips":[{"version":"4","address":"1.2.3.4/24"},null],"routes":[null]}`))
+		Expect(err).NotTo(HaveOccurred())
+		_, err = res.GetAsVersion("0.2.0")
+		Expect(err).NotTo(HaveOccurred())
 	})
 })


### PR DESCRIPTION
## What happens

`[null]` is valid JSON, so a result like `{"ips":[null]}` unmarshals into a slice that holds a nil pointer. When that result is converted to another spec version, the IP, interface, and route converters read the element directly and hit a nil pointer dereference. `convertIPConfigFrom040` at `pkg/types/100/types.go:149` reaches for `from.Address` on a nil `*IPConfig`, and `convertInterfaceFrom040`, `convertIPConfigTo040`, `convertInterfaceTo040`, and the two inline loops in `convertTo02x` (`pkg/types/040/types.go`) do the same. The neighbouring DNS and route paths do not crash because they go through the nil-safe `Copy()`.

## Why it matters

The null does not have to be malicious. It reaches the converters on ADD through `result.GetAsVersion`, on a chained plugin through `NewResultFromResult(conf.PrevResult)`, and on CHECK, DEL, and GC through `getCachedResult`, which re-converts a cached result. A single buggy or hand-written plugin result, a crafted `prevResult`, or a tampered cache file panics the library, and on the cached-result path that panic can land inside the runtime that called into CNI. It is not reachable from unauthenticated network input.

## Reproducer

```go
r, _ := create.CreateFromBytes([]byte(`{"cniVersion":"0.4.0","ips":[null]}`))
r.GetAsVersion("1.0.0")
// panic: runtime error: invalid memory address or nil pointer dereference
```

## The change

Skip nil elements in the six conversion loops so a null entry is dropped rather than dereferenced, which keeps these paths in line with the nil-safe `Copy()` siblings. The added specs cover the up-convert (0.4.0 to 1.0.0), the down-convert (1.0.0 to 0.4.0), and the 0.4.0 to 0.2.0 route path; each panics before this change and passes after.
